### PR TITLE
Remove directory-caches.json on exit 69

### DIFF
--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -52,6 +52,7 @@ echo "Generic worker has reached idle timeout set in config file, <%= win_generi
 shutdown /r /t 0 /f /c "Generic worker has reached idle timeout; rebooting" >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 
 :exit_69
+del /Q /F <%= $win_generic_worker::generic_worker_dir %>\directory-caches.json
 del /Q /F <%= $win_generic_worker::generic_worker_config %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 echo "Generic-worker panic! Issue with enviroment or worker bug. (exit code %GW_EXIT_CODE%)" >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 Goto ErrorReboot

--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -26,7 +26,7 @@ set errorlevel=
 <%= $win_generic_worker::run_generic_worker_command %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker.log 2>&1
 set gw_exit_code=%errorlevel%
 
-del /Q /F <%= $facts[custom_win_roninsemaphoredir] %>\tasks-resolved-count.txt
+del /Q /F <%= $win_generic_worker::generic_worker_dir %>\tasks-resolved-count.txt
 
 if %GW_EXIT_CODE% EQU 0 GoTo exit_0
 if %GW_EXIT_CODE% EQU 67 GoTo exit_67


### PR DESCRIPTION
Maybe causing a gw panic:

Nov 09 15:58:59 T-W1064-MS-123.mdc1.mozilla.com generic-worker UTC Could not load file directory-caches.json into object *main.CacheMap - is it json?#015
Nov 09 15:58:59 T-W1064-MS-123.mdc1.mozilla.com generic-worker UTC goroutine 1 [running]: runtime/debug.Stack(0x0, 0xc042098980, 0x0) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/debug/stack.go:24 +0xae main.HandleCrash(0x921ac0, 0xc0420f6980) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:351 +0x2d main.RunWorker.func1(0xc04246de30) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:370 +0x59 panic(0x921ac0, 0xc0420f6980) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/panic.go:502 +0x237 main.(*CacheMap).LoadFromFile(0xd635f0, 0x9db409, 0x15, 0xc0420784d0, 0xc) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:146 +0x4a5 main.(*MountsFeature).Initialise(0xd81bc8, 0x1f, 0xc04246dae8) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:155 +0xaa main.initialiseFeatures(0xc0420c8000, 0xc04237a440) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:87 +0x471 main.RunWorker(0x0) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:407 +0x36c main.main() #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:157 +0x7ba#015