### PR TITLE
bug1572749 filter macos logs: worker or >error

### DIFF
--- a/modules/fluentd/manifests/init.pp
+++ b/modules/fluentd/manifests/init.pp
@@ -61,8 +61,9 @@ class fluentd (
             }
 
             service { 'td-agent':
-                require => File['/Library/LaunchDaemons/td-agent.plist'],
+                ensure  => running,
                 enable  => true,
+                require => File['/Library/LaunchDaemons/td-agent.plist'],
             }
 
         }

--- a/modules/fluentd/templates/fluentd.conf.erb
+++ b/modules/fluentd/templates/fluentd.conf.erb
@@ -2,9 +2,11 @@
   @type exec
   command "\
     log stream --color none --level <%= @mac_log_level %> --type log \
+      --predicate '(process MATCHES \"(logger|sudo|generic-worker)\") || (messageType > 2)' \
       --timeout 1d \
     | tail -n +3 \
     "
+    # messageTypes 0:Default 1:Info 2:Debug ?:Error
     # tail to omit first 2 lines that cause parsing to fail:
     #   Filtering the log data using "type == 1024"
     #   Timestamp                       Thread     Type        Activity             PID    TTL
@@ -29,31 +31,33 @@
   @type record_transformer
   enable_ruby true
   <record>
-<% if @syslog_host =~ /papertrail/ %>
+<% if @syslog_host =~ /papertrail/ -%>
     hostname "#{Socket.gethostname}"
-<% end %>
+<% end -%>
     # Logging pid can be enabled:
     # message pid:${record["pid"]} ${record["message"]}
     # MacOS Unified logging levels: Fault, Error, Default, Info, Debug
-<% if @syslog_host != '' %>
+<% if @syslog_host != '' -%>
     # syslog severities:
     #   https://github.com/eric/syslog_protocol/blob/master/lib/syslog_protocol/common.rb#L58
     syslog_severity #{record["severity"].gsub(/^(Info|Default|Error|Fault)/i, 'Info' => 'info', 'Default' => 'warn', 'Error' => 'err', 'Fault' => 'crit')}
-<% end %>
-<% if @stackdriver_clientid != '' %>
+<% end -%>
+<% if @stackdriver_clientid != '' -%>
     message ${record["program"]}: ${record['log_message']}
     # stackdriver severities: 
     #   https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
     stackdriver_severity #{record["severity"].gsub(/^(Info|Default|Error|Fault)/i, 'Info' => 'info', 'Default' => 'warning', 'Error' => 'error', 'Fault' => 'critical')}
-<% end %>
+<% end -%>
   </record>
 </filter>
 
+<% if @stackdriver_clientid != '' -%>
 # Add a unique insertId to each log entry that doesn't already have it.
 # This helps guarantee the order and prevent log duplication.
 <filter system>
   @type add_insert_ids
 </filter>
+<% end -%>
 
 # string/numbers only
 # msgpack cannot encode ruby Time fields
@@ -72,20 +76,23 @@
   <record>
     workerGroup "#{Socket.gethostname.split('.')[3]}"
   </record>
+<% if @stackdriver_clientid != '' -%>
   <record>
     severity #{record["stackdriver_severity"]}
   </record>
+<% end -%>
 </filter>
 
 <match system>
   @type copy
-<% if @syslog_host =~ /papertrail/ %>
+
+<% if @syslog_host =~ /papertrail/ -%>
   <store>
     @type papertrail
     papertrail_host <%= @syslog_host %>
     papertrail_port <%= @syslog_port %>
   </store>
-<% elsif @syslog_host != '' %>
+<% elsif @syslog_host != '' -%>
   <store>
     @type remote_syslog
     hostname "#{Socket.gethostname}"
@@ -100,11 +107,11 @@
       message_key log_message
     </format>
   </store>
-<% else %>
+<% else -%>
 # Disabled syslog output. (syslog_host: <%= @syslog_host %>)
-<% end %>
+<% end -%>
 
-<% if @stackdriver_clientid != '' %>
+<% if @stackdriver_clientid != '' -%>
   <store>
     @type google_cloud
     use_metadata_service false
@@ -136,7 +143,7 @@
     # valid ones and drop the invalid ones instead of dropping everything.
     partial_success true
   </store>
-<% else %>
+<% else -%>
 # Disabled stackdriver output. (clientid: <%= @stackdriver_clientid %>)
-<% end %>
+<% end -%>
 </match>


### PR DESCRIPTION
filter macos logs on the machines before forwarding

1. send all worker/puppet logs (reported as process=logger)
2. send other log entries error or more severe
3. send all sudo logs

This also:
* fixes the template formatting in the config file to not leave blank lines for each if/end.
* makes sure the logging service is running/starts