### PR TITLE
chrome v80 on macos

### DIFF
--- a/modules/packages/manifests/google_chrome.pp
+++ b/modules/packages/manifests/google_chrome.pp
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class packages::google_chrome (
-    String $version = 'v79.0.3945.117',
+    String $version = 'v80.0.3987.106',
 ) {
 
     packages::macos_package_from_s3 { "googlechrome_${version}.dmg":


### PR DESCRIPTION
*do not merge* (waiting on chromedriver updates)

running on -beta workers for qa testing

```
[dhouse@t-mojave-r7-446.test.releng.mdc1.mozilla.com ~]$ /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version
Google Chrome 79.0.3945.117
[...]
[root@t-mojave-r7-446.test.releng.mdc1.mozilla.com ~]# PUPPET_MAIL=dhouse@mozilla.com PUPPET_ENV=dev PUPPET_BRANCH=bug1615585_chrome-v80 PUPPET_REPO=https://github.com/davehouse/ronin_puppet.git run-puppet.sh
Network connectivity check passed 10.49.56.70
Initialized empty Git repository in /private/etc/puppet/environments/dev/code/.git/
[...]
Notice: /Stage[main]/Packages::Google_chrome/Packages::Macos_package_from_s3[googlechrome_v80.0.3987.106.dmg]/Package[googlechrome_v80.0.3987.106.dmg]/ensure: created
[...]
[dhouse@t-mojave-r7-446.test.releng.mdc1.mozilla.com ~]$ /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version
Google Chrome 80.0.3987.106
```