### PR TITLE
Update bolt config to comply with bolt v2.37.0

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -1,0 +1,6 @@
+---
+name: ronin_puppet
+modulepath:
+- "./modules"
+- "./r10k_modules"
+concurrency: 8

--- a/bolt.yaml
+++ b/bolt.yaml
@@ -1,4 +1,0 @@
-modulepath: ['./modules', './r10k_modules']
-concurrency: 8
-ssh:
-  host-key-check: false


### PR DESCRIPTION
This makes the config compliant with bolt 2.37.  The `host-key-check` is moved to the users config under `~/.puppetlabs/etc/bolt/bolt-defaults.yaml` since it shouldn't be assumed to be project wide.