### PR TITLE
remote_syslog not remote-syslog

### DIFF
--- a/modules/packages/manifests/fluent_plugin_remote_syslog.pp
+++ b/modules/packages/manifests/fluent_plugin_remote_syslog.pp
@@ -5,13 +5,13 @@
 class packages::fluent_plugin_remote_syslog {
     require packages::td_agent
 
-    $version = '1.1'
+    $version = '1.0.0'
 
     exec {
         'install remote syslog plugin with agent ruby':
             path    => ['/bin', '/sbin', '/usr/sbin', '/usr/local/bin', '/usr/bin'],
-            command => "/usr/sbin/td-agent-gem install fluent-plugin-remote-syslog --version ${version}",
-            unless  => "test -f /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-remote-syslog-${version}",
+            command => "/usr/sbin/td-agent-gem install fluent-plugin-remote_syslog --version ${version}",
+            unless  => "test -f /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-remote_syslog-${version}",
             require => Class['packages::td_agent'];
     }
 }


### PR DESCRIPTION
I left it with the wrong remote_syslog package. 
remote_syslog takes severity and program/etc from the event, and uses the current plugin interface. 
remote-syslog does not take the syslog tags from the event and uses the deprecated fluent plugin interface.