### PR TITLE
Remove file-caches.json on exit 69

### DIFF
--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -52,6 +52,7 @@ echo "Generic worker has reached idle timeout set in config file, <%= win_generi
 shutdown /r /t 0 /f /c "Generic worker has reached idle timeout; rebooting" >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 
 :exit_69
+del /Q /F <%= $win_generic_worker::generic_worker_dir %>\file-caches.json
 del /Q /F <%= $win_generic_worker::generic_worker_dir %>\directory-caches.json
 del /Q /F <%= $win_generic_worker::generic_worker_config %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 echo "Generic-worker panic! Issue with enviroment or worker bug. (exit code %GW_EXIT_CODE%)" >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log


### PR DESCRIPTION
Causing a gw panic:
Nov 09 16:12:17 T-W1064-MS-201.mdc1.mozilla.com-1 generic-worker UTC goroutine 1 [running]: runtime/debug.Stack(0x0, 0xc042098948, 0x0) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/debug/stack.go:24 +0xae main.HandleCrash(0x921ac0, 0xc0423f5f60) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:351 +0x2d main.RunWorker.func1(0xc04246be30) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:370 +0x59 panic(0x921ac0, 0xc0423f5f60) #011/home/travis/.gimme/versions/go1.10.8.src/src/runtime/panic.go:502 +0x237 main.(*CacheMap).LoadFromFile(0xd635f8, 0x9d80d4, 0x10, 0xc042078a20, 0x8) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:146 +0x4a5 main.(*MountsFeature).Initialise(0xd81bc8, 0x1f, 0xc04246bae8) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/mounts.go:154 +0x66 main.initialiseFeatures(0xc0420c8000, 0xc04237a340) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:87 +0x471 main.RunWorker(0x0) #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:407 +0x36c main.main() #011/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:157 +0x7ba#015