### PR TITLE
Pf firewall

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
 For more details, please read the
-[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## How to Report
 For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.

--- a/data/os/Darwin.yaml
+++ b/data/os/Darwin.yaml
@@ -1,3 +1,2 @@
 --- {}
 # A hash/dictionary is expected. This prevents a puppet load failure warning.
-

--- a/modules/fw/manifests/apps.pp
+++ b/modules/fw/manifests/apps.pp
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::apps {
+    $app_proto_port = { 'ssh'                 => { proto => 'tcp', port  => '22' },
+                        'vnc'                 => { proto => 'tcp', port  => '5900' },
+                        'nrpe'                => { proto => 'tcp', port  => '5666' },
+                        'http'                => { proto => 'tcp', port  => '80' },
+                        'https'               => { proto => 'tcp', port  => '443' },
+                        'dhcp_server'         => { proto => 'udp', port  => '67' },
+                        'tftp'                => { proto => 'udp', port  => '69' },
+                        'rpc_udp'             => { proto => 'udp', port  => '111' },
+                        'rpc_tcp'             => { proto => 'tcp', port  => '111' },
+                        # These ports (stat) are set static in /etc/nfs.conf
+                        'stat_udp'            => { proto => 'udp', port  => '1019-1022' },
+                        'stat_tcp'            => { proto => 'tcp', port  => '1019-1022' },
+                        'nfs_udp'             => { proto => 'udp', port  => '2049' },
+                        'nfs_tcp'             => { proto => 'tcp', port  => '2049' },
+                        'smb_udp'             => { proto => 'udp', port  => '137-139' },
+                        'smb_tcp'             => { proto => 'tcp', port  => '137-139' },
+                        'smb_ip'              => { proto => 'tcp', port  => '445' },
+                        'afp'                 => { proto => 'tcp', port  => '548' },
+                        'ds_http'             => { proto => 'tcp', port  => '60080' },
+                        'ds_https'            => { proto => 'tcp', port  => '60443' },
+                        'puppet'              => { proto => 'tcp', port  => '8140' },
+                        'bacula'              => { proto => 'tcp', port  => '9102' },
+                        'dep_signing'         => { proto => 'tcp', port  => '9110' },
+                        'rel_signing'         => { proto => 'tcp', port  => '9120' },
+                        'nightly_signing'     => { proto => 'tcp', port  => '9100' },
+                        'syslog_udp'          => { proto => 'udp', port  => '514' },
+                        'syslog_tcp'          => { proto => 'tcp', port  => '514' },
+                        'roller_api'          => { proto => 'tcp', port  => '8000' },
+                        }
+}

--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -1,0 +1,182 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::networks {
+
+    # Everywhere
+    $everywhere = [ '0.0.0.0/0' ]
+
+    # Data Center CIDRs
+    $mdc1_releng = [ '10.49.0.0/16' ]
+    $mdc2_releng = [ '10.51.0.0/16' ]
+
+    # AWS VPC CIDRs
+    $use1_releng = [ '10.134.0.0/16' ]
+    $usw2_releng = [ '10.132.0.0/16' ]
+
+    # MDC1 Releng Network CIDRs
+    $ops_mdc1     = [ '10.49.8.0/21' ]  # *.ops.releng.mdc1.mozilla.com
+    $inband_mdc1  = [ '10.49.16.0/22' ] # *.inband.releng.mdc1.mozilla.com
+    $wintest_mdc1 = [ '10.49.40.0/22' ] # *.wintest.releng.mdc1.mozilla.com
+    $srv_mdc1     = [ '10.49.48.0/24' ] # *.srv.releng.mdc1.mozilla.com
+    $test_mdc1    = [ '10.49.56.0/22' ] # *.test.releng.mdc1.mozilla.com
+    $private_mdc1 = [ '10.49.75.0/24' ] # *.private.releng.mdc1.mozilla.com
+    $relabs_mdc1  = [ '10.49.78.0/24' ] # *.relabs.releng.mdc1.mozilla.com
+
+    # MDC2 Releng Network CIDRs
+    $ops_mdc2     = [ '10.51.8.0/21' ]  # *.ops.releng.mdc2.mozilla.com
+    $inband_mdc2  = [ '10.51.16.0/22' ] # *.inband.releng.mdc2.mozilla.com
+    $wintest_mdc2 = [ '10.51.40.0/22' ] # *.wintest.releng.mdc2.mozilla.com
+    $srv_mdc2     = [ '10.51.48.0/24' ] # *.srv.releng.mdc2.mozilla.com
+    $test_mdc2    = [ '10.51.56.0/22' ] # *.test.releng.mdc2.mozilla.com
+    $private_mdc2 = [ '10.51.75.0/24' ] # *.private.releng.mdc2.mozilla.com
+    $relabs_mdc2  = [ '10.51.78.0/24' ] # *.relabs.releng.mdc2.mozilla.com
+
+    # AWS Networks; See https://github.com/mozilla-releng/build-cloud-tools/blob/master/configs/subnets.yml
+
+    # USE1 Network CIDRs
+    $use1_srv     = [ '10.134.48.0/22' ]
+    $use1_bb      = [ '10.134.68.0/26', '10.134.68.64/26', '10.134.68.128/26', '10.134.68.192/26' ]
+    $use1_signing = [ '10.134.30.0/24' ]
+
+    # USW2 Network CIDRs
+    $usw2_srv     = [ '10.132.48.0/22' ]
+    $usw2_bb      = [ '10.132.68.0/26', '10.132.68.64/26', '10.132.68.128/26', '10.132.68.192/26' ]
+    $usw2_signing = [ '10.132.30.0/24' ]
+
+    #
+    # Logical groups of hosts
+    #
+
+    # All releng subnets
+    $all_releng = [ $mdc1_releng, $mdc2_releng, $use1_releng, $usw2_releng ]
+
+    # All buildbot master subnets
+    $all_bb_masters = [ $use1_bb, $usw2_bb ]
+
+    $dc_test   = [ $test_mdc1, $wintest_mdc1, $test_mdc2, $wintest_mdc2 ]
+
+    $buildduty_tools = [ '10.132.51.74/32' ] # buildduty-tools.srv.releng.usw2.mozilla.com
+
+    $roller = [ '10.49.48.75/32',  # roller1.srv.releng.mdc1.mozilla.com
+                '10.49.48.76/32',  # roller-dev1.srv.releng.mdc1.mozilla.com
+                '10.51.48.75/32',  # roller1.srv.releng.mdc2.mozilla.com
+                '10.51.48.76/32' ] # roller-dev1.srv.releng.mdc2.mozilla.com
+
+    $non_distingushed_puppetmasters = [ '10.134.48.16/32', # releng-puppet1.srv.releng.use1.mozilla.com
+                                        '10.132.48.16/32', # releng-puppet1.srv.releng.usw2.mozilla.com
+                                        '10.49.48.21/32',  # releng-puppet1.srv.releng.mdc1.mozilla.com
+                                        '10.49.48.22/32',  # releng-puppet2.srv.releng.mdc1.mozilla.com
+                                        '10.51.48.21/32',  # releng-puppet1.srv.releng.mdc2.mozilla.com
+                                        '10.51.48.22/32' ] # releng-puppet2.srv.releng.mdc2.mozilla.com
+
+    $distingushed_puppetmaster = [ '10.49.48.22/32' ] # releng-puppet2.srv.releng.mdc1.mozilla.com
+
+    $infra_bacula_mdc1 = [ '10.48.75.200/32' ] # bacula1.private.mdc1.mozilla.com
+    $infra_bacula_mdc2 = [ '10.50.75.200/32' ] # bacula1.private.mdc2.mozilla.com
+
+    # Jumphosts
+
+    # MDC1 Jumphosts
+    $mdc1_rejh = [ '10.49.48.100/32', '10.49.48.101/32' ] # rejhi[1,2].srv.releng.mdc1.mozilla.com
+
+    # MDC2 Jumphosts
+    $mdc2_rejh = [ '10.51.48.100/32', '10.51.48.101/32' ] # rejhi[1,2].srv.releng.mdc2.mozilla.com
+
+    # ALL Jumphosts
+    $rejh      = [ $mdc1_rejh, $mdc2_rejh ]
+
+    # Nagios hosts
+    $nagios = [ '10.49.75.30/32',  # nagios1.private.releng.mdc1.mozilla.com
+                '10.51.75.30/32' ] # nagios1.private.releng.mdc2.mozilla.com
+
+    # NOTE: The signing server application also limits by IP
+    # See $signing_allowed_ips in moco-config.pp
+
+    # Dep signing workers
+    $use1_dep_signing_workers = [ '10.134.30.231/32',  # depsigning-worker1.srv.releng.use1.mozilla.com
+                                  '10.134.30.38/32',   # depsigning-worker3.srv.releng.use1.mozilla.com
+                                  '10.134.30.130/32',  # depsigning-worker5.srv.releng.use1.mozilla.com
+                                  '10.134.30.254/32',  # depsigning-worker7.srv.releng.use1.mozilla.com
+                                  '10.134.30.159/32',  # depsigning-worker9.srv.releng.use1.mozilla.com
+                                  '10.134.30.164/32',  # depsigning-worker11.srv.releng.use1.mozilla.com
+                                  '10.134.30.103/32',  # depsigning-worker13.srv.releng.use1.mozilla.com
+                                  '10.134.30.78/32',   # depsigning-worker15.srv.releng.use1.mozilla.com
+                                  '10.134.30.109/32' ] # tb-depsigning-worker1.srv.releng.use1.mozilla.com
+
+    $usw2_dep_signing_workers = [ '10.132.30.55/32',   # depsigning-worker2.srv.releng.usw2.mozilla.com
+                                  '10.132.30.242/32',  # depsigning-worker4.srv.releng.usw2.mozilla.com
+                                  '10.132.30.139/32',  # depsigning-worker6.srv.releng.usw2.mozilla.com
+                                  '10.132.30.117/32',  # depsigning-worker8.srv.releng.usw2.mozilla.com
+                                  '10.132.30.112/32',  # depsigning-worker10.srv.releng.usw2.mozilla.com
+                                  '10.132.30.250/32',  # depsigning-worker12.srv.releng.usw2.mozilla.com
+                                  '10.132.30.90/32',   # depsigning-worker14.srv.releng.usw2.mozilla.com
+                                  '10.132.30.135/32' ] # depsigning-worker16.srv.releng.usw2.mozilla.com
+
+    $all_dep_signing_workers = [ $use1_dep_signing_workers, $usw2_dep_signing_workers ]
+
+    # Signing linux workers
+    $use1_signing_linux_workers = [ '10.134.30.12/32',   # signing-linux-1.srv.releng.use1.mozilla.com
+                                    '10.134.30.125/32',  # signing-linux-3.srv.releng.use1.mozilla.com
+                                    '10.134.30.97/32',   # signing-linux-5.srv.releng.use1.mozilla.com
+                                    '10.134.30.39/32',   # signing-linux-7.srv.releng.use1.mozilla.com
+                                    '10.134.30.180/32',  # signing-linux-9.srv.releng.use1.mozilla.com
+                                    '10.134.30.119/32',  # signing-linux-11.srv.releng.use1.mozilla.com
+                                    '10.134.30.162/32',  # tb-signing-1.srv.releng.use1.mozilla.com
+                                    '10.134.30.205/32',  # tb-signing-3.srv.releng.use1.mozilla.com
+                                    '10.134.30.227/32',  # tb-signing-5.srv.releng.use1.mozilla.com
+                                    '10.134.30.110/32',  # tb-signing-7.srv.releng.use1.mozilla.com
+                                    '10.134.30.42/32',   # tb-signing-9.srv.releng.use1.mozilla.com
+                                    '10.134.30.184/32' ] # mobil-signing-linux-1.srv.releng.use1.mozilla.com
+
+    $usw2_signing_linux_workers = [ '10.132.30.46/32',   # signing-linux-2.srv.releng.usw2.mozilla.com
+                                    '10.132.30.82/32',   # signing-linux-4.srv.releng.usw2.mozilla.com
+                                    '10.132.30.182/32',  # signing-linux-6.srv.releng.usw2.mozilla.com
+                                    '10.132.30.219/32',  # signing-linux-8.srv.releng.usw2.mozilla.com
+                                    '10.132.30.166/32',  # signing-linux-10.srv.releng.usw2.mozilla.com
+                                    '10.132.30.43/32',   # signing-linux-12.srv.releng.usw2.mozilla.com
+                                    '10.132.30.120/32',  # signing-linux-13.srv.releng.usw2.mozilla.com
+                                    '10.132.30.124/32',  # signing-linux-14.srv.releng.usw2.mozilla.com
+                                    '10.132.30.144/32',  # signing-linux-15.srv.releng.usw2.mozilla.com
+                                    '10.132.30.215/32',  # signing-linux-16.srv.releng.usw2.mozilla.com
+                                    '10.132.30.77/32',   # signing-linux-17.srv.releng.usw2.mozilla.com
+                                    '10.132.30.240/32',  # signing-linux-18.srv.releng.usw2.mozilla.com
+                                    '10.132.30.253/32',  # signing-linux-19.srv.releng.usw2.mozilla.com
+                                    '10.132.30.224/32',  # signing-linux-20.srv.releng.usw2.mozilla.com
+                                    '10.132.30.20/32',   # signing-linux-21.srv.releng.usw2.mozilla.com
+                                    '10.132.30.114/32',  # signing-linux-22.srv.releng.usw2.mozilla.com
+                                    '10.132.30.76/32',   # tb-signing-2.srv.releng.usw2.mozilla.com
+                                    '10.132.30.63/32',   # tb-signing-4.srv.releng.usw2.mozilla.com
+                                    '10.132.30.163/32',  # tb-signing-6.srv.releng.usw2.mozilla.com
+                                    '10.132.30.190/32',  # tb-signing-8.srv.releng.usw2.mozilla.com
+                                    '10.132.30.206/32' ] # tb-signing-10.srv.releng.usw2.mozilla.com
+
+    $all_signing_linux_workers = [ $use1_signing_linux_workers, $usw2_signing_linux_workers ]
+
+    # Dev linux signing workers
+    $dev_signing_linux_workers = [ '10.134.30.207/32' ] # signing-linux-dev1.srv.releng.use1.mozilla.com
+
+
+    # Infra VPN Network Endpoints (CIDR blocks of IPs given to vpn clients)
+    # See bug 1419983
+    $infra_mdc1_vpn_users = [ '10.48.236.0/23',  # 10.48.236.0/23 (stage TCP) = 10-48-Y-Z.vpn-stage.mdc1.mozilla.com
+                              '10.48.238.0/23',  # 10.48.238.0/23 (stage UDP) = 10-48-Y-Z.vpn-stage.mdc1.mozilla.com
+                              '10.48.240.0/23',  # 10.48.240.0/23 (prod UDP)  = 10-48-Y-Z.vpn.mdc1.mozilla.com
+                              '10.48.242.0/23' ] # 10.48.242.0/23 (prod TCP)  = 10-48-Y-Z.vpn.mdc1.mozilla.com
+
+    $infra_mdc2_vpn_users = [ '10.50.236.0/23',  # 10.50.236.0/23 (stage TCP) = 10-50-Y-Z.vpn-stage.mdc2.mozilla.com
+                              '10.50.238.0/23',  # 10.50.238.0/23 (stage UDP) = 10-50-Y-Z.vpn-stage.mdc2.mozilla.com
+                              '10.50.240.0/23',  # 10.50.240.0/23 (prod UDP)  = 10-50-Y-Z.vpn.mdc2.mozilla.com
+                              '10.50.242.0/23' ] # 10.50.242.0/23 (prod TCP)  = 10-50-Y-Z.vpn.mdc2.mozilla.com
+
+    # All vpn endpoint ranges
+    $infra_vpn_users =  [ $infra_mdc1_vpn_users, $infra_mdc2_vpn_users ]
+
+    # Infra Jumphosts
+    $infra_corp_jumphost = [  '10.48.72.100/32',  # ssh1.corpdmz.mdc1.mozilla.com
+                              '10.50.72.100/32' ] # ssh1.corpdmz.mdc2.mozilla.com
+
+    # mtv2 qa network
+    $mtv2_qa = [ '10.252.73.0/24' ] # *.qa.mtv2.mozilla.com
+}

--- a/modules/fw/manifests/pf_rule.pp
+++ b/modules/fw/manifests/pf_rule.pp
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+define fw::pf_rule (
+    Array   $sources,
+    String  $proto,
+    String  $port,
+    Boolean $log = false,
+) {
+
+    include ::pf
+
+    # Create a source table
+    pf::table { $name:
+        cidr_array => $sources,
+    }
+
+    # Create a rule with the source table as the source address
+    pf::rule { $name:
+        action    => 'pass',
+        direction => 'in',
+        log       => $log,
+        quick     => true,
+        interface => 'en0',
+        af        => 'inet',
+        protocol  => $proto,
+        src_addr  => "<${name}>",
+        dst_port  => $port,
+    }
+}

--- a/modules/fw/manifests/profiles/bacula_from_mdc1_bacula_host.pp
+++ b/modules/fw/manifests/profiles/bacula_from_mdc1_bacula_host.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::bacula_from_mdc1_bacula_host {
+    include fw::networks
+
+    fw::rules { 'allow_infra_bacula_mdc1':
+        sources =>  $::fw::networks::infra_bacula_mdc1,
+        app     => 'bacula'
+    }
+}

--- a/modules/fw/manifests/profiles/bacula_from_mdc2_bacula_host.pp
+++ b/modules/fw/manifests/profiles/bacula_from_mdc2_bacula_host.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::bacula_from_mdc2_bacula_host {
+    include fw::networks
+
+    fw::rules { 'allow_infra_bacula_mdc2':
+        sources =>  $::fw::networks::infra_bacula_mdc2,
+        app     => 'bacula'
+    }
+}

--- a/modules/fw/manifests/profiles/bsdpy_from_mdc1_releng.pp
+++ b/modules/fw/manifests/profiles/bsdpy_from_mdc1_releng.pp
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::bsdpy_from_mdc1_releng {
+    include fw::networks
+
+    # Technicially it's BSDP. See https://static.afp548.com/mactips/bootpd.html
+    fw::rules { 'allow_dhcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'dhcp_server'
+    }
+    # TFTP so client can get booter file
+    fw::rules { 'allow_tftp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'tftp'
+    }
+    # Used if NBI is set to netboot via http
+    fw::rules { 'allow_http_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'http'
+    }
+}

--- a/modules/fw/manifests/profiles/bsdpy_from_mdc2_releng.pp
+++ b/modules/fw/manifests/profiles/bsdpy_from_mdc2_releng.pp
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::bsdpy_from_mdc2_releng {
+    include fw::networks
+
+    # Technicially it's BSDP. See https://static.afp548.com/mactips/bootpd.html
+    fw::rules { 'allow_dhcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'dhcp_server'
+    }
+    # TFTP so client can get booter file
+    fw::rules { 'allow_tftp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'tftp'
+    }
+    # Used if NBI is set to netboot via http
+    fw::rules { 'allow_http_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'http'
+    }
+}

--- a/modules/fw/manifests/profiles/dep_signing_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/dep_signing_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::dep_signing_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_dep_signing_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'dep_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/dep_signing_from_linux.pp
+++ b/modules/fw/manifests/profiles/dep_signing_from_linux.pp
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::dep_signing_from_linux {
+    include fw::networks
+
+    fw::rules { 'allow_dep_signing_from_linux':
+        # All signing sources
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers,
+                        $::fw::networks::all_dep_signing_workers ],
+        app     => 'dep_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/dep_signing_from_osx.pp
+++ b/modules/fw/manifests/profiles/dep_signing_from_osx.pp
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::dep_signing_from_osx {
+    include fw::networks
+
+    fw::rules { 'allow_dep_signing_from_osx':
+        # All signing sources
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers,
+                        $::fw::networks::all_dep_signing_workers ],
+        app     => 'dep_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/deploystudio_from_mdc1_releng.pp
+++ b/modules/fw/manifests/profiles/deploystudio_from_mdc1_releng.pp
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::deploystudio_from_mdc1_releng {
+    include fw::networks
+
+    # Technicially it's BSDP. See https://static.afp548.com/mactips/bootpd.html
+    fw::rules { 'allow_dhcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'dhcp_server'
+    }
+    # TFTP so client can get booter file
+    fw::rules { 'allow_tftp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'tftp'
+    }
+    # RPC(portmapper)/NFS. Used to during netboot for NBI system image
+    fw::rules { 'allow_rpc_udp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'rpc_udp'
+    }
+    fw::rules { 'allow_rpc_tcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'rpc_tcp'
+    }
+    # Set static in /etc/nfs.conf
+    fw::rules { 'allow_stat_udp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'stat_udp'
+    }
+    fw::rules { 'allow_stat_tcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'stat_tcp'
+    }
+    fw::rules { 'allow_nfs_udp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'nfs_udp'
+    }
+    fw::rules { 'allow_nfs_tcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'nfs_tcp'
+    }
+    # SMB/AFP used by DS client (images, logs, etc)
+    fw::rules { 'allow_smb_udp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'smb_udp'
+    }
+    fw::rules { 'allow_smb_tcp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'smb_tcp'
+    }
+    # SMB over IP
+    fw::rules { 'allow_smb_ip_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'smb_ip'
+    }
+    fw::rules { 'allow_afp_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'afp'
+    }
+    # http(s) is the main DS port
+    fw::rules { 'allow_ds_http_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'ds_http'
+    }
+    fw::rules { 'allow_ds_https_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'ds_https'
+    }
+    # Used if NBI is set to netboot via http
+    fw::rules { 'allow_http_from_mdc1_releng':
+        sources => $::fw::networks::mdc1_releng,
+        app     => 'http'
+    }
+}

--- a/modules/fw/manifests/profiles/deploystudio_from_mdc2_releng.pp
+++ b/modules/fw/manifests/profiles/deploystudio_from_mdc2_releng.pp
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::deploystudio_from_mdc2_releng {
+    include fw::networks
+
+    # Technicially it's BSDP. See https://static.afp548.com/mactips/bootpd.html
+    fw::rules { 'allow_dhcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'dhcp_server'
+    }
+    # TFTP so client can get booter file
+    fw::rules { 'allow_tftp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'tftp'
+    }
+    # RPC(portmapper)/NFS. Used to during netboot for NBI system image
+    fw::rules { 'allow_rpc_udp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'rpc_udp'
+    }
+    fw::rules { 'allow_rpc_tcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'rpc_tcp'
+    }
+    # Set static in /etc/nfs.conf
+    fw::rules { 'allow_stat_udp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'stat_udp'
+    }
+    fw::rules { 'allow_stat_tcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'stat_tcp'
+    }
+    fw::rules { 'allow_nfs_udp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'nfs_udp'
+    }
+    fw::rules { 'allow_nfs_tcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'nfs_tcp'
+    }
+    # SMB/AFP used by DS client (images, logs, etc)
+    fw::rules { 'allow_smb_udp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'smb_udp'
+    }
+    fw::rules { 'allow_smb_tcp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'smb_tcp'
+    }
+    # SMB over IP
+    fw::rules { 'allow_smb_ip_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'smb_ip'
+    }
+    fw::rules { 'allow_afp_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'afp'
+    }
+    # http(s) is the main DS port
+    fw::rules { 'allow_ds_http_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'ds_http'
+    }
+    fw::rules { 'allow_ds_https_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'ds_https'
+    }
+    # Used if NBI is set to netboot via http
+    fw::rules { 'allow_http_from_mdc2_releng':
+        sources => $::fw::networks::mdc2_releng,
+        app     => 'http'
+    }
+}

--- a/modules/fw/manifests/profiles/nightly_signing_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/nightly_signing_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::nightly_signing_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_nightly_signing_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'nightly_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/nightly_signing_from_linux.pp
+++ b/modules/fw/manifests/profiles/nightly_signing_from_linux.pp
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::nightly_signing_from_linux {
+    include fw::networks
+
+    fw::rules { 'allow_nightly_signing_from_linux':
+        # All sources sans dep signing workers
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers ],
+        app     => 'nightly_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/nightly_signing_from_osx.pp
+++ b/modules/fw/manifests/profiles/nightly_signing_from_osx.pp
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::nightly_signing_from_osx {
+    include fw::networks
+
+    fw::rules { 'allow_nightly_signing_from_osx':
+        # All sigining sources sans try
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers,
+                        $::fw::networks::all_dep_signing_workers ],
+        app     => 'nightly_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/nrpe_from_nagios.pp
+++ b/modules/fw/manifests/profiles/nrpe_from_nagios.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::nrpe_from_nagios {
+    include fw::networks
+
+    fw::rules { 'allow_nrpe_from_nagios':
+        sources =>  $::fw::networks::nagios,
+        app     => 'nrpe'
+    }
+}

--- a/modules/fw/manifests/profiles/puppetmaster_from_all_releng.pp
+++ b/modules/fw/manifests/profiles/puppetmaster_from_all_releng.pp
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::puppetmaster_from_all_releng {
+    include fw::networks
+
+    fw::rules { 'allow_puppetmaster_http':
+        sources =>  $::fw::networks::all_releng,
+        app     => 'http'
+    }
+    fw::rules { 'allow_puppetmaster_https':
+        sources =>  $::fw::networks::all_releng,
+        app     => 'https'
+    }
+    fw::rules { 'allow_puppetmaster_puppet':
+        sources =>  $::fw::networks::all_releng,
+        app     => 'puppet'
+    }
+}

--- a/modules/fw/manifests/profiles/puppetmaster_sync_from_all_puppetmasters.pp
+++ b/modules/fw/manifests/profiles/puppetmaster_sync_from_all_puppetmasters.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::puppetmaster_sync_from_all_puppetmasters {
+    include fw::networks
+
+    fw::rules { 'allow_puppetmaster_sync':
+        sources => [ $::fw::networks::non_distingushed_puppetmasters,
+                    $::fw::networks::distingushed_puppetmaster ],
+        app     => 'ssh'
+    }
+}

--- a/modules/fw/manifests/profiles/rel_signing_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/rel_signing_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::rel_signing_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_rel_signing_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'rel_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/rel_signing_from_linux.pp
+++ b/modules/fw/manifests/profiles/rel_signing_from_linux.pp
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::rel_signing_from_linux {
+    include fw::networks
+
+    fw::rules { 'allow_rel_signing_from_linux':
+        # All signing sources sans dep signing workers
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers ],
+        app     => 'rel_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/rel_signing_from_osx.pp
+++ b/modules/fw/manifests/profiles/rel_signing_from_osx.pp
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::rel_signing_from_osx {
+    include fw::networks
+
+    fw::rules { 'allow_rel_signing_from_osx':
+        # All signing sources sans try
+        sources =>  [   $::fw::networks::all_signing_linux_workers,
+                        $::fw::networks::dev_signing_linux_workers,
+                        $::fw::networks::all_dep_signing_workers ],
+        app     => 'rel_signing'
+    }
+}

--- a/modules/fw/manifests/profiles/roller_api_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/roller_api_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::roller_api_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'roller_api_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'roller_api'
+    }
+}

--- a/modules/fw/manifests/profiles/ssh_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/ssh_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'ssh'
+    }
+}

--- a/modules/fw/manifests/profiles/ssh_from_anywhere_logging.pp
+++ b/modules/fw/manifests/profiles/ssh_from_anywhere_logging.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_anywhere_logging {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_anywhere_logging':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'ssh',
+        log     => true
+    }
+}

--- a/modules/fw/manifests/profiles/ssh_from_rejh.pp
+++ b/modules/fw/manifests/profiles/ssh_from_rejh.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_rejh {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_rejh':
+        sources =>  $::fw::networks::rejh,
+        app     => 'ssh'
+    }
+}

--- a/modules/fw/manifests/profiles/ssh_from_rejh_logging.pp
+++ b/modules/fw/manifests/profiles/ssh_from_rejh_logging.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_rejh_logging {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_rejh_logging':
+        sources =>  $::fw::networks::rejh,
+        app     => 'ssh',
+        log     => true
+    }
+}

--- a/modules/fw/manifests/profiles/ssh_from_roller.pp
+++ b/modules/fw/manifests/profiles/ssh_from_roller.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_roller {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_roller':
+        sources =>  $::fw::networks::roller,
+        app     => 'ssh'
+    }
+}

--- a/modules/fw/manifests/profiles/syslog_from_mdc1_releng.pp
+++ b/modules/fw/manifests/profiles/syslog_from_mdc1_releng.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::syslog_from_mdc1_releng {
+    include fw::networks
+
+    fw::rules { 'allow_syslog_udp_from_mdc1_releng':
+        sources =>  $::fw::networks::mdc1_releng,
+        app     => 'syslog_udp'
+    }
+    fw::rules { 'allow_syslog_tcp_from_mdc1_releng':
+        sources =>  $::fw::networks::mdc1_releng,
+        app     => 'syslog_tcp'
+    }
+}

--- a/modules/fw/manifests/profiles/syslog_from_mdc2_releng.pp
+++ b/modules/fw/manifests/profiles/syslog_from_mdc2_releng.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::syslog_from_mdc2_releng {
+    include fw::networks
+
+    fw::rules { 'allow_syslog_udp_from_mdc2_releng':
+        sources =>  $::fw::networks::mdc2_releng,
+        app     => 'syslog_udp'
+    }
+    fw::rules { 'allow_syslog_tcp_from_mdc2_releng':
+        sources =>  $::fw::networks::mdc2_releng,
+        app     => 'syslog_tcp'
+    }
+}

--- a/modules/fw/manifests/profiles/syslog_from_mtv2_qa.pp
+++ b/modules/fw/manifests/profiles/syslog_from_mtv2_qa.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::syslog_from_mtv2_qa {
+    include fw::networks
+
+    fw::rules { 'allow_syslog_udp_from_mtv2_qa':
+        sources =>  $::fw::networks::mtv2_qa,
+        app     => 'syslog_udp'
+    }
+    fw::rules { 'allow_syslog_tcp_from_mtv2_qa':
+        sources =>  $::fw::networks::mtv2_qa,
+        app     => 'syslog_tcp'
+    }
+}

--- a/modules/fw/manifests/profiles/taskcluster_host_secrets_from_dc_test.pp
+++ b/modules/fw/manifests/profiles/taskcluster_host_secrets_from_dc_test.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::taskcluster_host_secrets_from_dc_test {
+    include fw::networks
+
+    fw::rules { 'allow_taskcluster_host_secrets_from_dc_test':
+        sources =>  $::fw::networks::dc_test,
+        app     => 'http'
+    }
+}

--- a/modules/fw/manifests/profiles/vnc_from_anywhere.pp
+++ b/modules/fw/manifests/profiles/vnc_from_anywhere.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::vnc_from_anywhere {
+    include fw::networks
+
+    fw::rules { 'allow_vnc_from_anywhere':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'vnc'
+    }
+}

--- a/modules/fw/manifests/profiles/vnc_from_anywhere_logging.pp
+++ b/modules/fw/manifests/profiles/vnc_from_anywhere_logging.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::vnc_from_anywhere_logging {
+    include fw::networks
+
+    fw::rules { 'allow_vnc_from_anywhere_logging':
+        sources =>  $::fw::networks::everywhere,
+        app     => 'vnc',
+        log     => true
+    }
+}

--- a/modules/fw/manifests/profiles/vnc_from_rejh.pp
+++ b/modules/fw/manifests/profiles/vnc_from_rejh.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::vnc_from_rejh {
+    include fw::networks
+
+    fw::rules { 'allow_vnc_from_rejh':
+        sources =>  $::fw::networks::rejh,
+        app     => 'vnc'
+    }
+}

--- a/modules/fw/manifests/profiles/vnc_from_rejh_logging.pp
+++ b/modules/fw/manifests/profiles/vnc_from_rejh_logging.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::vnc_from_rejh_logging {
+    include fw::networks
+
+    fw::rules { 'allow_vnc_from_rejh_logging':
+        sources =>  $::fw::networks::rejh,
+        app     => 'vnc',
+        log     => true
+    }
+}

--- a/modules/fw/manifests/roles/bsdpy.pp
+++ b/modules/fw/manifests/roles/bsdpy.pp
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::bsdpy {
+
+    case $::fqdn {
+        /.*\.mdc1\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::bsdpy_from_mdc1_releng
+        }
+        /.*\.mdc2\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::bsdpy_from_mdc2_releng
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/deploystudio.pp
+++ b/modules/fw/manifests/roles/deploystudio.pp
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::deploystudio {
+
+    case $::fqdn {
+        /.*\.mdc1\.mozilla\.com/: {
+            include ::fw::profiles::vnc_from_rejh_logging
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::bacula_from_mdc1_bacula_host
+            include ::fw::profiles::deploystudio_from_mdc1_releng
+        }
+        /.*\.mdc2\.mozilla\.com/: {
+            include ::fw::profiles::vnc_from_rejh_logging
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::bacula_from_mdc2_bacula_host
+            include ::fw::profiles::deploystudio_from_mdc2_releng
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/depsigning.pp
+++ b/modules/fw/manifests/roles/depsigning.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::depsigning {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::dep_signing_from_anywhere
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/distinguished_puppetmaster.pp
+++ b/modules/fw/manifests/roles/distinguished_puppetmaster.pp
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::distinguished_puppetmaster {
+
+    case $::fqdn {
+        /.*\.mdc1\.mozilla\.com/: {
+            include ::fw::profiles::bacula_from_mdc1_bacula_host
+
+            include ::fw::profiles::puppetmaster_from_all_releng
+            include ::fw::profiles::puppetmaster_sync_from_all_puppetmasters
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        /.*\.mdc2\.mozilla\.com/: {
+            include ::fw::profiles::bacula_from_mdc2_bacula_host
+
+            include ::fw::profiles::puppetmaster_from_all_releng
+            include ::fw::profiles::puppetmaster_sync_from_all_puppetmasters
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        default: {
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/linux_taskcluster_worker.pp
+++ b/modules/fw/manifests/roles/linux_taskcluster_worker.pp
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::linux_taskcluster_worker {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::vnc_from_rejh_logging
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::ssh_from_roller
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/log_aggregator.pp
+++ b/modules/fw/manifests/roles/log_aggregator.pp
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::log_aggregator {
+
+    case $::fqdn {
+        /.*\.mdc1\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::syslog_from_mdc1_releng
+            include ::fw::profiles::syslog_from_mtv2_qa
+        }
+        /.*\.mdc2\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::syslog_from_mdc2_releng
+            include ::fw::profiles::syslog_from_mtv2_qa
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/mac_depsigning.pp
+++ b/modules/fw/manifests/roles/mac_depsigning.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::mac_depsigning {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::dep_signing_from_osx
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/mac_signing.pp
+++ b/modules/fw/manifests/roles/mac_signing.pp
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::mac_signing {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::dep_signing_from_osx
+            include ::fw::profiles::rel_signing_from_osx
+            include ::fw::profiles::nightly_signing_from_osx
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/osx_taskcluster_worker.pp
+++ b/modules/fw/manifests/roles/osx_taskcluster_worker.pp
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::osx_taskcluster_worker {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::vnc_from_rejh_logging
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::ssh_from_roller
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/partner_repack.pp
+++ b/modules/fw/manifests/roles/partner_repack.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::partner_repack {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::vnc_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::ssh_from_rejh_logging
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/puppetmasters.pp
+++ b/modules/fw/manifests/roles/puppetmasters.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::puppetmasters {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::puppetmaster_from_all_releng
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/rejh.pp
+++ b/modules/fw/manifests/roles/rejh.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::rejh {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_anywhere_logging
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/roller.pp
+++ b/modules/fw/manifests/roles/roller.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::roller {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::roller_api_from_anywhere
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/signing.pp
+++ b/modules/fw/manifests/roles/signing.pp
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::signing {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+            include ::fw::profiles::dep_signing_from_linux
+            include ::fw::profiles::rel_signing_from_linux
+            include ::fw::profiles::nightly_signing_from_linux
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/roles/taskcluster_host_secrets.pp
+++ b/modules/fw/manifests/roles/taskcluster_host_secrets.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::roles::taskcluster_host_secrets {
+
+    case $::fqdn {
+        /.*\.(mdc1|mdc2)\.mozilla\.com/: {
+            include ::fw::profiles::taskcluster_host_secrets_from_dc_test
+            include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::nrpe_from_nagios
+        }
+        default:{
+            # Silently skip other DCs
+        }
+    }
+}

--- a/modules/fw/manifests/rules.pp
+++ b/modules/fw/manifests/rules.pp
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+define fw::rules (
+    Array   $sources,
+    String  $app,
+    Boolean $log = false,
+) {
+
+    include fw::apps
+
+    $proto = $::fw::apps::app_proto_port[$app]['proto']
+    $port  = $::fw::apps::app_proto_port[$app]['port']
+
+    $sources_uniq = unique(flatten($sources))
+    $rules = suffix($sources_uniq, " ${proto}/${port} ${name}")
+
+    case $facts['kernel'] {
+        'Darwin': {
+            fw::pf_rule { $name:
+                sources => $sources_uniq,
+                proto   => $proto,
+                port    => $port,
+                log     => $log,
+            }
+        }
+        default: {
+            fail("This ${::operatingsystem} is not supported")
+        }
+    }
+
+}

--- a/modules/pf/files/org.mozilla.pf.plist
+++ b/modules/pf/files/org.mozilla.pf.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Disabled</key>
+        <false/>
+        <key>Label</key>
+        <string>org.mozilla.pf</string>
+        <key>ProgramArguments</key>
+        <array>
+                <string>sh</string>
+                <string>-c</string>
+                <string>/sbin/pfctl -e -f /etc/pf.conf</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>LaunchOnlyOnce</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>/var/run</string>
+</dict>
+</plist>

--- a/modules/pf/files/org.mozilla.pflog.plist
+++ b/modules/pf/files/org.mozilla.pflog.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Disabled</key>
+        <false/>
+        <key>Label</key>
+        <string>org.mozilla.pflog</string>
+        <key>ProgramArguments</key>
+                <array>
+                        <string>/usr/local/bin/pflog.sh</string>
+                </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+</dict>
+</plist>

--- a/modules/pf/files/pf.conf.mojave
+++ b/modules/pf/files/pf.conf.mojave
@@ -1,0 +1,29 @@
+#
+# Default PF configuration file.
+#
+# This file contains the main ruleset, which gets automatically loaded
+# at startup.  PF will not be automatically enabled, however.  Instead,
+# each component which utilizes PF is responsible for enabling and disabling
+# PF via -E and -X as documented in pfctl(8).  That will ensure that PF
+# is disabled only when the last enable reference is released.
+#
+# Care must be taken to ensure that the main ruleset does not get flushed,
+# as the nested anchors rely on the anchor point defined here. In addition,
+# to the anchors loaded by this file, some system services would dynamically
+# insert anchors into the main ruleset. These anchors will be added only when
+# the system service is used and would removed on termination of the service.
+#
+# See pf.conf(5) for syntax.
+#
+
+#
+# com.apple anchor point
+#
+scrub-anchor "com.apple/*"
+nat-anchor "com.apple/*"
+rdr-anchor "com.apple/*"
+dummynet-anchor "com.apple/*"
+anchor "com.apple/*"
+anchor "org.mozilla"
+load anchor "com.apple" from "/etc/pf.anchors/com.apple"
+load anchor "org.mozilla" from "/etc/pf.mozilla.anchors/main.conf"

--- a/modules/pf/files/pflog.sh
+++ b/modules/pf/files/pflog.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+ifconfig pflog0 create
+/usr/sbin/tcpdump -lnettti pflog0 2> /dev/null | /usr/bin/logger -t pflog -p local2.info

--- a/modules/pf/manifests/init.pp
+++ b/modules/pf/manifests/init.pp
@@ -1,0 +1,95 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class pf {
+
+    # The default /etc/pf.conf differs between major osx version
+    case $facts['os']['macosx']['version']['major'] {
+        '10.14': {
+            $osx_ver = 'mojave'
+        }
+        default: {
+            fail("OSX ${::macosx_productversion_major} is not supported")
+        }
+    }
+
+    # Default ethernet interface
+    $iface    = 'en0'
+    $pf_dir   = '/etc/pf.mozilla.anchors'
+    $pfctl    = '/sbin/pfctl'
+    $pf_entry = '/etc/pf.conf'
+
+    file {
+        $pf_dir:
+            ensure => 'directory',
+            owner  => 'root',
+            group  => 'wheel',
+            mode   => '0700';
+
+        "${pf_dir}/main.conf":
+            ensure  => file,
+            owner   => 'root',
+            group   => 'wheel',
+            mode    => '0600',
+            content => template('pf/main.conf.erb'),
+            require => File[$pf_dir],
+            notify  => Exec['update_pf'];
+    }
+
+    concat {
+        "${pf_dir}/tables.conf":
+            owner   => 'root',
+            group   => 'wheel',
+            mode    => '0600',
+            require => File[$pf_dir],
+            notify  => Exec['update_pf'];
+
+        "${pf_dir}/rules.conf":
+            owner   => 'root',
+            group   => 'wheel',
+            mode    => '0600',
+            require => File[$pf_dir],
+            notify  => Exec['update_pf'];
+    }
+
+    file {
+        $pf_entry:
+            ensure => present,
+            owner  => 'root',
+            group  => 'wheel',
+            notify => Exec['update_pf'],
+            source => "puppet:///modules/pf/pf.conf.${osx_ver}";
+
+        '/Library/LaunchDaemons/org.mozilla.pf.plist':
+            ensure => present,
+            source => 'puppet:///modules/pf/org.mozilla.pf.plist';
+
+        '/Library/LaunchDaemons/org.mozilla.pflog.plist':
+            ensure => present,
+            source => 'puppet:///modules/pf/org.mozilla.pflog.plist',
+            notify => Service['org.mozilla.pflog'];
+
+        '/usr/local/bin/pflog.sh':
+            ensure => present,
+            mode   => '0755',
+            source => 'puppet:///modules/pf/pflog.sh',
+            notify => Service['org.mozilla.pflog'];
+    }
+
+    service { 'org.mozilla.pflog':
+        ensure  => running,
+        enable  => true,
+        require => File['/usr/local/bin/pflog.sh', '/Library/LaunchDaemons/org.mozilla.pflog.plist'],
+    }
+
+    exec {
+        'update_pf':
+            command     => "${pfctl} -nf ${pf_entry} && ${pfctl} -f ${pf_entry}",
+            refreshonly => true;
+
+        'enable_pf':
+            command => "${pfctl} -e",
+            onlyif  => '/bin/test `pfctl -sa| grep "Status" | awk \'/Status:/ {print $2}\'` != "Enabled"';
+    }
+}

--- a/modules/pf/manifests/rule.pp
+++ b/modules/pf/manifests/rule.pp
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+define pf::rule (
+    Enum['pass', 'drop', 'block'] $action,
+    Enum['in', 'out'] $direction,
+    Boolean $log                       = false,
+    Boolean $quick                     = false,
+    Optional[String] $interface        = undef,
+    Optional[Enum['inet','inet6']] $af = undef,
+    Optional[String] $protocol         = undef,
+    Optional[String] $src_addr         = undef,
+    Optional[String] $src_port         = undef,
+    Optional[String] $dst_addr         = undef,
+    Optional[String] $dst_port         = undef,
+    Optional[String] $tcp_flags        = undef,
+    Optional[String] $state            = undef,
+) {
+
+    include ::pf
+
+    $_action    = $action ? { /^(pass|drop|block)$/ => $action } # Explicitly fail if action is undef
+    $_direction = $direction ? { /^(in|out)$/ => " ${direction}" }    # Explicitly fail if direction is undef
+    $_log       = $log ? { true => ' log', default => '' }
+    $_quick     = $quick ? { true => ' quick', default => '' }
+    if $interface {  $_interface = " on ${interface}" } else { $_interface = '' }
+    $_af        = $af ? { /^(inet|inet6)$/ => " ${af}", undef => '' }
+    if $protocol { $_protocol = " proto ${protocol}" } else { $_protocol = '' }
+    if $src_addr { $_src_addr = " from ${src_addr}" } else { $_src_addr = ' from any' }
+    if $src_port { $_src_port = " port ${src_port}" } else { $_src_port = '' }
+    if $dst_addr { $_dst_addr = " to ${dst_addr}" } else { $_dst_addr = ' to any' }
+
+    if $dst_port {
+        # Split the port ranges (or not)
+        $port_range = split($dst_port, '-')
+
+        # if there is a second element, set as an inclusive port range
+        if $port_range[1] {
+            $_dst_port = " port ${port_range[0]}:${port_range[1]}"
+        } else {
+            $_dst_port = " port ${dst_port}"
+        }
+    } else {
+        $_dst_port = ''
+    }
+
+    if $tcp_flags { $_tcp_flags = " flags ${tcp_flags}" } else { $_tcp_flags = '' }
+    if $state { $_state = " ${state}" } else { $_state = '' }
+
+    concat::fragment { "rule_${name}":
+        target  => "${::pf::pf_dir}/rules.conf",
+        content => template('pf/rule.erb'),
+    }
+}

--- a/modules/pf/manifests/table.pp
+++ b/modules/pf/manifests/table.pp
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+define pf::table (
+    Array $cidr_array
+) {
+
+    include ::pf
+
+    concat::fragment { "table_${name}":
+        target  => "${::pf::pf_dir}/tables.conf",
+        content => template('pf/table.erb'),
+    }
+}

--- a/modules/pf/templates/main.conf.erb
+++ b/modules/pf/templates/main.conf.erb
@@ -1,0 +1,48 @@
+
+# Do not packet filter anything on loopback device
+set skip on lo0
+
+# Setup antispoofing
+antispoof quick for <%= @iface %>
+
+# Set default rule which can be overridden by the nodescope var $fw_allow_all
+# This applies to IPv6 also
+<% if @fw_allow_all -%>
+pass all
+<% else -%>
+block all
+<% end -%>
+
+# Make an exception for all outgoing packets (includes IPv6)
+pass out all
+
+# Allow all IPv4 icmp packets
+pass in quick inet proto icmp all icmp-type echoreq
+
+## allow icmp6 for getting address using IPv6 autoconfiguration from router
+pass quick inet6 proto ipv6-icmp all icmp6-type routeradv
+pass quick inet6 proto ipv6-icmp all icmp6-type routersol
+
+## allow icmp6 for getting neighbor addresses
+pass quick inet6 proto ipv6-icmp all icmp6-type neighbradv
+pass quick inet6 proto ipv6-icmp all icmp6-type neighbrsol
+
+## allow icmp6 echo
+pass in quick inet6 proto ipv6-icmp all icmp6-type echoreq
+
+## pass icmp-types: unreachable, time exceeded, parameter problem
+pass in quick inet6 proto ipv6-icmp all icmp6-type {1 3 4}
+
+# See bug 1401601 and 1409349
+# Just in case the state tables fail to allow a dhcp exchange
+# Allow all dhcp packets
+pass in quick inet proto udp from any port 67 to any port 68
+
+# Include tables
+include "<%= @pf_dir -%>/tables.conf"
+
+# Include rules
+include "<%= @pf_dir -%>/rules.conf"
+
+# Log all ssh that ends up denied
+block in log quick on <%= @iface %> inet proto tcp from any to any port 22

--- a/modules/pf/templates/rule.erb
+++ b/modules/pf/templates/rule.erb
@@ -1,0 +1,2 @@
+# Rule <%= @name %>
+<%= @_action -%><%= @_direction -%><%= @_log -%><%= @_quick -%><%= @_interface -%><%= @_af -%><%= @_protocol -%><%= @_src_addr -%><%= @_src_port -%><%= @_dst_addr -%><%= @_dst_port -%><%= @_tcp_flags -%><%= @_state %>

--- a/modules/pf/templates/table.erb
+++ b/modules/pf/templates/table.erb
@@ -1,0 +1,6 @@
+# Table <%= @name %>
+table <<%= @name %>> persist { \
+    <% @cidr_array.sort.each do |i| -%>
+    <%= i %> \
+    <% end -%>
+}

--- a/vagrantfiles/Vagrantfile-debianoid.erb
+++ b/vagrantfiles/Vagrantfile-debianoid.erb
@@ -88,4 +88,3 @@ Vagrant.configure("2") do |c|
     git commit -m "initial state" -a
     EOF
  end
-


### PR DESCRIPTION
These modules were imported from puppetagain.  I've removed the linux bits to stay within scope and added modern puppet data types to class and define parameters.

In puppetagain, the roles and profiles names were swapped so I've swapped them to be in line with the layout of ronin puppet.  I also wrestled with the idea of moving the fw roles and profiles to the 'roles and profiles' module itself in order to keep consistent with the idea that component modules should be generic but I decided against it.

The fw roles and profiles also contain things we don't use anymore or things that aren't going to be supported in ronin puppet but we can clean those out at a later date.