### PR TITLE
Bug1572190 macos nic lookup

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -55,17 +55,19 @@ function valid_ip {
 
 function block_on_network {
     local delay=1
-	while true; do
-		IP=`ifconfig en0 | grep "inet "| awk '{print $2}'`
-		if valid_ip $IP; then
-			echo "Network connectivity check passed $IP"
-			break
-		else
+    while true; do
+        interface=$(ifconfig | grep -v "127.0.0.1\|169." | grep -C4 "inet [0-9]\+\.[0-9]\+" | head -1 | cut -d\: -f1)
+        ifconfig $interface 2>&1 >/dev/null || interface="en0"
+        IP=$(ipconfig getifaddr $interface)
+        if valid_ip $IP; then
+            echo "Network connectivity check passed $IP"
+            break
+        else
             echo "Network connectivity failed; retry in ${delay}s"
-			sleep $delay
+            sleep $delay
             (( delay *= delay<60?2:1 ))
-		fi
-	done
+        fi
+    done
 }
 
 function email_report {

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -57,7 +57,7 @@ function valid_ip {
 function block_on_network {
     local delay=1
     while true; do
-        interface=$(ifconfig | grep -v "127.0.0.1\|169." | grep -C4 "inet [0-9]\+\.[0-9]\+" | head -1 | cut -d\: -f1)
+        interface=$(route get 1.1.1.1 | grep interface | cut -d\: -f2)
         ifconfig $interface 2>&1 >/dev/null || interface="en0"
         IP=$(ipconfig getifaddr $interface)
         if valid_ip $IP; then


### PR DESCRIPTION
The macbookpro workers NICs are en1 not en0. Look up the route that gets out to use that nic in our network connectivity check.