### PR TITLE
remove tasks-resolved-count.txt file

### DIFF
--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -26,6 +26,8 @@ set errorlevel=
 <%= $win_generic_worker::run_generic_worker_command %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker.log 2>&1
 set gw_exit_code=%errorlevel%
 
+del /Q /F <%= $facts[custom_win_roninsemaphoredir] %>\tasks-resolved-count.txt
+
 if %GW_EXIT_CODE% EQU 0 GoTo exit_0
 if %GW_EXIT_CODE% EQU 67 GoTo exit_67
 if %GW_EXIT_CODE% EQU 68 GoTo exit_68


### PR DESCRIPTION
The file maybe causing an issue;

Nov 09 15:15:50 T-W1064-MS-123.mdc1.mozilla.com generic-worker UTC goroutine 1 [running]: runtime/debug.Stack(0x0, 0xc0424d87f8, 0x0) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/debug/stack.go:24 +0xae main.HandleCrash(0x921ac0, 0xc0424dde40) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:351 +0x2d main.RunWorker.func1(0xc042469e30) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:370 +0x59 panic(0x921ac0, 0xc0424dde40) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/panic.go:502 +0x237 main.(*CacheMap).LoadFromFile(0xd635f8, 0x9d80d4, 0x10, 0xc0420784b0, 0x8) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:146 +0x4a5 main.(*MountsFeature).Initialise(0xd81bc8, 0x1f, 0xc042469ae8) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:154 +0x66 main.initialiseFeatures(0xc0420c8000, 0xc0424ac4c0) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:87 +0x471 main.RunWorker(0x0) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:407 +0x36c main.main() #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:157 +0x7ba#015
Nov 09 15:15:50 T-W1064-MS-123.mdc1.mozilla.com generic-worker UTC  *********** PANIC occurred! *********** #015
Nov 09 15:15:50 T-W1064-MS-123.mdc1.mozilla.com generic-worker UTC invalid character '\x00' looking for beginning of value#015