### PR TITLE
Revert "use UTC on macos also"

### DIFF
--- a/modules/roles_profiles/manifests/profiles/timezone.pp
+++ b/modules/roles_profiles/manifests/profiles/timezone.pp
@@ -7,7 +7,7 @@ class roles_profiles::profiles::timezone {
     case $::operatingsystem {
         'Darwin': {
             class { 'macos_timezone':
-                timezone => 'UTC',
+                timezone => 'GMT',
             }
         }
         'Ubuntu': {


### PR DESCRIPTION
This reverts commit 921901135194b44a12b17471bd75a987a9b88669.

So, the module uses systemsetup which limits us to the same timezones as the gui. We could set it directly to UTC, but not with systemsetup.
So, I'll accept using GMT and not fight it.