### PR TITLE
Bustage Update tooltool.pp

### DIFF
--- a/modules/win_mozilla_build/manifests/tooltool.pp
+++ b/modules/win_mozilla_build/manifests/tooltool.pp
@@ -11,7 +11,7 @@ class win_mozilla_build::tooltool {
     $tooltool_cache = "${builds}\\tooltool_cache"
 
     file { "${win_mozilla_build::install_path}\\tooltool.py":
-        source => 'https://raw.githubusercontent.com/mozilla/release-services/master/src/tooltool/client/tooltool.py',
+        source => 'https://ronin-puppet-package-repo.s3-us-west-2.amazonaws.com/macos/public/common/tooltool.py',
     }
     file { $tooltool_cache:
         ensure => directory,


### PR DESCRIPTION
The tooltool.py url change and broke Puppet runs on Windows. This is a temporary fix. https://bugzilla.mozilla.org/show_bug.cgi?id=1595556