### PR TITLE
Bug1572749 macos logging to file

### DIFF
--- a/modules/fluentd/templates/fluentd.conf.erb
+++ b/modules/fluentd/templates/fluentd.conf.erb
@@ -2,7 +2,7 @@
   @type exec
   command "\
     log stream --color none --level <%= @mac_log_level %> --type log \
-      --predicate '(process MATCHES \"(logger|sudo|generic-worker)\") || (messageType > 2)' \
+      --predicate '(process MATCHES \"(logger|sudo|kernel|sshd|firefox|plugin-agent)\") || (messageType > 16)' \
       --timeout 1d \
     | tail -n +3 \
     "
@@ -17,22 +17,79 @@
     types pid:integer
     time_key time
     time_format "%Y-%m-%d %H:%M:%S.%N%z"
-    utc true
   </parse>
   tag system
   run_interval 60s  # run command if not still running
 </source>
 
-<match fluent.**>
-  @type null
-</match>
+
+<source>
+  @type tail
+  read_from_head true
+  path /var/log/genericworker/stderr.log
+  pos_file /var/log/genericworker/stderr.log.pos
+  <parse>
+    @type multiline
+    # 2019/11/07 18:41:43 Disk available: 225110376448 bytes\n
+    format_firstline /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} /
+    format1 /^(?<time>\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})( [A-Z]{3})? (?<message>.*)/
+    time_key time
+    time_format "%Y/%m/%d %H:%M:%S"
+    keep_time_key true
+  </parse>
+  tag worker.err
+</source>
+<source>
+  @type tail
+  read_from_head true
+  path /var/log/genericworker/stdout.log
+  pos_file /var/log/genericworker/stdout.log.pos
+  <parse>
+    @type multiline
+    # 2019/11/07 18:41:43 Disk available: 225110376448 bytes\n
+    format_firstline /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} /
+    format1 /^(?<time>\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})( [A-Z]{3})? (?<message>.*)/
+    time_key time
+    time_format "%Y/%m/%d %H:%M:%S"
+    keep_time_key true
+  </parse>
+  tag worker.info
+</source>
+
+<filter worker.**>
+  @type grep
+  <exclude>
+    key message
+    pattern /^Disk available: \d+ bytes$/
+  </exclude>
+</filter>
+
+<filter worker.**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    program "worker"
+<% if @syslog_host != '' -%>
+    syslog_severity "${tag_parts[1]}"
+    # No task claimed. Idle for 5h15m43.362805902s (will exit if no task claimed in 90h44m16.637194098s). 1 more tasks to run before exiting.
+    # No task 5h15m43 1
+    log_message #{record["message"].sub(/^(No task) claimed. Idle for ([^\.]+)\..* (\d+) more tasks to run before exiting\.$/, '\1 \2 \3')}
+<% end -%>
+<% if @stackdriver_clientid != '' -%>
+    # stackdriver severities: 
+    #   https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+    stackdriver_severity "${tag_parts[1].gsub(/^(err|info)/i, 'info' => 'info', 'err' => 'error')}"
+    message #{record["program"]} #{record["message"].sub(/^(No task) claimed. Idle for ([^\.]+)\..* (\d+) more tasks to run before exiting\.$/, '\1 \2 \3')}
+<% end -%>
+  </record>
+</filter>
 
 <filter system>
   @type record_transformer
   enable_ruby true
   <record>
 <% if @syslog_host =~ /papertrail/ -%>
-    hostname "#{Socket.gethostname}"
+    hostname "#{Socket.gethostname.split('.')[0]}"
 <% end -%>
     # Logging pid can be enabled:
     # message pid:${record["pid"]} ${record["message"]}
@@ -54,14 +111,13 @@
 <% if @stackdriver_clientid != '' -%>
 # Add a unique insertId to each log entry that doesn't already have it.
 # This helps guarantee the order and prevent log duplication.
-<filter system>
+<filter **>
   @type add_insert_ids
 </filter>
-<% end -%>
 
 # string/numbers only
 # msgpack cannot encode ruby Time fields
-<filter system>
+<filter **>
   @type record_transformer
   remove_keys ["host"]
   <record>
@@ -76,14 +132,17 @@
   <record>
     workerGroup "#{Socket.gethostname.split('.')[3]}"
   </record>
-<% if @stackdriver_clientid != '' -%>
   <record>
     severity #{record["stackdriver_severity"]}
   </record>
-<% end -%>
 </filter>
+<% end -%>
 
-<match system>
+<match fluent.**>
+  @type null
+</match>
+
+<match **>
   @type copy
 
 <% if @syslog_host =~ /papertrail/ -%>
@@ -95,10 +154,12 @@
 <% elsif @syslog_host != '' -%>
   <store>
     @type remote_syslog
-    hostname "#{Socket.gethostname}"
+    hostname "#{Socket.gethostname.split('.')[0]}"
     host <%= @syslog_host %>
     port <%= @syslog_port %>
     <buffer program,syslog_severity>
+      flush_at_shutdown true
+      overflow_action block
     </buffer>
     program ${program}
     severity ${syslog_severity}

--- a/modules/generic_worker/templates/run-generic-worker.sh.erb
+++ b/modules/generic_worker/templates/run-generic-worker.sh.erb
@@ -10,12 +10,21 @@
 # to numberOfTasksToRun, the worker won't exit and machine won't reboot.
 rm -f tasks-resolved-count.txt
 
+<% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
+exec 1> >(tee /var/log/genericworker/stdout.log >&1)
+exec 2> >(tee /var/log/genericworker/stderr.log >&2)
+<% end %>
+
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
 source /usr/local/share/generic-worker/bugzilla-utils.sh
 
 # First run the generic-worker, passing through any arguments handed to this
 # wrapper script...
+<% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
+/usr/local/bin/generic-worker "$@"
+<% else %>
 /usr/local/bin/generic-worker "$@" 2>&1 | logger -t generic-worker -s
+<% end %>
 
 exitstatus="${PIPESTATUS[0]}"
 


### PR DESCRIPTION
We are losing macos mojave generic-worker logs because of failing to parse some text in the log entries from unified logging.

> The failure is in my regex of the generic-worker logs in unified logging format including newlines and unexpected characters. If we tail from a file, we can parse multiline with starting timestamps denoting new log entries and glob all of the remaining log line, and newlines until the next timestamp, as the log message.

* put generic-worker logs on disk (clear at each reboot (run-generic-worker.sh execution), launchd does not logrotate and so we cannot use the launch plist to set stderr/stdout to disk)
* tail those logs from fluentd
    1. tag as Error(stderr file) or Info(stdout file)
    2. parse logged timestamp as log entry time
* reduce log noise for entries that repeat each minute:
    1. shorten idle message:
     No task claimed. Idle for 5h15m43.362805902s (will exit if no task claimed in 90h44m16.637194098s). 1 more tasks to run before exiting.
     No task 5h15m43 1
    2. drop disk space message