### PR TITLE
bug1671594 cot key perms

### DIFF
--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -70,7 +70,7 @@ class generic_worker (
             mode      => '0600',
             owner     => $user,
             show_diff => false,
-            target    => "${ed25519_signing_key}";
+            path      => "${ed25519_signing_key}";
     }
 
     case $::operatingsystem {

--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -65,12 +65,12 @@ class generic_worker (
             require => Class['packages::generic_worker'];
     }
     file {
-        "ed25519_signing_key_permissions":
+        'ed25519_signing_key_permissions':
             ensure    => present,
             mode      => '0600',
             owner     => $user,
             show_diff => false,
-            path      => "${ed25519_signing_key}";
+            path      => $ed25519_signing_key;
     }
 
     case $::operatingsystem {

--- a/modules/generic_worker/manifests/init.pp
+++ b/modules/generic_worker/manifests/init.pp
@@ -64,6 +64,14 @@ class generic_worker (
             unless  => "test -f ${ed25519_signing_key}",
             require => Class['packages::generic_worker'];
     }
+    file {
+        "ed25519_signing_key_permissions":
+            ensure    => present,
+            mode      => '0600',
+            owner     => $user,
+            show_diff => false,
+            target    => "${ed25519_signing_key}";
+    }
 
     case $::operatingsystem {
         'Darwin': {


### PR DESCRIPTION
The file permissions on the CoT key must be 0600 and although it is that on many(358) of the mac mini workers, it is 0655 on 35.