### PR TITLE
Macos provisioner script

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -48,7 +48,7 @@ function update_puppet {
 
     # Fetch and checkout production branch
     git fetch --all --prune || return 1
-    git checkout --force origin/${PUPPET_BRANCH} || return 1
+    git checkout --force "origin/${PUPPET_BRANCH}" || return 1
 
     # Purge modules no longer managed by Puppetfile
     R10K_PURGE_OPTIONS=("--moduledir=${R10K_DIR}" '-v')

--- a/provisioners/macos/bootstrap_mojave.sh
+++ b/provisioners/macos/bootstrap_mojave.sh
@@ -147,7 +147,7 @@ function get_puppet_repo {
     chmod 777 .
 
     # Install R10k Modules
-    R10K_OPTIONS=('--moduledir "./r10k_modules"' '--force' '-v')
+    R10K_OPTIONS=('--moduledir=./r10k_modules' '--force' '-v')
     $R10K_BIN puppetfile install "${R10K_OPTIONS[@]}" || fail "Failed to install R10k modules"
 
     # Inject hiera secrets

--- a/provisioners/macos/bootstrap_mojave.sh
+++ b/provisioners/macos/bootstrap_mojave.sh
@@ -147,7 +147,8 @@ function get_puppet_repo {
     chmod 777 .
 
     # Install R10k Modules
-    $R10K_BIN puppetfile install -v || fail "Failed to install R10k modules"
+    R10K_OPTIONS=('--moduledir "./r10k_modules"' '--force' '-v')
+    $R10K_BIN puppetfile install "${R10K_OPTIONS[@]}" || fail "Failed to install R10k modules"
 
     # Inject hiera secrets
     mkdir -p ./data/secrets


### PR DESCRIPTION
TLDR; be explicit as to where r10k modules are installed.

Since removing the modulepath config from Puppetfile, we need to be explicit about where r10k modules are installed.  This should be in the './r10k_modules' dir in the root of this repo for the bootstrapping process.  But, for reasons, this location is different than the one maintained by puppet::atboot.
