### PR TITLE
bug 1620697 - notarization single_zip

### DIFF
--- a/modules/signing_worker/templates/script_config.yaml.erb
+++ b/modules/signing_worker/templates/script_config.yaml.erb
@@ -16,7 +16,7 @@ dmg_prefix: "<%= @dmg_prefix %>"
 mac_config:
 <% @role_config.each do |role, role_data| -%>
     <%= role %>:
-        notarize_type: multi_account
+        notarize_type: single_zip
         signing_keychain: "<%= @certs_dir %>/<%= role %>-signing.keychain"
         supported_behaviors:
 <% @supported_behaviors.each do |behavior| -%>


### PR DESCRIPTION
This is to match the manual changes we made for [bug 1620697](https://bugzilla.mozilla.org/show_bug.cgi?id=1620697).

Once we decide this is how we want to proceed for the foreseeable future, we can also remove the `notary_users` / `local_notarization_accounts`. I'd like to see this working for a while before we take that step.