### PR TITLE
Puppet apply email reports and telegraf metrics

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,6 +2,7 @@
 
 ntp_server: "0.pool.ntp.org"
 
+smtp_relay_host: "smtp1.private.mdc1.mozilla.com"
 
 # Apple firmware acceptance hash
 apple_firmware_acceptance:
@@ -76,3 +77,5 @@ all_users:
 # so use only when necessary
 packages::setup::default_bucket: "ronin-puppet-package-repo"
 packages::setup::default_s3_domain: "s3-us-west-2.amazonaws.com"
+
+puppet::atboot::smtp_relay_host: "%{hiera('smtp_relay_host')}"

--- a/modules/puppet/manifests/atboot.pp
+++ b/modules/puppet/manifests/atboot.pp
@@ -3,8 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class puppet::atboot (
-    String $puppet_repo   = 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-    String $puppet_branch = 'master',
+    String $telegraf_user,
+    String $telegraf_password,
+    String $puppet_repo         = 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+    String $puppet_branch       = 'master',
+    String $puppet_notify_email = 'puppet-ronin-reports@mozilla.com',
+    String $smtp_relay_host     = 'localhost',
+    Hash $meta_data             = {},
 ) {
 
     include puppet::setup

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -145,6 +145,7 @@ function run_puppet {
         retval=1
     fi
 
+    LOG_OUT=$(cat "{$TMP_LOG}")
     rm "${TMP_LOG}"
     case $retval in
         0|2)
@@ -152,7 +153,6 @@ function run_puppet {
             return 0
             ;;
         *)
-            LOG_OUT=$(cat "{$TMP_LOG}")
             notify_telegraf "puppet_ronin_apply_failure"
             email_report "Puppet apply failed on ${FQDN}" "${LOG_OUT}"
             return 1

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -68,6 +68,38 @@ function block_on_network {
 	done
 }
 
+function email_report {
+    ERR_SUBJECT=$1
+    ERR_MSG=$2
+
+    SENDER="root@${FQDN}"
+    RECEIVER="<%= @puppet_notify_email %>"
+    python <<EOF
+import smtplib
+
+msg = """From: ${SENDER}
+To: ${RECEIVER}
+Subject: ${ERR_SUBJECT}
+
+${ERR_MSG}
+"""
+
+try:
+   smtpObj = smtplib.SMTP('<%= @smtp_relay_host %>')
+   smtpObj.sendmail($SENDER, $RECEIVER, msg)
+   print "Successfully sent email"
+except SMTPException:
+   print "Error: unable to send email"
+EOF
+}
+
+function notify_telegraf {
+    TELEGRAF_TABLE=$1
+    META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
+    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "\"https://telegraf.relops.mozops.net/write?db=relops\"" '--data-binary' "\"${TELEGRAF_TABLE}${META_DATA} value=1\"")
+    curl "${CURL_OPTIONS[@]}" 2>&1
+}
+
 function update_puppet {
     # Initialize working dir if dir is empty
     if [ ! "$(find "$WORKING_DIR" -mindepth 1 -print -quit 2>/dev/null)" ]; then
@@ -115,8 +147,16 @@ function run_puppet {
 
     rm "${TMP_LOG}"
     case $retval in
-        0|2) return 0;;
-        *) return 1;;
+        0|2)
+            notify_telegraf "puppet_ronin_apply_success"
+            return 0
+            ;;
+        *)
+            LOG_OUT=$(cat "{$TMP_LOG}")
+            notify_telegraf "puppet_ronin_apply_failure"
+            email_report "Puppet apply failed on ${FQDN}" "${LOG_OUT}"
+            return 1
+            ;;
     esac
 }
 

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -96,7 +96,7 @@ EOF
 function notify_telegraf {
     TELEGRAF_TABLE=$1
     META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
-    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "\"https://telegraf.relops.mozops.net/write?db=relops\"" '--data-binary' "\"${TELEGRAF_TABLE}${META_DATA} value=1\"")
+    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "https://telegraf.relops.mozops.net/write?db=relops" '--data-binary' "${TELEGRAF_TABLE}${META_DATA} value=1")
     curl "${CURL_OPTIONS[@]}" 2>&1
 }
 

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -86,7 +86,7 @@ ${ERR_MSG}
 
 try:
    smtpObj = smtplib.SMTP('<%= @smtp_relay_host %>')
-   smtpObj.sendmail($SENDER, $RECEIVER, msg)
+   smtpObj.sendmail("${SENDER}", "${RECEIVER}", msg)
    print "Successfully sent email"
 except SMTPException:
    print "Error: unable to send email"

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -15,11 +15,12 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
+                # Note the camelCase key names
                 meta_data         => {
-                    worker_type    => $worker_type,
-                    worker_group   => $worker_group,
-                    provisioner_id => 'releng-hardware',
-                    worker_id      => $facts['networking']['hostname'],
+                    workerType    => $worker_type,
+                    workerGroup   => $worker_group,
+                    provisionerId => 'releng-hardware',
+                    workerId      => $facts['networking']['hostname'],
                 },
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -6,12 +6,22 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
 
     require roles_profiles::profiles::cltbld_user
 
-    $worker_type = 'gecko-t-osx-1014'
+    $worker_type  = 'gecko-t-osx-1014'
+    $worker_group = regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
     case $::operatingsystem {
         'Darwin': {
 
-            include puppet::atboot
+            class { 'puppet::atboot':
+                telegraf_user     => lookup('telegraf.user'),
+                telegraf_password => lookup('telegraf.password'),
+                meta_data         => {
+                    worker_type    => $worker_type,
+                    worker_group   => $worker_group,
+                    provisioner_id => 'releng-hardware',
+                    worker_id      => $facts['netowrking']['hostname'],
+                },
+            }
 
             class { 'roles_profiles::profiles::logging':
                 worker_type => $worker_type,
@@ -32,7 +42,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                 taskcluster_client_id     => $taskcluster_client_id,
                 taskcluster_access_token  => $taskcluster_access_token,
                 livelog_secret            => $livelog_secret,
-                worker_group              => regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1'),
+                worker_group              => $worker_group,
                 worker_type               => $worker_type,
                 quarantine_client_id      => $quarantine_client_id,
                 quarantine_access_token   => $quarantine_access_token,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -23,7 +23,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                     worker_type    => $worker_type,
                     worker_group   => $worker_group,
                     provisioner_id => 'releng-hardware',
-                    worker_id      => $facts['netowrking']['hostname'],
+                    worker_id      => $facts['networking']['hostname'],
                 },
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -9,6 +9,9 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
     $worker_type  = 'gecko-t-osx-1014'
     $worker_group = regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
+    # temp failure for testing
+    fail('This is a failed pupppet run')
+
     case $::operatingsystem {
         'Darwin': {
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -13,6 +13,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
         'Darwin': {
 
             class { 'puppet::atboot':
+                # Temp pinning
+                puppet_repo       => 'https://github.com/dividehex/ronin_puppet.git',
+                puppet_branch     => 'puppet_apply_email_reports',
+
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
                 meta_data         => {

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -9,17 +9,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
     $worker_type  = 'gecko-t-osx-1014'
     $worker_group = regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
-    # temp failure for testing
-    fail('This is a failed pupppet run')
-
     case $::operatingsystem {
         'Darwin': {
 
             class { 'puppet::atboot':
-                # Temp pinning
-                puppet_repo       => 'https://github.com/dividehex/ronin_puppet.git',
-                puppet_branch     => 'puppet_apply_email_reports',
-
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
                 meta_data         => {


### PR DESCRIPTION
The puppet atboot now fires off a metric tick when puppet is successful or fails.  On failure, we also fire off an email report to a google groups email.