### PR TITLE
macos run-puppet wait for network

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -64,10 +64,10 @@ function block_on_network()
 	while true; do
 		IP=`ifconfig en0 | grep "inet "| awk '{print $2}'`
 		if valid_ip $IP; then
-			echo "Network connectivity check passed"
+			echo "Network connectivity check passed $IP"
 			break
 		else
-			echo "Network connectivity failed; retry in $delay s"
+            echo "Network connectivity failed; retry in ${delay}s"
 			sleep $delay
             (( delay *= 2 ))
 		fi

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -40,7 +40,7 @@ fi
 
 
 # Return true is valid IP and not APIPA address
-function valid_ip() {
+function valid_ip {
     local IP=$1
     local STAT=1
     if [[ $IP =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
@@ -56,7 +56,7 @@ function valid_ip() {
     return $STAT
 }
 
-function block_on_network() {
+function block_on_network {
     local delay=1
 	while true; do
 		IP=`ifconfig en0 | grep "inet "| awk '{print $2}'`

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -69,7 +69,7 @@ function block_on_network()
 		else
             echo "Network connectivity failed; retry in ${delay}s"
 			sleep $delay
-            (( delay *= 2 ))
+            (( delay *= delay<60?2:1 ))
 		fi
 	done
 }

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -40,8 +40,7 @@ fi
 
 
 # Return true is valid IP and not APIPA address
-function valid_ip()
-{
+function valid_ip() {
     local IP=$1
     local STAT=1
     if [[ $IP =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
@@ -57,10 +56,8 @@ function valid_ip()
     return $STAT
 }
 
-function block_on_network()
-{
-    delay=1
-
+function block_on_network() {
+    local delay=1
 	while true; do
 		IP=`ifconfig en0 | grep "inet "| awk '{print $2}'`
 		if valid_ip $IP; then

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -38,8 +38,43 @@ fi
 
 [ -f '/var/root/vault.yaml' ] || fail "Secrets file not found"
 
-function update_puppet {
 
+# Return true is valid IP and not APIPA address
+function valid_ip()
+{
+    local IP=$1
+    local STAT=1
+    if [[ $IP =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        OIFS=$IFS
+        IFS='.'
+        IP=($IP)
+        IFS=$OIFS
+        ( ! [[ ${IP[0]} -eq 169 && ${IP[1]} -eq 254 ]]) && \
+        (   [[ ${IP[0]} -le 255 && ${IP[1]} -le 255 && \
+               ${IP[2]} -le 255 && ${IP[3]} -le 255 ]])
+        STAT=$?
+    fi
+    return $STAT
+}
+
+function block_on_network()
+{
+    delay=1
+
+	while true; do
+		IP=`ifconfig en0 | grep "inet "| awk '{print $2}'`
+		if valid_ip $IP; then
+			echo "Network connectivity check passed"
+			break
+		else
+			echo "Network connectivity failed; retry in $delay s"
+			sleep $delay
+            (( delay *= 2 ))
+		fi
+	done
+}
+
+function update_puppet {
     # Initialize working dir if dir is empty
     if [ ! "$(find "$WORKING_DIR" -mindepth 1 -print -quit 2>/dev/null)" ]; then
         git init || return 1
@@ -98,6 +133,9 @@ function run_puppet {
         *) return 1;;
     esac
 }
+
+
+block_on_network
 
 # Call the run_puppet function in a endless loop
 while ! run_puppet; do


### PR DESCRIPTION
copy block_on_network() from puppetagain puppetize.sh
https://github.com/mozilla-releng/build-puppet/blob/master/modules/puppet/files/puppetize.sh#L63

* It works for us currently.
* It doesn't make a network request (good or bad).

Changed:
* time between retries to increment. We do not want to wait 60s on the first few tries, at boot we're likely to hit a retry or two.
* log the IP