### PR TITLE
Bug1584553 macos - disable google chrome updater

### DIFF
--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -36,10 +36,12 @@ class roles_profiles::profiles::disable_chrome_updater (
                 file { [ '/Library/Caches/com.google.Keystone.agent',
                          '/Users/cltbld/Library/Caches/com.google.Keystone.agent' ]:
                     ensure  => absent,
+                    force   => true,
                 }
                 file { [ '/Library/LaunchAgents/com.google.Keystone.agent.plist',
                          '/Users/cltbld/Library/LaunchAgents/com.google.Keystone.agent.plist' ]:
                     ensure  => absent,
+                    force   => true,
                 }
             } else {
                 exec {

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::profiles::disable_chrome_updater (
-    Boolean purge = true,
+    Boolean $purge = true,
 ) {
 
     case $::operatingsystem {

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class roles_profiles::profiles::disable_chrome_updater {
+class roles_profiles::profiles::disable_chrome_updater (
     Boolean purge = true,
 ) {
 
     case $::operatingsystem {
         'Darwin': {
-            file { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
+            file: { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
                 ensure  => file,
                 force   => true,
                 mode    => '0444',

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -24,23 +24,33 @@ class roles_profiles::profiles::disable_chrome_updater (
             }
             if $purge {
                 file { [ '/Library/Google',
-                         '/Library/Google/GoogleSoftwareUpdate' ]:
+                         '/Library/Google/GoogleSoftwareUpdate',
+                         '/Users/cltbld',
+                         '/Users/cltbld/Library',
+                         '/Users/cltbld/Library/Google',
+                         '/Users/cltbld/Library/Google/GoogleSoftwareUpdate' ]:
                     ensure  => directory,
                     purge   => true,
                     force   => true,
                     recurse => true,
                     mode    => '0444',
                 }
-                file { '/Library/Caches/com.google.Keystone.agent':
+                file { [ '/Library/Caches/com.google.Keystone.agent',
+                         '/Users/cltbld/Library/Caches/com.google.Keystone.agent' ]:
                     ensure  => absent,
                 }
-                file { '/Library/LaunchAgents/com.google.Keystone.agent.plist':
+                file { [ '/Library/LaunchAgents/com.google.Keystone.agent.plist',
+                         '/Users/cltbld/Library/LaunchAgents/com.google.Keystone.agent.plist' ]:
                     ensure  => absent,
                 }
             } else {
                 exec {
                     'chrome-update-service-no-interval':
-                        command     => 'defaults write com.google.Keystone.Agent checkInterval 0',
+                        command => 'defaults write com.google.Keystone.Agent checkInterval 0',
+                }
+                exec {
+                    'chrome-update-service-no-interval-cltbld':
+                        command => 'sudo -u cltbld defaults write com.google.Keystone.Agent checkInterval 0',
                 }
                 service {
                     [

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -8,11 +8,18 @@ class roles_profiles::profiles::disable_chrome_updater (
 
     case $::operatingsystem {
         'Darwin': {
-            file: { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
+            file { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
                 ensure  => file,
                 force   => true,
                 mode    => '0444',
                 content => '',
+            }
+            file { '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate':
+                ensure  => directory,
+                purge   => true,
+                force   => true,
+                recurse => true,
+                mode    => '0444',
             }
             if $purge {
                 file { '/Library/Google/GoogleSoftwareUpdate':

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -8,6 +8,12 @@ class roles_profiles::profiles::disable_chrome_updater {
 
     case $::operatingsystem {
         'Darwin': {
+            file { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
+                ensure  => file,
+                force   => true,
+                mode    => '0444',
+                content => '',
+            }
             if $purge {
                 file { '/Library/Google/GoogleSoftwareUpdate':
                     ensure  => directory,

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -12,7 +12,6 @@ class roles_profiles::profiles::disable_chrome_updater (
                      '/System/Library/User Template/English.lproj/Library/Google',
                      '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate' ]:
                 ensure  => directory,
-                purge   => true,
                 force   => true,
                 recurse => true,
                 mode    => '0444',

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -9,8 +9,8 @@ class roles_profiles::profiles::disable_chrome_updater (
     case $::operatingsystem {
         'Darwin': {
             file { [ '/System/Library/User Template/English.lproj/Library/LaunchAgents',
-                     '/System/Library/User Template/English.lproj/Library/Google',
-                     '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate' ]:
+                  '/System/Library/User Template/English.lproj/Library/Google',
+                  '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate' ]:
                 ensure  => directory,
                 force   => true,
                 recurse => true,
@@ -24,9 +24,9 @@ class roles_profiles::profiles::disable_chrome_updater (
             }
             if $purge {
                 file { [ '/Library/Google',
-                         '/Library/Google/GoogleSoftwareUpdate',
-                         '/Users/cltbld/Library/Google',
-                         '/Users/cltbld/Library/Google/GoogleSoftwareUpdate' ]:
+                      '/Library/Google/GoogleSoftwareUpdate',
+                      '/Users/cltbld/Library/Google',
+                      '/Users/cltbld/Library/Google/GoogleSoftwareUpdate' ]:
                     ensure  => directory,
                     purge   => true,
                     force   => true,
@@ -34,14 +34,14 @@ class roles_profiles::profiles::disable_chrome_updater (
                     mode    => '0444',
                 }
                 file { [ '/Library/Caches/com.google.Keystone.agent',
-                         '/Users/cltbld/Library/Caches/com.google.Keystone.agent' ]:
-                    ensure  => absent,
-                    force   => true,
+                      '/Users/cltbld/Library/Caches/com.google.Keystone.agent' ]:
+                    ensure => absent,
+                    force  => true,
                 }
                 file { [ '/Library/LaunchAgents/com.google.Keystone.agent.plist',
-                         '/Users/cltbld/Library/LaunchAgents/com.google.Keystone.agent.plist' ]:
-                    ensure  => absent,
-                    force   => true,
+                      '/Users/cltbld/Library/LaunchAgents/com.google.Keystone.agent.plist' ]:
+                    ensure => absent,
+                    force  => true,
                 }
             } else {
                 exec {

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -46,11 +46,11 @@ class roles_profiles::profiles::disable_chrome_updater (
             } else {
                 exec {
                     'chrome-update-service-no-interval':
-                        command => 'defaults write com.google.Keystone.Agent checkInterval 0',
+                        command => '/usr/bin/defaults write com.google.Keystone.Agent checkInterval 0',
                 }
                 exec {
                     'chrome-update-service-no-interval-cltbld':
-                        command => 'sudo -u cltbld defaults write com.google.Keystone.Agent checkInterval 0',
+                        command => '/usr/bin/sudo -u cltbld /usr/bin/defaults write com.google.Keystone.Agent checkInterval 0',
                 }
                 service {
                     [

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -23,7 +23,8 @@ class roles_profiles::profiles::disable_chrome_updater (
                 content => '',
             }
             if $purge {
-                file { '/Library/Google/GoogleSoftwareUpdate':
+                file { [ '/Library/Google',
+                         '/Library/Google/GoogleSoftwareUpdate' ]:
                     ensure  => directory,
                     purge   => true,
                     force   => true,

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -8,18 +8,20 @@ class roles_profiles::profiles::disable_chrome_updater (
 
     case $::operatingsystem {
         'Darwin': {
-            file { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
-                ensure  => file,
-                force   => true,
-                mode    => '0444',
-                content => '',
-            }
-            file { '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate':
+            file { [ '/System/Library/User Template/English.lproj/Library/LaunchAgents',
+                     '/System/Library/User Template/English.lproj/Library/Google',
+                     '/System/Library/User Template/English.lproj/Library/Google/GoogleSoftwareUpdate' ]:
                 ensure  => directory,
                 purge   => true,
                 force   => true,
                 recurse => true,
                 mode    => '0444',
+            }
+            file { '/System/Library/User Template/English.lproj/Library/LaunchAgents/com.google.keystone.agent.plist':
+                ensure  => file,
+                force   => true,
+                mode    => '0444',
+                content => '',
             }
             if $purge {
                 file { '/Library/Google/GoogleSoftwareUpdate':

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -25,8 +25,6 @@ class roles_profiles::profiles::disable_chrome_updater (
             if $purge {
                 file { [ '/Library/Google',
                          '/Library/Google/GoogleSoftwareUpdate',
-                         '/Users/cltbld',
-                         '/Users/cltbld/Library',
                          '/Users/cltbld/Library/Google',
                          '/Users/cltbld/Library/Google/GoogleSoftwareUpdate' ]:
                     ensure  => directory,

--- a/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_chrome_updater.pp
@@ -52,14 +52,6 @@ class roles_profiles::profiles::disable_chrome_updater (
                     'chrome-update-service-no-interval-cltbld':
                         command => '/usr/bin/sudo -u cltbld /usr/bin/defaults write com.google.Keystone.Agent checkInterval 0',
                 }
-                service {
-                    [
-                      'com.google.keystone.system.agent',
-                      'com.google.keystone.system.xpcservice',
-                    ]:
-                        ensure => 'stopped',
-                        enable => false,
-                }
             }
         }
         default: {

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -67,6 +67,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
+            class { 'roles_profiles::profiles::disable_chrome_updater':
+                purge => false,
+            }
+
             contain packages::nodejs
             contain packages::wget
             contain packages::tooltool

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -67,9 +67,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
-            class { 'roles_profiles::profiles::disable_chrome_updater':
-                purge => false,
-            }
+            include roles_profiles::profiles::disable_chrome_updater
 
             contain packages::nodejs
             contain packages::wget

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -68,7 +68,9 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
-            include roles_profiles::profiles::disable_chrome_updater
+            class { 'roles_profiles::profiles::disable_chrome_updater':
+                purge => false,
+            }
 
             contain packages::nodejs
             contain packages::wget

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -68,9 +68,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
-            class { 'roles_profiles::profiles::disable_chrome_updater':
-                purge => false,
-            }
+            include roles_profiles::profiles::disable_chrome_updater'
 
             contain packages::nodejs
             contain packages::wget

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -68,7 +68,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
-            include roles_profiles::profiles::disable_chrome_updater'
+            include roles_profiles::profiles::disable_chrome_updater
 
             contain packages::nodejs
             contain packages::wget

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -68,6 +68,8 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'packages::google_chrome':
                 version => 'v76.0.3809.132',
             }
+            include roles_profiles::profiles::disable_chrome_updater
+
             contain packages::nodejs
             contain packages::wget
             contain packages::tooltool


### PR DESCRIPTION
This blocks the macos user LaunchAgent for google updater from being set up (not-writable) for new users (anticipating multiuser generic-worker creating new users that will execute chrome) and removes the google updater from the system level and cltbld user (if already installed).