### PR TITLE
use PUPPET_{ENV,MAIL} in macos run-puppet.sh

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -3,9 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-PUPPET_ENV='production'
+PUPPET_ENV="${PUPPET_ENV:-production}"
 PUPPET_REPO="${PUPPET_REPO:-<%= @puppet_repo -%>}"
 PUPPET_BRANCH="${PUPPET_BRANCH:-<%= @puppet_branch -%>}"
+PUPPET_MAIL="${PUPPET_MAIL:-<%= @puppet_notify_email %>}"
 WORKING_DIR="/etc/puppet/environments/${PUPPET_ENV}/code"
 ROLE_FILE='/etc/puppet_role'
 PUPPET_BIN='/opt/puppetlabs/bin/puppet'
@@ -73,7 +74,7 @@ function email_report {
     ERR_MSG=$2
 
     SENDER="root@${FQDN}"
-    RECEIVER="<%= @puppet_notify_email %>"
+    RECEIVER="${PUPPET_MAIL}"
     python <<EOF
 import smtplib
 


### PR DESCRIPTION
This does not pin the puppet environment for the next at-boot run. It allows running against a user repo+branch on a existing machine (not requiring re-puppetize/reimage or changing the production env local repo):

Example:
```
[dhouse@t-mojave-r7-460.test.releng.mdc1.mozilla.com ~]$ sudo \
  PUPPET_ENV=dev \
  PUPPET_REPO="https://github.com/davehouse/ronin_puppet.git" \
  PUPPET_BRANCH="bug1572749_macos-to-papertrail" \
  PUPPET_MAIL=dhouse@mozilla.com \
  run-puppet.sh
Network connectivity check passed 10.49.56.84
Fetching origin
remote: Enumerating objects: 13, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 7 (delta 4), reused 7 (delta 4), pack-reused 0
Unpacking objects: 100% (7/7), done.
From https://github.com/davehouse/ronin_puppet
   dba8d76..dc88224  bug1572749_macos-to-papertrail -> origin/bug1572749_macos-to-papertrail
Previous HEAD position was dba8d76 wrap lines
HEAD is now at dc88224 wrap the array
Notice: Compiled catalog for t-mojave-r7-460.test.releng.mdc1.mozilla.com in environment production in 1.40 seconds
Notice: /Stage[main]/Packages::Fluent_plugin_google_cloud/Exec[install plugin with agent ruby]/returns: executed successfully
Notice: /Stage[main]/Packages::Fluent_plugin_remote_syslog/Exec[install remote syslog plugin with agent ruby]/returns: executed successfully
Notice: Applied catalog in 13.90 seconds
HTTP/2 204
date: Tue, 24 Sep 2019 16:19:36 GMT

HTTP/2 204
date: Tue, 24 Sep 2019 16:19:36 GMT

[dhouse@t-mojave-r7-460.test.releng.mdc1.mozilla.com ~]$
```