### PR TITLE
Dump mac profile xml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,9 @@ repos:
     name: macos-profile-xml
     description: Extract plist contents from signed MacOS profiles
     language: system
-    files: \.(.*)$
     verbose: True
-    pass_filenames: True
-    entry: bash -c 'for f in "$@"; do openssl smime -inform DER -verify -in "$f" -noverify -out "$f.xml" || echo "Failed extraction of $f"; done'
+    files: '\.mobileconfig$'
+    types: [binary]
+    entry: /bin/bash
+    args: ['-c', 'for f in "$@"; do openssl smime -inform DER -verify -noverify -in "$f" -noverify -out "$f.xml" 2>/dev/null && (git diff --quiet "$f.xml" || echo "Extracted text from $f") || echo "Failed extraction of $f"; done', '--']
+    #entry: bash -c 'for f in "$@"; do strings "$f" | grep -Pazo "(?s)<\?xml.*<plist.*\/plist>\n?" > "$f.2xml" && echo "Extracted text from $f" || echo "Failed extraction of $f"; done'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,14 @@ repos:
   rev: 1.11.0
   hooks:
     - id: shellcheck
+
+- repo: local
+  hooks:
+  - id: macos-profile-xml
+    name: macos-profile-xml
+    description: Extract plist contents from signed MacOS profiles
+    language: system
+    files: \.(.*)$
+    verbose: True
+    pass_filenames: True
+    entry: bash -c 'for f in "$@"; do openssl smime -inform DER -verify -in "$f" -noverify -out "$f.xml" || echo "Failed extraction of $f"; done'


### PR DESCRIPTION
This adds a prehook (local run of openssl) to dump out the MacOS profiles from binary to plist xml files. So we will have a direct view in the repo of what the profiles contain.

I'm guessing we could add a hook to re-sign the binary profiles when the xmls change also, but I don't think we'll be changing these often enough for that. And it might be simpler to put the plist/xml un-signed in another directory. 