### PR TITLE
Bug1571949 make telegraf module configurable

### DIFF
--- a/modules/puppet/manifests/atboot.pp
+++ b/modules/puppet/manifests/atboot.pp
@@ -5,6 +5,7 @@
 class puppet::atboot (
     String $telegraf_user,
     String $telegraf_password,
+    Optional[String] $puppet_env = 'production',
     String $puppet_repo         = 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
     String $puppet_branch       = 'master',
     String $puppet_notify_email = 'puppet-ronin-reports@mozilla.com',

--- a/modules/puppet/manifests/atboot.pp
+++ b/modules/puppet/manifests/atboot.pp
@@ -5,7 +5,6 @@
 class puppet::atboot (
     String $telegraf_user,
     String $telegraf_password,
-    Optional[String] $puppet_env = 'production',
     String $puppet_repo         = 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
     String $puppet_branch       = 'master',
     String $puppet_notify_email = 'puppet-ronin-reports@mozilla.com',

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-PUPPET_ENV="${PUPPET_ENV:-production}"
+PUPPET_ENV="${PUPPET_ENV:-<%= @puppet_env -%>}"
 PUPPET_REPO="${PUPPET_REPO:-<%= @puppet_repo -%>}"
 PUPPET_BRANCH="${PUPPET_BRANCH:-<%= @puppet_branch -%>}"
 PUPPET_MAIL="${PUPPET_MAIL:-<%= @puppet_notify_email %>}"
@@ -111,7 +111,7 @@ function update_puppet {
         git remote add origin "${PUPPET_REPO}" || return 1
     fi
 
-    # Fetch and checkout production branch
+    # Fetch and checkout branch
     git fetch --all --prune || return 1
     git checkout --force "origin/${PUPPET_BRANCH}" || return 1
 

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -104,7 +104,7 @@ function notify_telegraf {
         "https://telegraf.relops.mozops.net/write?db=relops" \
         '--data-binary' \
         "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
-    out=$(curl --silent "${CURL_OPTIONS[@]}" 2>&1) || echo "${out}"
+    out=$(curl --fail --silent --show-error "${CURL_OPTIONS[@]}" 2>&1) || echo "${out}"
 }
 
 function update_puppet {

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -101,7 +101,7 @@ function notify_telegraf {
     TELEGRAF_VALUE=$2
     META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
     CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "https://telegraf.relops.mozops.net/write?db=relops" '--data-binary' "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
-    curl "${CURL_OPTIONS[@]}" 2>&1
+    curl --silent "${CURL_OPTIONS[@]}" 2>&1
 }
 
 function update_puppet {
@@ -113,7 +113,15 @@ function update_puppet {
 
     # Fetch and checkout branch
     git fetch --all --prune || return 1
-    git checkout --force "origin/${PUPPET_BRANCH}" || return 1
+    # If it fails (maybe different repo:branch used before),
+    # re-add with the current repo and try again.
+    git checkout --force "origin/${PUPPET_BRANCH}" \
+      || (
+      git remote rm previous
+      git remote rename origin previous
+      git remote add origin "${PUPPET_REPO}"
+      git checkout --force "origin/${PUPPET_BRANCH}"
+    ) || return 1
 
     # Copy secrets
     mkdir -p "${WORKING_DIR}/data/secrets"

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -100,8 +100,11 @@ function notify_telegraf {
     TELEGRAF_TABLE=$1
     TELEGRAF_VALUE=$2
     META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
-    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "https://telegraf.relops.mozops.net/write?db=relops" '--data-binary' "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
-    curl --silent "${CURL_OPTIONS[@]}" 2>&1
+    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' \
+        "https://telegraf.relops.mozops.net/write?db=relops" \
+        '--data-binary' \
+        "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
+    out=$(curl --silent "${CURL_OPTIONS[@]}" 2>&1) || echo "${out}"
 }
 
 function update_puppet {

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-PUPPET_ENV="${PUPPET_ENV:-<%= @puppet_env -%>}"
+PUPPET_ENV="${PUPPET_ENV:-production}"
 PUPPET_REPO="${PUPPET_REPO:-<%= @puppet_repo -%>}"
 PUPPET_BRANCH="${PUPPET_BRANCH:-<%= @puppet_branch -%>}"
 PUPPET_MAIL="${PUPPET_MAIL:-<%= @puppet_notify_email %>}"
@@ -100,10 +100,7 @@ function notify_telegraf {
     TELEGRAF_TABLE=$1
     TELEGRAF_VALUE=$2
     META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
-    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' \
-        "https://telegraf.relops.mozops.net/write?db=relops" \
-        '--data-binary' \
-        "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
+    CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "https://telegraf.relops.mozops.net/write?db=relops" '--data-binary' "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
     out=$(curl --fail --silent --show-error "${CURL_OPTIONS[@]}" 2>&1) || echo "${out}"
 }
 
@@ -115,8 +112,6 @@ function update_puppet {
     fi
 
     # Fetch and checkout production branch
-    # Fetch and checkout branch
-    git fetch --all --prune || return 1
     git fetch --all --prune || return 1
     git checkout --force "origin/${PUPPET_BRANCH}" || return 1
 

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -101,6 +101,7 @@ function notify_telegraf {
     TELEGRAF_VALUE=$2
     META_DATA="<% @meta_data.each do |key,value| -%>,<%= key -%>=<%= value -%><% end -%>"
     CURL_OPTIONS=('--user' '<%= @telegraf_user -%>:<%= @telegraf_password -%>' '-i' '-XPOST' "https://telegraf.relops.mozops.net/write?db=relops" '--data-binary' "${TELEGRAF_TABLE}${META_DATA} value=${TELEGRAF_VALUE}")
+    # Print the metrics post output only if there is an error.
     out=$(curl --fail --silent --show-error "${CURL_OPTIONS[@]}" 2>&1) || echo "${out}"
 }
 

--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -114,17 +114,11 @@ function update_puppet {
         git remote add origin "${PUPPET_REPO}" || return 1
     fi
 
+    # Fetch and checkout production branch
     # Fetch and checkout branch
     git fetch --all --prune || return 1
-    # If it fails (maybe different repo:branch used before),
-    # re-add with the current repo and try again.
-    git checkout --force "origin/${PUPPET_BRANCH}" \
-      || (
-      git remote rm previous
-      git remote rename origin previous
-      git remote add origin "${PUPPET_REPO}"
-      git checkout --force "origin/${PUPPET_BRANCH}"
-    ) || return 1
+    git fetch --all --prune || return 1
+    git checkout --force "origin/${PUPPET_BRANCH}" || return 1
 
     # Copy secrets
     mkdir -p "${WORKING_DIR}/data/secrets"

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -22,7 +22,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                # Note the camelCase key names
                 meta_data         => $meta_data,
             }
 
@@ -52,19 +51,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                        ## If true, compute and report the sum of all non-idle CPU states.
                        report_active => false,
                    },
-                   system => {},
-                   mem => {},
                    swap => {},
                    diskio => {},
-                   disk => {
-                       mount_points => ['/'],
-                   },
                    procstat => {
                        interval => '60s',
                        exe => 'generic-worker',
-                   },
-                   puppetagent => {
-                       location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                    },
                 },
             }
@@ -79,7 +70,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             $quarantine_client_id     = lookup('generic_worker.datacenter_gecko_t_osx_1014.quarantine_client_id')
             $quarantine_access_token  = lookup('generic_worker.datacenter_gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.datacenter_gecko_t_osx_1014.bugzilla_api_key')
-
 
             class { 'packages::zstandard':
                 version => '1.3.8',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -22,6 +22,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
+                # Note the camelCase key names
                 meta_data         => $meta_data,
             }
 
@@ -41,6 +42,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                     precision => 's',
                 },
                 inputs => {
+                   # current default telegraf monitors: system, mem, swap, disk'/', puppetagent
                    temp => {},
                    cpu => {
                        interval => '60s',
@@ -51,7 +53,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
                        ## If true, compute and report the sum of all non-idle CPU states.
                        report_active => false,
                    },
-                   swap => {},
                    diskio => {},
                    procstat => {
                        interval => '60s',
@@ -70,6 +71,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             $quarantine_client_id     = lookup('generic_worker.datacenter_gecko_t_osx_1014.quarantine_client_id')
             $quarantine_access_token  = lookup('generic_worker.datacenter_gecko_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.datacenter_gecko_t_osx_1014.bugzilla_api_key')
+
 
             class { 'packages::zstandard':
                 version => '1.3.8',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -33,6 +33,33 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
 
             class { 'telegraf':
                 global_tags => $meta_data,
+                agent_params => {
+                    interval => '60s',
+                    collection_jitter => '0s',
+                    flush_interval => '120s',
+                    flush_jitter => '60s',
+                    precision => 's',
+                },
+                inputs => {
+                   swap => {
+                       interval => '300s',
+                   },
+                   system => {
+                       interval => '300s',
+                   },
+                   disk => {
+                       interval => '300s',
+                       path => '/',
+                   },
+                   procstat => {
+                       interval => '60s',
+                       exe => 'generic-worker',
+                   },
+                   puppetagent => {
+                       interval => '120s',
+                       location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
+                   },
+                },
             }
 
             class { 'talos':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -34,29 +34,36 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             class { 'telegraf':
                 global_tags => $meta_data,
                 agent_params => {
-                    interval => '60s',
+                    interval => '300s',
+                    round_interval => true,
                     collection_jitter => '0s',
                     flush_interval => '120s',
                     flush_jitter => '60s',
                     precision => 's',
                 },
                 inputs => {
-                   swap => {
-                       interval => '300s',
+                   temp => {},
+                   cpu => {
+                       interval => '60s',
+                       percpu => true,
+                       totalcpu => true,
+                       ## If true, collect raw CPU time metrics.
+                       collect_cpu_time => false,
+                       ## If true, compute and report the sum of all non-idle CPU states.
+                       report_active => false,
                    },
-                   system => {
-                       interval => '300s',
-                   },
+                   system => {},
+                   mem => {},
+                   swap => {},
+                   diskio => {},
                    disk => {
-                       interval => '300s',
-                       path => '/',
+                       mount_points => ['/'],
                    },
                    procstat => {
                        interval => '60s',
                        exe => 'generic-worker',
                    },
                    puppetagent => {
-                       interval => '120s',
                        location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                    },
                 },

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker.pp
@@ -32,32 +32,32 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker {
             }
 
             class { 'telegraf':
-                global_tags => $meta_data,
+                global_tags  => $meta_data,
                 agent_params => {
-                    interval => '300s',
-                    round_interval => true,
+                    interval          => '300s',
+                    round_interval    => true,
                     collection_jitter => '0s',
-                    flush_interval => '120s',
-                    flush_jitter => '60s',
-                    precision => 's',
+                    flush_interval    => '120s',
+                    flush_jitter      => '60s',
+                    precision         => 's',
                 },
-                inputs => {
-                   # current default telegraf monitors: system, mem, swap, disk'/', puppetagent
-                   temp => {},
-                   cpu => {
-                       interval => '60s',
-                       percpu => true,
-                       totalcpu => true,
-                       ## If true, collect raw CPU time metrics.
-                       collect_cpu_time => false,
-                       ## If true, compute and report the sum of all non-idle CPU states.
-                       report_active => false,
-                   },
-                   diskio => {},
-                   procstat => {
-                       interval => '60s',
-                       exe => 'generic-worker',
-                   },
+                inputs       => {
+                    # current default telegraf monitors: system, mem, swap, disk'/', puppetagent
+                    temp     => {},
+                    cpu      => {
+                        interval         => '60s',
+                        percpu           => true,
+                        totalcpu         => true,
+                        ## If true, collect raw CPU time metrics.
+                        collect_cpu_time => false,
+                        ## If true, compute and report the sum of all non-idle CPU states.
+                        report_active    => false,
+                    },
+                    diskio   => {},
+                    procstat => {
+                        interval => '60s',
+                        exe      => 'generic-worker',
+                    },
                 },
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -22,10 +22,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_env        => 'dev',
-                puppet_repo       => 'https://github.com/davehouse/ronin_puppet.git',
-                puppet_branch     => 'bug1571949_telegraf-monitor-sign',
-                puppet_notify_email => 'dhouse@mozilla.com',
                 meta_data         => $meta_data,
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -39,14 +39,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 agent_params => {
                     interval => '300s',
                     round_interval => true,
-                    metric_batch_size => 5000,
-                    metric_buffer_limit => 20000,
                     collection_jitter => '0s',
                     flush_interval => '120s',
                     flush_jitter => '60s',
                     precision => 's',
-                    quiet => true,
-                    omit_hostname => false,
                 },
                 inputs => {
                    temp => {},
@@ -59,19 +55,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                        ## If true, compute and report the sum of all non-idle CPU states.
                        report_active => false,
                    },
-                   system => {},
-                   mem => {},
                    swap => {},
                    diskio => {},
-                   disk => {
-                       mount_points => ['/'],
-                   },
                    procstat => {
                        interval => '60s',
                        exe => 'generic-worker',
-                   },
-                   puppetagent => {
-                       location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                    },
                 },
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -23,6 +23,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
                 puppet_branch     => 'staging',
+                # Note the camelCase key names
                 meta_data         => $meta_data,
             }
 
@@ -52,7 +53,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                        ## If true, compute and report the sum of all non-idle CPU states.
                        report_active => false,
                    },
-                   swap => {},
                    diskio => {},
                    procstat => {
                        interval => '60s',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -52,6 +52,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                     omit_hostname => 'false',
                 },
                 inputs => {
+                   temp => {},
                    cpu => {
                        interval => '60s',
                        percpu => true,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -54,19 +54,20 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 inputs => {
                    swap => {
                        interval => '300s',
-                   }
+                   },
                    system => {
                        interval => '300s',
-                   }
+                   },
                    disk => {
                        interval => '300s',
                        path => '/',
-                   }
+                   },
                    procstat => {
                        interval => '300s',
                        exe => '/builds/scriptworker/bin/scriptworker',
                    },
-                   procstat => {
+                   procstat2 => {
+                       plugin_type => 'procstat',
                        interval => '300s',
                        pattern => 'tools/release/signing/signing-server.py',
                    },

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -22,6 +22,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
+                puppet_branch     => 'staging',
                 meta_data         => $meta_data,
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -33,31 +33,31 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             }
 
             class { 'telegraf':
-                global_tags => $meta_data,
+                global_tags  => $meta_data,
                 agent_params => {
-                    interval => '300s',
-                    round_interval => true,
+                    interval          => '300s',
+                    round_interval    => true,
                     collection_jitter => '0s',
-                    flush_interval => '120s',
-                    flush_jitter => '60s',
-                    precision => 's',
+                    flush_interval    => '120s',
+                    flush_jitter      => '60s',
+                    precision         => 's',
                 },
-                inputs => {
-                   temp => {},
-                   cpu => {
-                       interval => '60s',
-                       percpu => true,
-                       totalcpu => true,
-                       ## If true, collect raw CPU time metrics.
-                       collect_cpu_time => false,
-                       ## If true, compute and report the sum of all non-idle CPU states.
-                       report_active => false,
-                   },
-                   diskio => {},
-                   procstat => {
-                       interval => '60s',
-                       exe => 'generic-worker',
-                   },
+                inputs       => {
+                    temp     => {},
+                    cpu      => {
+                        interval         => '60s',
+                        percpu           => true,
+                        totalcpu         => true,
+                        ## If true, collect raw CPU time metrics.
+                        collect_cpu_time => false,
+                        ## If true, compute and report the sum of all non-idle CPU states.
+                        report_active    => false,
+                    },
+                    diskio   => {},
+                    procstat => {
+                        interval => '60s',
+                        exe      => 'generic-worker',
+                    },
                 },
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -37,6 +37,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
 
             class { 'telegraf':
                 global_tags => $meta_data,
+                inputs => {
+                   procstat => {
+                       exe => '/builds/scriptworker/bin/scriptworker',
+                   },
+                },
             }
 
             class { 'talos':

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -39,17 +39,17 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 global_tags => $meta_data,
                 agent_params => {
                     interval => '300s',
-                    round_interval => 'true',
+                    round_interval => true,
                     metric_batch_size => 5000,
                     metric_buffer_limit => 20000,
                     collection_jitter => '0s',
                     flush_interval => '120s',
                     flush_jitter => '60s',
                     precision => 's',
-                    debug => 'true',
-                    quiet => 'false',
+                    debug => true,
+                    quiet => false,
                     logfile => '/tmp/telegraf.log',
-                    omit_hostname => 'false',
+                    omit_hostname => false,
                 },
                 inputs => {
                    temp => {},
@@ -67,12 +67,11 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                    swap => {},
                    diskio => {},
                    disk => {
-                       path => '/',
+                       mount_points => ['/'],
                    },
                    procstat => {
-                       exe => 'generic-worker',
-                   },
-                   procstat1 => {
+                       interval => '60s',
+                       # exe => 'generic-worker',
                        exe => '/builds/scriptworker/bin/scriptworker',
                    },
                    procstat2 => {

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -26,7 +26,6 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 puppet_repo       => 'https://github.com/davehouse/ronin_puppet.git',
                 puppet_branch     => 'bug1571949_telegraf-monitor-sign',
                 puppet_notify_email => 'dhouse@mozilla.com',
-                # Note the camelCase key names
                 meta_data         => $meta_data,
             }
 

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -46,9 +46,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                     flush_interval => '120s',
                     flush_jitter => '60s',
                     precision => 's',
-                    debug => true,
-                    quiet => false,
-                    logfile => '/tmp/telegraf.log',
+                    quiet => true,
                     omit_hostname => false,
                 },
                 inputs => {
@@ -71,12 +69,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                    },
                    procstat => {
                        interval => '60s',
-                       # exe => 'generic-worker',
-                       exe => '/builds/scriptworker/bin/scriptworker',
-                   },
-                   procstat2 => {
-                       plugin_type => 'procstat',
-                       pattern => 'tools/release/signing/signing-server.py',
+                       exe => 'generic-worker',
                    },
                    puppetagent => {
                        location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -22,7 +22,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_branch     => 'staging',
+                puppet_env        => 'dev',
+                puppet_repo       => 'https://github.com/davehouse/ronin_puppet.git',
+                puppet_branch     => 'bug1571949_telegraf-monitor-sign',
+                puppet_notify_email = 'dhouse@mozilla.com',
                 # Note the camelCase key names
                 meta_data         => $meta_data,
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -37,9 +37,42 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
 
             class { 'telegraf':
                 global_tags => $meta_data,
+                agent_params => {
+                    interval => '60s',
+                    round_interval => 'true',
+                    metric_batch_size => 5000,
+                    metric_buffer_limit => 20000,
+                    collection_jitter => '0s',
+                    flush_interval => '120s',
+                    flush_jitter => '60s',
+                    precision => 's',
+                    debug => 'true',
+                    quiet => 'false',
+                    logfile => '/tmp/telegraf.log',
+                    omit_hostname => 'false',
+                },
                 inputs => {
+                   swap => {
+                       interval => '300s',
+                   }
+                   system => {
+                       interval => '300s',
+                   }
+                   disk => {
+                       interval => '300s',
+                       path => '/',
+                   }
                    procstat => {
+                       interval => '300s',
                        exe => '/builds/scriptworker/bin/scriptworker',
+                   },
+                   procstat => {
+                       interval => '300s',
+                       pattern => 'tools/release/signing/signing-server.py',
+                   },
+                   puppetagent => {
+                       interval => '120s',
+                       location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                    },
                 },
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -61,10 +61,10 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                        ## If true, compute and report the sum of all non-idle CPU states.
                        report_active => false,
                    },
-                   system,
-                   mem,
-                   swap,
-                   diskio,
+                   system => {},
+                   mem => {},
+                   swap => {},
+                   diskio => {},
                    disk => {
                        path => '/',
                    },

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -25,7 +25,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                 puppet_env        => 'dev',
                 puppet_repo       => 'https://github.com/davehouse/ronin_puppet.git',
                 puppet_branch     => 'bug1571949_telegraf-monitor-sign',
-                puppet_notify_email = 'dhouse@mozilla.com',
+                puppet_notify_email => 'dhouse@mozilla.com',
                 # Note the camelCase key names
                 meta_data         => $meta_data,
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_osx_1014_generic_worker_staging.pp
@@ -38,7 +38,7 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
             class { 'telegraf':
                 global_tags => $meta_data,
                 agent_params => {
-                    interval => '60s',
+                    interval => '300s',
                     round_interval => 'true',
                     metric_batch_size => 5000,
                     metric_buffer_limit => 20000,
@@ -52,27 +52,33 @@ class roles_profiles::profiles::gecko_t_osx_1014_generic_worker_staging {
                     omit_hostname => 'false',
                 },
                 inputs => {
-                   swap => {
-                       interval => '300s',
+                   cpu => {
+                       interval => '60s',
+                       percpu => true,
+                       totalcpu => true,
+                       ## If true, collect raw CPU time metrics.
+                       collect_cpu_time => false,
+                       ## If true, compute and report the sum of all non-idle CPU states.
+                       report_active => false,
                    },
-                   system => {
-                       interval => '300s',
-                   },
+                   system,
+                   mem,
+                   swap,
+                   diskio,
                    disk => {
-                       interval => '300s',
                        path => '/',
                    },
                    procstat => {
-                       interval => '300s',
+                       exe => 'generic-worker',
+                   },
+                   procstat1 => {
                        exe => '/builds/scriptworker/bin/scriptworker',
                    },
                    procstat2 => {
                        plugin_type => 'procstat',
-                       interval => '300s',
                        pattern => 'tools/release/signing/signing-server.py',
                    },
                    puppetagent => {
-                       interval => '120s',
                        location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                    },
                 },

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -41,7 +41,7 @@ class telegraf (
         puppetagent => {
             location => $facts['os']['name'] ? {
                 'Darwin' => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
-                 default  => '/var/lib/puppet/state/last_run_summary.yaml',
+                default  => '/var/lib/puppet/state/last_run_summary.yaml',
             },
         },
     } + $inputs

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -4,8 +4,8 @@
 
 class telegraf (
     Hash $global_tags  = {},
-    Hash $agent_params = {},
-    Hash $inputs       = {},
+    Hash $agent_params = {},  # see merged defaults below
+    Hash $inputs       = {},  # see merged defaults below
 ) {
     include shared
 
@@ -15,6 +15,7 @@ class telegraf (
     $influxdb_username = lookup('telegraf.user')
     $influxdb_password = lookup('telegraf.password')
 
+    # Merge full hash of defaults for agent and input plugins.
     $_agent_params = {
         'interval' => '300s',
         'round_interval' => true,
@@ -31,20 +32,9 @@ class telegraf (
     } + $agent_params
 
     $_inputs = {
-       temp => {},
-       cpu => {
-           interval => '60s',
-           percpu => true,
-           totalcpu => true,
-           ## If true, collect raw CPU time metrics.
-           collect_cpu_time => false,
-           ## If true, compute and report the sum of all non-idle CPU states.
-           report_active => false,
-       },
        system => {},
        mem => {},
        swap => {},
-       diskio => {},
        disk => {
            mount_points => ['/'],
        },

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -18,6 +18,7 @@ class telegraf (
         'logfile' => '',
         'omit_hostname' => false,
     },
+    Hash $inputs  = {},
 ) {
 
     include shared

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -15,7 +15,7 @@ class telegraf (
     $influxdb_username = lookup('telegraf.user')
     $influxdb_password = lookup('telegraf.password')
 
-    $base_agent_params = {
+    $_agent_params = {
         'interval' => '300s',
         'round_interval' => true,
         'metric_batch_size' => 5000,
@@ -28,10 +28,9 @@ class telegraf (
         'quiet' => true,
         'logfile' => '',
         'omit_hostname' => false,
-    }
-    $agent_params = $base_agent_params + $agent_params
+    } + $agent_params
 
-    $base_inputs = {
+    $_inputs = {
        temp => {},
        cpu => {
            interval => '60s',
@@ -52,8 +51,7 @@ class telegraf (
        puppetagent => {
            location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
        },
-    }
-    $inputs = $base_inputs + $inputs
+    } + $inputs
 
     case $facts['os']['name'] {
         'Darwin': {

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -32,15 +32,18 @@ class telegraf (
     } + $agent_params
 
     $_inputs = {
-       system => {},
-       mem => {},
-       swap => {},
-       disk => {
-           mount_points => ['/'],
-       },
-       puppetagent => {
-           location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
-       },
+        system => {},
+        mem => {},
+        swap => {},
+        disk => {
+            mount_points => ['/'],
+        },
+        puppetagent => {
+            location => $facts['os']['name'] ? {
+                'Darwin' => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
+                 default  => '/var/lib/puppet/state/last_run_summary.yaml',
+            },
+        },
     } + $inputs
 
     case $facts['os']['name'] {

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -14,36 +14,12 @@
 [[outputs.influxdb]]
   urls = ["<%= @influxdb_url %>"]
   database = "relops"
-  #skip_database_creation = true
+  skip_database_creation = true
   username = "<%= @influxdb_username %>"
   password = "<%= @influxdb_password %>"
   retention_policy = ""
   write_consistency = "any"
   timeout = "120s"
-
-<% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
-[[inputs.exec]]
-  interval = "300s"
-  commands = [
-    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/bin/pmset -g therm | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
-  ]
-  timeout = "60s"
-  data_format = "influx"
-
-[[inputs.exec]]
-  interval = "300s"
-  commands = [
-    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/sbin/sysctl -ie machdep.xcpm.cpu_thermal_level machdep.xcpm.gpu_thermal_level machdep.xcpm.io_thermal_level | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
-  ]
-  timeout = "60s"
-  data_format = "influx"
-<% else -%>
-[[inputs.temp]]
-  interval = "300s"
-
-[[inputs.hddtemp]]
-  interval = "300s"
-<% end -%>
 
 <% if @inputs -%>
 # INPUTS:
@@ -51,7 +27,23 @@
 <%     if options['plugin_type'] -%>
 [[inputs.<%= options['plugin_type'] %>]]
 <%     else -%>
+<%       if input == 'temp' and scope.lookupvar('::operatingsystem') == 'Darwin' -%>
+# MacOS temp: (as sysctl and pmset thermal checks)
+[[inputs.exec]]
+  commands = [
+    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/bin/pmset -g therm | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
+  ]
+  timeout = "60s"  # 5s default is too short
+  data_format = "influx"
+[[inputs.exec]]
+  commands = [
+    "/bin/bash -c \"printf \\\"thermal %sboottime=$(/usr/sbin/sysctl -n kern.boottime | cut -d' ' -f4 | cut -d',' -f1)i\\\" $(/usr/sbin/sysctl -ie machdep.xcpm.cpu_thermal_level machdep.xcpm.gpu_thermal_level machdep.xcpm.io_thermal_level | awk $'/=/{printf $1$2$3\\\",\\\"}')\""
+  ]
+  timeout = "60s"  # 5s default is too short
+  data_format = "influx"
+<%       else -%>
 [[inputs.<%= input %>]]
+<%       end -%>
 <%     end -%>
 <%     unless options == nil -%>
 <%       options.sort.each do | option, value | -%>

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -71,3 +71,15 @@
 
 [[inputs.procstat]]
   exe = "generic-worker"
+
+<% if @inputs -%>
+# INPUTS:
+<%   @inputs.sort.each do | input, options | -%>
+[[inputs.<%= input %>]]
+<%     unless options == nil -%>
+<%       options.sort.each do | option, value | -%>
+  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+<%       end -%>
+<%     end -%>
+<%   end -%>
+<% end -%>

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -75,14 +75,16 @@
 <% if @inputs -%>
 # INPUTS:
 <%   @inputs.sort.each do | input, options | -%>
-<%     if options.plugin_type == nil -%>
-[[inputs.<%= input %>]]
+<%     if options['plugin_type'] -%>
+[[inputs.<%= options['plugin_type'] %>]]
 <%     else -%>
-[[inputs.<%= options.plugin_type %>]]
+[[inputs.<%= input %>]]
 <%     end -%>
 <%     unless options == nil -%>
 <%       options.sort.each do | option, value | -%>
+<%         unless option == 'plugin_type' -%>
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+<%         end -%>
 <%       end -%>
 <%     end -%>
 <%   end -%>

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -21,30 +21,6 @@
   write_consistency = "any"
   timeout = "120s"
 
-[[inputs.cpu]]
-  ## Whether to report per-cpu stats or not
-  percpu = true
-  ## Whether to report total system cpu stats or not
-  totalcpu = true
-  ## If true, collect raw CPU time metrics.
-  collect_cpu_time = false
-  ## If true, compute and report the sum of all non-idle CPU states.
-  report_active = false
-
-[[inputs.disk]]
-  interval = "300s"
-  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
-
-[[inputs.diskio]]
-  interval = "300s"
-
-[[inputs.mem]]
-
-[[inputs.swap]]
-  interval = "300s"
-
-[[inputs.system]]
-
 <% if scope.lookupvar('::operatingsystem') == 'Darwin' -%>
 [[inputs.exec]]
   interval = "300s"
@@ -68,9 +44,6 @@
 [[inputs.hddtemp]]
   interval = "300s"
 <% end -%>
-
-[[inputs.procstat]]
-  exe = "generic-worker"
 
 <% if @inputs -%>
 # INPUTS:

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -75,7 +75,11 @@
 <% if @inputs -%>
 # INPUTS:
 <%   @inputs.sort.each do | input, options | -%>
+<%     if options.plugin_type == nil -%>
 [[inputs.<%= input %>]]
+<%     else -%>
+[[inputs.<%= options.plugin_type %>]]
+<%     end -%>
 <%     unless options == nil -%>
 <%       options.sort.each do | option, value | -%>
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -7,7 +7,7 @@
 <% end -%>
 
 [agent]
-<% @agent_params.sort.each do |key, value| -%>
+<% @_agent_params.sort.each do |key, value| -%>
   <%= key -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%   end -%>
 
@@ -21,9 +21,9 @@
   write_consistency = "any"
   timeout = "120s"
 
-<% if @inputs -%>
+<% if @_inputs -%>
 # INPUTS:
-<%   @inputs.sort.each do | input, options | -%>
+<%   @_inputs.sort.each do | input, options | -%>
 <%     if options['plugin_type'] -%>
 [[inputs.<%= options['plugin_type'] %>]]
 <%     else -%>

--- a/modules/telegraf/templates/telegraf.conf.erb
+++ b/modules/telegraf/templates/telegraf.conf.erb
@@ -14,7 +14,7 @@
 [[outputs.influxdb]]
   urls = ["<%= @influxdb_url %>"]
   database = "relops"
-  skip_database_creation = true
+  #skip_database_creation = true
   username = "<%= @influxdb_username %>"
   password = "<%= @influxdb_password %>"
   retention_policy = ""


### PR DESCRIPTION
Prepare telegraf monitoring for use on non-test workers (signing).

1. make agent parameters configurable (with defaults)
2. make input plugins configurable (with defaults)

* also silence the telegraf post during the atboot puppet run unless there is a failure (has been logging a "204" at each post).