### PR TITLE
integer not seconds

### DIFF
--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -49,7 +49,7 @@
 [[inputs.exec]]
   interval = "300s"
   commands = [
-    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)s\\\" $(/usr/bin/pmset -g therm | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
+    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/bin/pmset -g therm | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
   ]
   timeout = "60s"
   data_format = "influx"
@@ -57,7 +57,7 @@
 [[inputs.exec]]
   interval = "300s"
   commands = [
-    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)s\\\" $(/usr/sbin/sysctl -ie machdep.xcpm.cpu_thermal_level machdep.xcpm.gpu_thermal_level machdep.xcpm.io_thermal_level | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
+    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/sbin/sysctl -ie machdep.xcpm.cpu_thermal_level machdep.xcpm.gpu_thermal_level machdep.xcpm.io_thermal_level | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
   ]
   timeout = "60s"
   data_format = "influx"


### PR DESCRIPTION
boottimes in thermal stats are not being accepted by telegraf because they need to be integers (suffix "i") and  not my typo "s"

```
2019-11-27T21:31:00Z E! [inputs.exec] Error in plugin: metric parse error: expected field at 1:93: 
"thermal CPU_Scheduler_Limit=100,CPU_Available_CPUs=4,CPU_Speed_Limit=100,boottime=1574833772s"
```