### PR TITLE
Bug1580502 zstd macos

### DIFF
--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class packages::zstandard (
-    Pattern[/^v\d+\.\d+\.\d+$/] $version,
+    Pattern[/^\d+\.\d+\.\d+$/] $version,
 ) {
 
     packages::macos_package_from_s3 { "zstd-${version}.dmg":

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::zstandard (
+    Pattern[/^v\d+\.\d+\.\d+$/] $zstandard_version,
+    String                      $zstandard_sha256,
+) {
+
+    packages::macos_package_from_s3 { "zstd-${zstandard_version}.dmg":
+        private             => false,
+        os_version_specific => false,
+        type                => 'dmg',
+        checksum            => $zstandard_sha256,
+    }
+}

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -4,13 +4,11 @@
 
 class packages::zstandard (
     Pattern[/^v\d+\.\d+\.\d+$/] $zstandard_version,
-    String                      $zstandard_sha256,
 ) {
 
     packages::macos_package_from_s3 { "zstd-${zstandard_version}.dmg":
         private             => false,
         os_version_specific => false,
         type                => 'dmg',
-        checksum            => $zstandard_sha256,
     }
 }

--- a/modules/packages/manifests/zstandard.pp
+++ b/modules/packages/manifests/zstandard.pp
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class packages::zstandard (
-    Pattern[/^v\d+\.\d+\.\d+$/] $zstandard_version,
+    Pattern[/^v\d+\.\d+\.\d+$/] $version,
 ) {
 
-    packages::macos_package_from_s3 { "zstd-${zstandard_version}.dmg":
+    packages::macos_package_from_s3 { "zstd-${version}.dmg":
         private             => false,
         os_version_specific => false,
         type                => 'dmg',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -39,8 +39,8 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             $quarantine_access_token  = lookup('generic_worker.gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
-            class { 'zstandard':
-                zstandard_version => '1.3.8',
+            class { 'packages:;zstandard':
+                version => '1.3.8',
             }
 
             class { 'generic_worker':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -40,8 +40,8 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
             class { 'zstandard':
-                zstandard_version         => '1.3.8',
-                zstandard_sha256          => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
+                zstandard_version => '1.3.8',
+                zstandard_sha256  => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
             }
 
             class { 'generic_worker':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -39,6 +39,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             $quarantine_access_token  = lookup('generic_worker.gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
+            class { 'zstandard':
+                zstandard_version         => '1.3.8',
+                zstandard_sha256          => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
+            }
+
             class { 'generic_worker':
                 taskcluster_client_id     => $taskcluster_client_id,
                 taskcluster_access_token  => $taskcluster_access_token,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -41,7 +41,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
 
             class { 'zstandard':
                 zstandard_version => '1.3.8',
-                zstandard_sha256  => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
             }
 
             class { 'generic_worker':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -42,7 +42,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
 
             class { 'zstandard':
                 zstandard_version => '1.3.8',
-                zstandard_sha256  => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
             }
 
             class { 'generic_worker':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -40,6 +40,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             $quarantine_access_token  = lookup('generic_worker.gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
+            class { 'zstandard':
+                zstandard_version         => '1.3.8',
+                zstandard_sha256          => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
+            }
+
             class { 'generic_worker':
                 taskcluster_client_id     => $taskcluster_client_id,
                 taskcluster_access_token  => $taskcluster_access_token,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -40,8 +40,8 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             $quarantine_access_token  = lookup('generic_worker.gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
-            class { 'zstandard':
-                zstandard_version => '1.3.8',
+            class { 'packages::zstandard':
+                version => '1.3.8',
             }
 
             class { 'generic_worker':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -41,8 +41,8 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             $bugzilla_api_key         = lookup('generic_worker.gecko_t_osx_1014.bugzilla_api_key')
 
             class { 'zstandard':
-                zstandard_version         => '1.3.8',
-                zstandard_sha256          => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
+                zstandard_version => '1.3.8',
+                zstandard_sha256  => 'fa4c25da32000a6a6ab8135e72a4159e15b54bbda7f83c3947beb7a889ffd60a',
             }
 
             class { 'generic_worker':


### PR DESCRIPTION
macos cli binaries for zstandard 1.3.8 (matching the version in the python zstandard library we'll also install, https://github.com/indygreg/python-zstandard/blob/0.11/zstd/zstd.h#L72)