### PR TITLE
on macos, use apple time.

### DIFF
--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -6,7 +6,7 @@ class roles_profiles::profiles::ntp {
 
     case $::operatingsystem {
         'Darwin': {
-            $ntp_server = lookup('ntp_server', String)
+            $ntp_server = 'time.apple.com'
             class { 'macos_ntp':
                 enabled    => true,
                 ntp_server => $ntp_server,

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -6,10 +6,9 @@ class roles_profiles::profiles::ntp {
 
     case $::operatingsystem {
         'Darwin': {
-            $ntp_server = 'time.apple.com'
             class { 'macos_ntp':
                 enabled    => true,
-                ntp_server => $ntp_server,
+                # ntp_server => $ntp_server,  # use time.apple.com
             }
         }
         'Windows': {


### PR DESCRIPTION
re: https://bugzilla.mozilla.org/show_bug.cgi?id=1571949#c13 let's use apple time on the macs (by default, macos is configured to use time.apple.com and our ntp puppet module overrides it).

* windows workers are using ntp.org
* we're fixing the linux workers to also use ntp.org