### PR TITLE
bug1593017 use unsigned java dev package

### DIFF
--- a/modules/packages/manifests/java_developer_package_for_osx.pp
+++ b/modules/packages/manifests/java_developer_package_for_osx.pp
@@ -5,7 +5,9 @@
 class packages::java_developer_package_for_osx {
 
     # https://download.developer.apple.com/Developer_Tools/java_for_os_x_2013005_developer_package/java_for_os_x_2013005_dp__11m4609.dmg
-    packages::macos_package_from_s3 { 'java_for_os_x_2013005_dp__11m4609.dmg':
+    # the signing certificate expired Oct 24, 2019
+    # I expanded and flattened the package (without signing)
+    packages::macos_package_from_s3 { 'java_for_os_x_2013005_dp__11m4609_unsigned.dmg':
         private             => true,
         os_version_specific => true,
         type                => 'dmg',


### PR DESCRIPTION
The cert expired Oct 24, 2019. I looked but did not find a re-release of the package from Apple. This uses a copy I expanded and re-created without signing so that it will install without the cert check on mojave.