### PR TITLE
Bug1405083 supress firewall warnings during tests

### DIFF
--- a/modules/roles_profiles/manifests/profiles/network.pp
+++ b/modules/roles_profiles/manifests/profiles/network.pp
@@ -11,16 +11,10 @@ class roles_profiles::profiles::network {
         }
         'Windows': {
 
-            if $facts['custom_win_location'] == 'datacenter' {
-                include win_network::set_search_domain
-                include win_network::disable_ipv6
-            }
-            if $facts['custom_win_location'] != 'datacenter' {
-                $net_category = 'private'
-                if $facts['custom_win_net_category'] != $net_category {
-                    win_network::set_network_category { 'aws_network_category':
-                        network_category => $net_category,
-                    }
+            $net_category = 'private'
+            if $facts['custom_win_net_category'] != $net_category {
+                win_network::set_network_category { 'private_network':
+                    network_category => $net_category,
                 }
             }
             # Bug list

--- a/modules/roles_profiles/manifests/roles/geckotwin10641803hw.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin10641803hw.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin10641803hw {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064dev.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064dev.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064dev {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064hb.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064hb.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064hb {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064ht.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064ht.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064ht {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064hw.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064hw.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064hw {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064hwtestpool.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064hwtestpool.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064hwtestpool {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064refht.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064refht.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064refht {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/roles_profiles/manifests/roles/geckotwin1064refhw.pp
+++ b/modules/roles_profiles/manifests/roles/geckotwin1064refhw.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::geckotwin1064refhw {
     include roles_profiles::profiles::disable_services
     include roles_profiles::profiles::files_system_managment
     include roles_profiles::profiles::firewall
+    include roles_profiles::profiles::network
     include roles_profiles::profiles::ntp
     include roles_profiles::profiles::power_management
     include roles_profiles::profiles::scheduled_tasks

--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -32,7 +32,6 @@ echo "%tot_time% Minutes (%total_time% seconds) have passed since last generic-w
 echo File <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid found >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 echo Deleting <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid file >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 del /Q /F <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log 2>&1
-netsh.exe firewall set notifications mode = disable profile = all
 pushd %~dp0
 set errorlevel=
 <%= $win_generic_worker::run_generic_worker_command %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker.log 2>&1

--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -32,6 +32,7 @@ echo "%tot_time% Minutes (%total_time% seconds) have passed since last generic-w
 echo File <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid found >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 echo Deleting <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid file >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 del /Q /F <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log 2>&1
+netsh.exe firewall set notifications mode = disable profile = all
 pushd %~dp0
 set errorlevel=
 <%= $win_generic_worker::run_generic_worker_command %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker.log 2>&1

--- a/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
+++ b/modules/win_generic_worker/templates/run-hw-generic-worker-and-reboot.bat.epp
@@ -32,6 +32,12 @@ echo "%tot_time% Minutes (%total_time% seconds) have passed since last generic-w
 echo File <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid found >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 echo Deleting <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid file >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log
 del /Q /F <%= $facts[custom_win_roninsemaphoredir] %>\task-claim-state.valid >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker-wrapper.log 2>&1
+
+rem Supressing firewall warnings. Current user needs to be fully logged in.
+rem not an ideal place for this, but it works as needed
+rem https://bugzilla.mozilla.org/show_bug.cgi?id=1405083
+netsh firewall set notifications mode = disable profile = all
+
 pushd %~dp0
 set errorlevel=
 <%= $win_generic_worker::run_generic_worker_command %> >> <%= $win_generic_worker::generic_worker_dir %>\generic-worker.log 2>&1

--- a/modules/win_os_settings/manifests/disbale_notifications.pp
+++ b/modules/win_os_settings/manifests/disbale_notifications.pp
@@ -5,13 +5,22 @@
 class win_os_settings::disbale_notifications {
 
   # Using puppetlabs-registry
-  registry::value { 'NoNewAppAlert' :
-    key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer',
-    type => dword,
-    data => '1',
-  }
-    registry_key { 'HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff' :
+    registry::value { 'NoNewAppAlert':
+        key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer',
+        type => dword,
+        data => '1',
+    }
+    registry_key { 'HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff':
         ensure => present
+    }
+    #registry::value { 'DisableNotifications':
+        #key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications',
+        #type => dword,
+        #data => '1',
+    #}
+    exec { 'disable_fw_notifications':
+        command     =>
+            "${facts[custom_win_system32]}\\netsh.exe firewall set notifications mode = disable profile = all",
     }
 }
 

--- a/modules/win_os_settings/manifests/disbale_notifications.pp
+++ b/modules/win_os_settings/manifests/disbale_notifications.pp
@@ -13,11 +13,6 @@ class win_os_settings::disbale_notifications {
     registry_key { 'HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff':
         ensure => present
     }
-    registry::value { 'DisableNotifications':
-        key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications',
-        type => dword,
-        data => '1',
-    }
 }
 
 # Bug list

--- a/modules/win_os_settings/manifests/disbale_notifications.pp
+++ b/modules/win_os_settings/manifests/disbale_notifications.pp
@@ -13,14 +13,10 @@ class win_os_settings::disbale_notifications {
     registry_key { 'HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff':
         ensure => present
     }
-    #registry::value { 'DisableNotifications':
-        #key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications',
-        #type => dword,
-        #data => '1',
-    #}
-    exec { 'disable_fw_notifications':
-        command     =>
-            "${facts[custom_win_system32]}\\netsh.exe firewall set notifications mode = disable profile = all",
+    registry::value { 'DisableNotifications':
+        key  => 'HKLM\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications',
+        type => dword,
+        data => '1',
     }
 }
 

--- a/provisioners/windows/mdt/geckotwin1064ht-bootstrap.ps1
+++ b/provisioners/windows/mdt/geckotwin1064ht-bootstrap.ps1
@@ -102,9 +102,9 @@ function Install-BootstrapModule {
 }
 
 $workerType = 'gecko-t-win10-64-ht'
-$src_Organisation = 'mozilla-platform-ops'
+$src_Organisation = 'markcor'
 $src_Repository = 'ronin_puppet'
-$src_Revision = 'master'
+$src_Revision = 'bug1405083'
 $image_provisioner = 'mdt'
 $max_boots = 10
 

--- a/provisioners/windows/mdt/geckotwin1064ht-bootstrap.ps1
+++ b/provisioners/windows/mdt/geckotwin1064ht-bootstrap.ps1
@@ -102,9 +102,9 @@ function Install-BootstrapModule {
 }
 
 $workerType = 'gecko-t-win10-64-ht'
-$src_Organisation = 'markcor'
+$src_Organisation = 'mozilla-platform-ops'
 $src_Repository = 'ronin_puppet'
-$src_Revision = 'bug1405083'
+$src_Revision = 'master'
 $image_provisioner = 'mdt'
 $max_boots = 10
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1405083

Set network to private which then allows for the firewall warnings to be silent. The notification itself was breaking tests and has been for years. The location of the netsh command is not ideal,  but it needs the user environment to be fully loaded in order for the preference to take affect. This corresponds  to a registry value in the HCCU hive, so in the future can be addressed by setting defaults in which determines what is in that hive. Currently we do not have a way of doing this. 