### PR TITLE
Simple bolt deploy plan to exec puppet on a remote target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
   rev: v2.1.0
   hooks:
   - id: puppet-validate
+    exclude: '^modules/\w+/plans'
   - id: erb-validate
   - id: epp-validate
   - id: puppet-lint

--- a/modules/deploy/plans/apply.pp
+++ b/modules/deploy/plans/apply.pp
@@ -1,0 +1,12 @@
+plan deploy::apply (
+  TargetSpec $targets,
+  String     $role,
+  Boolean    $noop = false,
+) {
+
+    $targets.apply_prep
+
+    apply($targets, _catch_errors => false, _noop => $noop, _run_as => root) {
+        include "roles_profiles::roles::${role}"
+    }
+}


### PR DESCRIPTION
Adds a simple bolt plan to deploy puppet to a remote target.  Also, requires pre-commit puppet validate to ignore the `.pp` files in modules plans dir since it can't differentiate between puppet and bolt plan files.