### PR TITLE
remove telegraf file count and turn telegraf back on

### DIFF
--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -31,9 +31,9 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                 mac_log_level => 'default',
             }
 
-            # class { 'telegraf':
-            #     global_tags => $meta_data,
-            # }
+            class { 'telegraf':
+                global_tags => $meta_data,
+            }
 
             class { 'talos':
                 user => 'cltbld',

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -32,18 +32,22 @@
   report_active = false
 
 [[inputs.disk]]
+  interval = "300s"
   ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
 
 [[inputs.diskio]]
+  interval = "300s"
 
 [[inputs.mem]]
 
 [[inputs.swap]]
+  interval = "300s"
 
 [[inputs.system]]
 
 <% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
 [[inputs.exec]]
+  interval = "300s"
   commands = [
     "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)s\\\" $(/usr/bin/pmset -g therm | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
   ]
@@ -51,6 +55,7 @@
   data_format = "influx"
 
 [[inputs.exec]]
+  interval = "300s"
   commands = [
     "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)s\\\" $(/usr/sbin/sysctl -ie machdep.xcpm.cpu_thermal_level machdep.xcpm.gpu_thermal_level machdep.xcpm.io_thermal_level | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
   ]
@@ -58,18 +63,11 @@
   data_format = "influx"
 <% else -%>
 [[inputs.temp]]
+  interval = "300s"
 
 [[inputs.hddtemp]]
+  interval = "300s"
 <% end -%>
-
-[[inputs.filecount]]
-<% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
-  directories = ["/Users/task*","/Users/cltbld"]
-<% else -%>
-  directories = ["/home/task*","/home/cltbld"]
-<% end -%>
-  tagexclude = ["directory"]
 
 [[inputs.procstat]]
   exe = "generic-worker"
-


### PR DESCRIPTION
* remove file count (this causes high cpu usage when there are many files. and the test worker has many files in the task directory tree)
* make temperature, swap and disk usage checks run every 5min instead of each minute
* turn telegraf back on