### PR TITLE
Change mac-v3-signing to install non-homebrew python3

### DIFF
--- a/modules/packages/manifests/python3_s3.pp
+++ b/modules/packages/manifests/python3_s3.pp
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::python3_s3 {
+
+    packages::macos_package_from_s3 { 'python-3.7.3-macosx10.9.pkg':
+        private             => false,
+        os_version_specific => true,
+        type                => 'pkg',
+    }
+}

--- a/modules/packages/manifests/virtualenv_python3_s3.pp
+++ b/modules/packages/manifests/virtualenv_python3_s3.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::virtualenv_python3_s3 {
+    require packages::python3_s3
+
+    package { 'virtualenv':
+        ensure   => '16.4.3',
+        provider => pip3,
+        require  => Class['packages::python3_s3'],
+    }
+}

--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -33,13 +33,13 @@ class roles_profiles::profiles::mac_v3_signing {
 
             include dirs::tools
 
-            contain packages::python3
+            contain packages::python3_s3
             file { '/tools/python3':
                     ensure  => 'link',
                     target  => '/usr/local/bin/python3',
-                    require => Class['packages::python3'],
+                    require => Class['packages::python3_s3'],
             }
-            contain packages::virtualenv
+            contain packages::virtualenv_python3_s3
 
         }
         default: {


### PR DESCRIPTION
I'm not happy with these funny package manifest names but we can refactor them when we remove homebrew completely.  Since this probably conflicts with the homebrew version already installed on the mac-v3-signing hosts, we should reimage all of them.  We have to do this anyway since the full xcode install is being front loaded in the image.