### PR TITLE
Fix mac profile handler module

### DIFF
--- a/r10k_modules/mac_profiles_handler/README.md
+++ b/r10k_modules/mac_profiles_handler/README.md
@@ -1,0 +1,50 @@
+# mac_profiles_handler module for Puppet
+
+## Description
+This module provides two resource types for interacting with macOS configuration profiles.
+
+The profile_manager resource type is the back-end type that interacts with /usr/bin/profiles for creating, destroying and verifying a resource type. The mac_profiles_handler::manage resource type is user-facing and handles the management of the actual files.
+
+A structured fact is also provided to list installed profiles along with some metadata.
+
+## Usage
+
+<pre>
+mac_profiles_handler::manage { 'com.puppetlabs.myprofile':  
+  ensure  => present,  
+  file_source => 'puppet:///modules/mymodule/com.puppetlabs.myprofile.mobileconfig',  
+}
+</pre>
+
+You can use an ERB template instead of a mobileconfig:  
+<pre>
+mac_profiles_handler::manage { 'com.puppetlabs.myprofile':  
+  ensure  => present,  
+  file_source => template('mymodule/com.puppetlabs.myprofile.erb'),  
+  type => 'template',  
+}
+</pre>
+
+You can also ensure that a profile is absent by specifying just the identifier:
+<pre>
+mac_profiles_handler::manage { '00000000-0000-0000-A000-4A414D460003':
+  ensure => absent,
+}
+</pre>
+
+
+You must pass the profilers identifier as your namevar, ensure accepts present or absent and file_source behaves the same way source behaves for file.
+
+## Dependencies
+
+* [puppetlabs/stdlib >= 2.3.1](https://forge.puppetlabs.com/puppetlabs/stdlib)
+* Puppet >= 4.4.0 for `puppet/util/plist`, for earlier versions use d13469a.
+
+## To-Do
+Improve provider parsing.  
+Handle more types of configuration profiles.  
+Improve documentation when author isn't presenting the next morning.  
+
+## Contributing
+Please do!  
+Create issues in GitHub, Make Pull Requests, Have Fun!

--- a/r10k_modules/mac_profiles_handler/examples/init.pp
+++ b/r10k_modules/mac_profiles_handler/examples/init.pp
@@ -1,0 +1,4 @@
+mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
+  ensure      => present,
+  file_source => 'puppet:///modules/mymodule/com.puppetlabs.myprofile.mobileconfig',
+}

--- a/r10k_modules/mac_profiles_handler/lib/facter/profiles.rb
+++ b/r10k_modules/mac_profiles_handler/lib/facter/profiles.rb
@@ -1,0 +1,42 @@
+Facter.add(:profiles) do
+  confine kernel: 'Darwin'
+  setcode do
+    
+    require 'puppet/util/plist'
+    require 'time'
+
+    profiles = {}
+
+    if Facter.value(:os)['release']['major'].to_i >= 12
+
+      plist = Puppet::Util::Plist.parse_plist(Facter::Util::Resolution.exec(['/usr/bin/profiles', '-C', '-o', 'stdout-xml'].join(' ')))
+
+      if plist.key?('_computerlevel')
+        for item in plist['_computerlevel']
+          profiles[item['ProfileIdentifier']] = {
+            'display_name' => item['ProfileDisplayName'],
+            'description' => item['ProfileDescription'],
+            'verification_state' => item['ProfileVerificationState'],
+            'uuid' => item['ProfileUUID'],
+            'organization' => item['ProfileOrganization'],
+            'type' => item['ProfileType'],
+            'install_date' => DateTime.parse(item['ProfileInstallDate']),
+            'payload' => []
+          }
+
+          for pl in item['ProfileItems']
+            profiles[item['ProfileIdentifier']]['payload'] << {
+              'type' => pl['PayloadType'],
+              'identifier' => pl['PayloadIdentifier'],
+              'uuid' => pl['PayloadUUID'],
+              # commented out for now because its not super useful.
+              # 'content' => pl['PayloadContent'],
+            }
+          end
+        end
+      end
+    end
+
+    profiles
+  end
+end

--- a/r10k_modules/mac_profiles_handler/lib/puppet/provider/profile_manager/macos.rb
+++ b/r10k_modules/mac_profiles_handler/lib/puppet/provider/profile_manager/macos.rb
@@ -1,0 +1,80 @@
+require 'puppet/util/plist'
+
+Puppet::Type.type(:profile_manager).provide :macos do
+  desc 'Provides management of mobileconfig profiles on macOS.'
+
+  confine operatingsystem: :darwin
+
+  defaultfor operatingsystem: :darwin
+
+  commands profilescmd: '/usr/bin/profiles'
+
+  def create
+    profilescmd('-I', '-F', resource[:profile])
+    writereceipt
+  end
+
+  def destroy
+    profilescmd('-R', '-p', resource[:name])
+  end
+
+  def exists?
+    # if already installed, check if it is the right one.
+    # if not installed, return false.
+    # if we are removing, don't care if it is the right one.
+    state = getinstalledstate
+    if state != false
+      if resource[:ensure] == :absent
+        return true
+      else
+        begin
+          return state['install_date'].to_time == getreceipts[resource[:name]]['install_date']
+        rescue NoMethodError
+          # no matching receipt
+          return false
+        end
+      end
+    else
+      return false
+    end
+  end
+
+  def getreceipts
+    begin
+      receipts = Puppet::Util::Plist.read_plist_file(Puppet[:vardir] + '/mobileconfigs/receipts.plist')
+    rescue IOError, Errno::ENOENT
+      receipts = {}
+    end
+    receipts
+  end
+
+  def writereceipt
+    # get install time from profile, write to disk so we know if the
+    # currently installed profile is the one we installed, this uses
+    # code from the fact but needs to re-run immediately.
+    receipts = getreceipts
+
+    receipts[resource[:name]] = { 'install_date' => getinstalledstate['install_date'] }
+
+    Puppet::Util::Plist.write_plist_file(receipts, Puppet[:vardir] + '/mobileconfigs/receipts.plist')
+  end
+
+  def getinstalledstate
+
+    plist = Puppet::Util::Plist.parse_plist(Puppet::Util::Execution.execute(['/usr/bin/profiles', '-C', '-o', 'stdout-xml']))
+
+    if plist.key?('_computerlevel')
+      for item in plist['_computerlevel']
+        if item['ProfileIdentifier'] == resource[:name]
+          return {
+            'identifier' => item['ProfileIdentifier'],
+            'display_name' => item['ProfileDisplayName'],
+            'uuid' => item['ProfileUUID'],
+            'install_date' => DateTime.parse(item['ProfileInstallDate'])
+          }
+        end
+      end
+    end
+    return false
+  end
+end

--- a/r10k_modules/mac_profiles_handler/lib/puppet/type/profile_manager.rb
+++ b/r10k_modules/mac_profiles_handler/lib/puppet/type/profile_manager.rb
@@ -1,0 +1,26 @@
+Puppet::Type.newtype(:profile_manager) do
+  @doc = <<-EOT
+    Manage Apple Configuration Profiles
+    http://help.apple.com/profilemanager/mac/10.7/#apd88330954-6FA0-4568-A88E-7F6828E763A7
+
+    Example Usage:
+      profile_manager { 'com.puppetlabs.foo':
+        ensure   => present,
+        profile  => '/path/to/profile.mobileconfig',
+      }
+
+    The namevar for this type is the identifier for the profile.
+    Profile = path to the profile on the client system.
+
+
+  EOT
+
+  ensurable
+
+  def refresh
+    provider.create
+  end
+
+  newparam(:name, namevar: true)
+  newparam(:profile)
+end

--- a/r10k_modules/mac_profiles_handler/manifests/manage.pp
+++ b/r10k_modules/mac_profiles_handler/manifests/manage.pp
@@ -1,0 +1,54 @@
+# manage mac profiles
+define mac_profiles_handler::manage(
+  $file_source = '',
+  $ensure = 'present',
+  $type = 'mobileconfig',
+) {
+
+  if $facts['os']['name'] != 'Darwin' {
+    fail('The mobileconfig::manage resource type is only supported on macOS')
+  }
+
+  case $ensure {
+    'absent': {
+      profile_manager { $name:
+        ensure    => $ensure,
+      }
+    }
+    default: {
+      File {
+        owner  => 'root',
+        group  => 'wheel',
+        mode   => '0700',
+      }
+
+      if ! defined(File["${facts['puppet_vardir']}/mobileconfigs"]) {
+        file { "${facts['puppet_vardir']}/mobileconfigs":
+          ensure => directory,
+        }
+      }
+      case $type {
+        'template': {
+          file { "${facts['puppet_vardir']}/mobileconfigs/${name}":
+            ensure  => file,
+            content => $file_source,
+          }
+        }
+        default: {
+          file { "${facts['puppet_vardir']}/mobileconfigs/${name}":
+            ensure => file,
+            source => $file_source,
+          }
+        }
+      }
+      profile_manager { $name:
+        ensure    => $ensure,
+        profile   => "${facts['puppet_vardir']}/mobileconfigs/${name}",
+        require   => File["${facts['puppet_vardir']}/mobileconfigs/${name}"],
+        subscribe => File["${facts['puppet_vardir']}/mobileconfigs/${name}"],
+      }
+    }
+  }
+
+}
+

--- a/r10k_modules/mac_profiles_handler/metadata.json
+++ b/r10k_modules/mac_profiles_handler/metadata.json
@@ -1,0 +1,33 @@
+{
+  "name": "puppet-mac_profiles_handler",
+  "author": "",
+  "license": "",
+  "version": "2.0.0",
+  "summary": "Puppet Module for managing macOS Configuration Profiles",
+  "source": "https://github.com/keeleysam/puppet-mac_profiles_handler",
+  "project_page": "https://github.com/keeleysam/puppet-mac_profiles_handler",
+  "issues_url": "https://github.com/keeleysam/puppet-mac_profiles_handler/issues",
+  "tags": [
+    "macOS",
+    "OS X",
+    "mobileconfig",
+    "profiles"
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Darwin"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.4.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 2.3.1"
+    }
+  ]
+}


### PR DESCRIPTION
This PR removes and reimports the mac_profile_handler module sans the .git and .gitignore that was causing it to be treated as a submodule.