### PR TITLE
Bug1639352 signing bootstrap

### DIFF
--- a/modules/python/manifests/virtualenv.pp
+++ b/modules/python/manifests/virtualenv.pp
@@ -54,6 +54,8 @@ define python::virtualenv (
 ) {
 
   if $ensure == 'present' {
+    require packages::virtualenv
+
     $python = $version ? {
       'system' => 'python',
       'pypy'   => 'pypy',

--- a/modules/scriptworker_prereqs/manifests/init.pp
+++ b/modules/scriptworker_prereqs/manifests/init.pp
@@ -2,12 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 class scriptworker_prereqs {
-    contain packages::python3_s3
+    contain packages::python3
     file { '/tools/python3':
-        ensure  => 'link',
-        target  => '/usr/local/bin/python3',
-        require => Class['packages::python3_s3'],
+            ensure  => 'link',
+            target  => '/usr/local/bin/python3',
+            require => Class['packages::python3'],
     }
+
     include dirs::builds
 
     # DeveloperIDCA.cer is only required on dep, but is harmless on prod
@@ -25,14 +26,6 @@ class scriptworker_prereqs {
             # For posterity, the error returned is "SecTrustSettingsSetTrustSettings: The authorization was
             # denied since no user interaction was possible.".
             returns => [1];
-    }
-
-    # Install certifi's set of CAs to override the system set
-    exec {
-        'install_python_certs':
-            command => "'/Applications/Python 3.7/Install Certificates.command'",
-            path    => ['/usr/bin', '/usr/sbin', '/bin'],
-            unless  =>  'test -h /Library/Frameworks/Python.framework/Versions/3.7/etc/openssl/cert.pm'
     }
 
     # Accept the xcode licence

--- a/modules/scriptworker_prereqs/manifests/init.pp
+++ b/modules/scriptworker_prereqs/manifests/init.pp
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 class scriptworker_prereqs {
-    contain packages::python3
+    class { 'packages::python3':
+        version => '3.8.3',
+    }
     file { '/tools/python3':
-            ensure  => 'link',
-            target  => '/usr/local/bin/python3',
-            require => Class['packages::python3'],
+        ensure  => 'link',
+        target  => '/usr/local/bin/python3',
+        require => Class['packages::python3'],
     }
 
     include dirs::builds

--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -104,7 +104,6 @@ define signing_worker (
         group           => $group,
         timeout         => 0,
         path            => [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/Library/Frameworks/Python.framework/Versions/3.8/bin'],
-        require         => 'packages::virtualenv',
     }
 
     # scriptworker config

--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -94,7 +94,6 @@ define signing_worker (
         force   => true,
     }
 
-    contain packages::virtualenv_python3_s3
     python::virtualenv { "signingworker_${user}" :
         ensure          => present,
         version         => '3',

--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -94,7 +94,8 @@ define signing_worker (
         force   => true,
     }
 
-    python::virtualenv { "signingworker_${user}" :
+    require packages::virtualenv
+    ->python::virtualenv { "signingworker_${user}" :
         ensure          => present,
         version         => '3',
         requirements    => $tmp_requirements,
@@ -103,7 +104,7 @@ define signing_worker (
         owner           => $user,
         group           => $group,
         timeout         => 0,
-        path            => [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/Library/Frameworks/Python.framework/Versions/3.7/bin'],
+        path            => [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/Library/Frameworks/Python.framework/Versions/3.8/bin'],
     }
 
     # scriptworker config

--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -94,8 +94,7 @@ define signing_worker (
         force   => true,
     }
 
-    require packages::virtualenv
-    ->python::virtualenv { "signingworker_${user}" :
+    python::virtualenv { "signingworker_${user}" :
         ensure          => present,
         version         => '3',
         requirements    => $tmp_requirements,
@@ -105,6 +104,7 @@ define signing_worker (
         group           => $group,
         timeout         => 0,
         path            => [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/Library/Frameworks/Python.framework/Versions/3.8/bin'],
+        require         => 'packages::virtualenv',
     }
 
     # scriptworker config


### PR DESCRIPTION
@escapewindow this moves signing over to py3.8.3 (and fixes the virtualenv dependency for a new reimaged machine to run puppet)