### PR TITLE
use UTC on macos also

### DIFF
--- a/modules/roles_profiles/manifests/profiles/timezone.pp
+++ b/modules/roles_profiles/manifests/profiles/timezone.pp
@@ -7,7 +7,7 @@ class roles_profiles::profiles::timezone {
     case $::operatingsystem {
         'Darwin': {
             class { 'macos_timezone':
-                timezone => 'GMT',
+                timezone => 'UTC',
             }
         }
         'Ubuntu': {


### PR DESCRIPTION
GMT is the same but since UTC is available, let's use it to avoid confusion?

I confirmed the UTC timezone is available on Mojave, Catalina, and BigSur.
```
[dhouse@t-mojave-r7-471.tier3.releng.mdc1.mozilla.com ~]$ ls -la /etc/localtime
lrwxr-xr-x  1 root  wheel  29 Apr 10  2020 /etc/localtime -> /var/db/timezone/zoneinfo/GMT
<leng.mdc1.mozilla.com ~]$ cat /var/db/timezone/zoneinfo/UTC                              
TZif2UTCTZif2UTC
UTC0
<leng.mdc1.mozilla.com ~]$ cat /var/db/timezone/zoneinfo/GMT                              
TZif2GMTTZif2GMT
GMT0
```
