### PR TITLE
Bug1572749 turn off stackdriver macos

### DIFF
--- a/modules/fluentd/manifests/init.pp
+++ b/modules/fluentd/manifests/init.pp
@@ -8,8 +8,8 @@ class fluentd (
     String $stackdriver_keyid    = '',
     String $stackdriver_key      = '',
     String $stackdriver_clientid = '',
-    String $syslog_host          = lookup('papertrail.host'),
-    Integer $syslog_port         = lookup('papertrail.port'),
+    String $syslog_host          = lookup('papertrail.host', {'default_value' => ''}),
+    Integer $syslog_port         = lookup('papertrail.port', {'default_value' => 514}),
     String $mac_log_level        = 'default',
 ) {
 

--- a/modules/packages/manifests/fluent_plugin_google_cloud.pp
+++ b/modules/packages/manifests/fluent_plugin_google_cloud.pp
@@ -14,7 +14,7 @@ class packages::fluent_plugin_google_cloud {
         'install plugin with agent ruby':
             path    => ['/bin', '/sbin', '/usr/sbin', '/usr/local/bin', '/usr/bin'],
             command => "/usr/sbin/td-agent-gem install fluent-plugin-google-cloud --version ${version}",
-            unless  => "test -f /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-${version}",
+            unless  => "test -e /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-google-cloud-${version}",
             require => Class['packages::td_agent'];
     }
 }

--- a/modules/packages/manifests/fluent_plugin_papertrail.pp
+++ b/modules/packages/manifests/fluent_plugin_papertrail.pp
@@ -11,7 +11,7 @@ class packages::fluent_plugin_papertrail {
         'install papertrail plugin with agent ruby':
             path    => ['/bin', '/sbin', '/usr/sbin', '/usr/local/bin', '/usr/bin'],
             command => "/usr/sbin/td-agent-gem install fluent-plugin-papertrail --version ${version}",
-            unless  => "test -f /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-papertrail-${version}",
+            unless  => "test -e /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-papertrail-${version}",
             require => Class['packages::td_agent'];
     }
 }

--- a/modules/packages/manifests/fluent_plugin_remote_syslog.pp
+++ b/modules/packages/manifests/fluent_plugin_remote_syslog.pp
@@ -11,7 +11,7 @@ class packages::fluent_plugin_remote_syslog {
         'install remote syslog plugin with agent ruby':
             path    => ['/bin', '/sbin', '/usr/sbin', '/usr/local/bin', '/usr/bin'],
             command => "/usr/sbin/td-agent-gem install fluent-plugin-remote_syslog --version ${version}",
-            unless  => "test -f /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-remote_syslog-${version}",
+            unless  => "test -e /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-remote_syslog-${version}",
             require => Class['packages::td_agent'];
     }
 }

--- a/modules/roles_profiles/manifests/profiles/logging.pp
+++ b/modules/roles_profiles/manifests/profiles/logging.pp
@@ -4,7 +4,7 @@
 
 class roles_profiles::profiles::logging (
     String $worker_type         = '',  # not used by windows
-    String $stackdriver_project = 'fx-worker-logging-prod',
+    String $stackdriver_project = 'none',
     String $syslog_host         = join([
       'log-aggregator',
       "${1 + fqdn_rand(2)}",
@@ -17,9 +17,9 @@ class roles_profiles::profiles::logging (
 ) {
 
     # use a single write-only service account for each project
-    $stackdriver_keyid    = lookup("stackdriver.${stackdriver_project}.keyid")
-    $stackdriver_key      = lookup("stackdriver.${stackdriver_project}.key")
-    $stackdriver_clientid = lookup("stackdriver.${stackdriver_project}.clientid")
+    $stackdriver_keyid    = lookup("stackdriver.${stackdriver_project}.keyid", {'default_value' => ''})
+    $stackdriver_key      = lookup("stackdriver.${stackdriver_project}.key", {'default_value' => ''})
+    $stackdriver_clientid = lookup("stackdriver.${stackdriver_project}.clientid", {'default_value' => ''})
 
     case $::operatingsystem {
         'Windows': {


### PR DESCRIPTION
Stop copying the macos mojave logs to stackdriver. This can be turned back on in the future like:
```ruby
class { 'roles_profiles::profiles::logging':
    worker_type => $worker_type,
    mac_log_level => 'default',
    stackdriver_project => 'fx-worker-logging-prod',  # enables stackdriver forwarding
}
```

also this fixes the unless check for the fluent plugins (was doing a file check instead of exists/dir)