### PR TITLE
Lookup ntp_server in hiera

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,6 @@
 ---
 
-ntp_server: "0.pool.ntp.org"
+ntp_server: "ntp.build.mozilla.org"
 
 smtp_relay_host: "smtp1.mail.mdc1.mozilla.com"
 

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -8,7 +8,7 @@ class roles_profiles::profiles::ntp {
         'Darwin': {
             class { 'macos_ntp':
                 enabled    => true,
-                # ntp_server => $ntp_server,  # use time.apple.com
+                ntp_server => lookup('ntp_server'),
             }
         }
         'Windows': {


### PR DESCRIPTION
All internal releng hosts should use `ntp.build.mozilla.org` as a time source

https://bugzilla.mozilla.org/show_bug.cgi?id=1607289