### PR TITLE
Introduce the use of role data in hiera

### DIFF
--- a/data/roles/gecko_t_osx_1014_r8.yaml
+++ b/data/roles/gecko_t_osx_1014_r8.yaml
@@ -1,0 +1,78 @@
+---
+gw:
+  worker_id: "%{facts.networking.hostname}"
+  worker_group: "%{facts.location}"
+  worker_type: gecko-t-osx-1014-r8
+  provisioner_id: releng-hardware
+  generic_worker_mode: single
+  generic_worker_version: v13.0.3
+  generic_worker_sha256: 6e5c1543fb3c333ca783d0a5c4e557b2b5438aada4bc23dc02402682ae4e245e
+  taskcluster_proxy_version: v5.1.0
+  taskcluster_proxy_sha256: 3faf524b9c6b9611339510797bf1013d4274e9f03e7c4bd47e9ab5ec8813d3ae
+  quarantine_worker_version: v1.0.0
+  quarantine_worker_sha256: 60bb15fa912589fd8d94dbbff2e27c2718eadaf2533fc4bbefb887f469e22627
+  user: cltbld
+  user_homedir: '/Users/cltbld'
+
+# Common worker metadata conveniently aliased to generic worker data from above
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+packages_classes:
+  - nodejs
+  - python2
+  - python3
+  - wget
+  - google_chrome
+  - mercurial
+  - virtualenv
+  - python2_zstandard
+  - python3_zstandard
+  - zstandard
+  - java_developer_package_for_osx
+  - xcode_cmd_line_tools
+  - tooltool
+
+# Package class parameters
+packages::nodejs::version: 12.11.1
+packages::python2::version: 2.7.16
+packages::python3::version: 3.7.4
+packages::wget::version: 1.20.3_1
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: '5.1'
+packages::virtualenv::version: 16.4.3
+packages::zstandard::version: 1.3.8
+packages::python2_zstandard::version: 0.11.1
+packages::python3_zstandard::version: 0.11.1
+
+# Talos class parameters
+talos::user: cltbld
+
+# Determines how puppet should be executed
+# ( atboot, cron, never )
+puppet_run_strategy: never
+
+# Firewall role to include
+#firewall_role: osx_taskcluster_worker
+
+# Override secrets with vault secrets
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+    livelog_secret: "%{lookup('vault_secrets::generic_worker.data.livelog_secret')}"
+    quarantine_client_id: "%{lookup('vault_secrets::generic_worker.data.quarantine_client_id')}"
+    quarantine_access_token: "%{lookup('vault_secrets::generic_worker.data.quarantine_access_token')}"
+    bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"

--- a/data/roles/gecko_t_osx_1014_r8_qa.yaml
+++ b/data/roles/gecko_t_osx_1014_r8_qa.yaml
@@ -1,0 +1,78 @@
+---
+gw:
+  worker_id: "%{facts.networking.hostname}"
+  worker_group: "%{facts.location}"
+  worker_type: gecko-t-osx-1014-r8-qa
+  provisioner_id: releng-hardware
+  generic_worker_mode: single
+  generic_worker_version: v13.0.3
+  generic_worker_sha256: 6e5c1543fb3c333ca783d0a5c4e557b2b5438aada4bc23dc02402682ae4e245e
+  taskcluster_proxy_version: v5.1.0
+  taskcluster_proxy_sha256: 3faf524b9c6b9611339510797bf1013d4274e9f03e7c4bd47e9ab5ec8813d3ae
+  quarantine_worker_version: v1.0.0
+  quarantine_worker_sha256: 60bb15fa912589fd8d94dbbff2e27c2718eadaf2533fc4bbefb887f469e22627
+  user: cltbld
+  user_homedir: '/Users/cltbld'
+
+# Common worker metadata conveniently aliased to generic worker data from above
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+packages_classes:
+  - nodejs
+  - python2
+  - python3
+  - wget
+  - google_chrome
+  - mercurial
+  - virtualenv
+  - python2_zstandard
+  - python3_zstandard
+  - zstandard
+  - java_developer_package_for_osx
+  - xcode_cmd_line_tools
+  - tooltool
+
+# Package class parameters
+packages::nodejs::version: 12.11.1
+packages::python2::version: 2.7.16
+packages::python3::version: 3.7.4
+packages::wget::version: 1.20.3_1
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: '5.1'
+packages::virtualenv::version: 16.4.3
+packages::zstandard::version: 1.3.8
+packages::python2_zstandard::version: 0.11.1
+packages::python3_zstandard::version: 0.11.1
+
+# Talos class parameters
+talos::user: cltbld
+
+# Determines how puppet should be executed
+# ( atboot, cron, never )
+puppet_run_strategy: never
+
+# Firewall role to include
+#firewall_role: osx_taskcluster_worker
+
+# Override secrets with vault secrets
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+    livelog_secret: "%{lookup('vault_secrets::generic_worker.data.livelog_secret')}"
+    quarantine_client_id: "%{lookup('vault_secrets::generic_worker.data.quarantine_client_id')}"
+    quarantine_access_token: "%{lookup('vault_secrets::generic_worker.data.quarantine_access_token')}"
+    bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"

--- a/data/roles/gecko_t_osx_1015_r8_qa.yaml
+++ b/data/roles/gecko_t_osx_1015_r8_qa.yaml
@@ -1,0 +1,78 @@
+---
+gw:
+  worker_id: "%{facts.networking.hostname}"
+  worker_group: "%{facts.location}"
+  worker_type: gecko-t-osx-1015-r8-qa
+  provisioner_id: releng-hardware
+  generic_worker_mode: single
+  generic_worker_version: v13.0.3
+  generic_worker_sha256: 6e5c1543fb3c333ca783d0a5c4e557b2b5438aada4bc23dc02402682ae4e245e
+  taskcluster_proxy_version: v5.1.0
+  taskcluster_proxy_sha256: 3faf524b9c6b9611339510797bf1013d4274e9f03e7c4bd47e9ab5ec8813d3ae
+  quarantine_worker_version: v1.0.0
+  quarantine_worker_sha256: 60bb15fa912589fd8d94dbbff2e27c2718eadaf2533fc4bbefb887f469e22627
+  user: cltbld
+  user_homedir: '/Users/cltbld'
+
+# Common worker metadata conveniently aliased to generic worker data from above
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+packages_classes:
+  - nodejs
+  - python2
+  - python3
+  - wget
+  - google_chrome
+  - mercurial
+  - virtualenv
+  - python2_zstandard
+  - python3_zstandard
+  - zstandard
+  - java_developer_package_for_osx
+  - xcode_cmd_line_tools
+  - tooltool
+
+# Package class parameters
+packages::nodejs::version: 12.11.1
+packages::python2::version: 2.7.16
+packages::python3::version: 3.7.4
+packages::wget::version: 1.20.3_1
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: '5.1'
+packages::virtualenv::version: 16.4.3
+packages::python2_zstandard::version: 0.11.1
+packages::python3_zstandard::version: 0.11.1
+packages::zstandard::version: 1.3.8
+
+# Talos class parameters
+talos::user: cltbld
+
+# Determines how puppet should be executed
+# ( atboot, cron, never )
+puppet_run_strategy: never
+
+# Firewall role to include
+#firewall_role: osx_taskcluster_worker
+
+# Override secrets with vault secrets
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+    livelog_secret: "%{lookup('vault_secrets::generic_worker.data.livelog_secret')}"
+    quarantine_client_id: "%{lookup('vault_secrets::generic_worker.data.quarantine_client_id')}"
+    quarantine_access_token: "%{lookup('vault_secrets::generic_worker.data.quarantine_access_token')}"
+    bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,6 +5,16 @@ defaults:
   datadir: data
 
 hierarchy:
+    # It is acceptable for dot notation facts (eg. %{facts.some_fact}) to not exist
+    # since they will simply return an empty string
+  - name: "Per-role data"
+    path: "roles/%{facts.puppet_role}_role.yaml"
+
+    # This should be deleted once the windows is converged to use per-role data instead
+    # and win_hiera.yaml can also be deleted
+  - name: "Per Windows workerType data"
+    path: "os/Windows/worker/%{facts.custom_win_gw_workertype}.yaml"
+
   - name: "Per-OS defaults"
     path: "os/%{facts.os.family}.yaml"
 

--- a/modules/roles_profiles/manifests/profiles/packages_installed.pp
+++ b/modules/roles_profiles/manifests/profiles/packages_installed.pp
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::packages_installed {
+
+    case $::operatingsystem {
+        'Darwin': {
+            $package_list = lookup('packages_classes', Array[String], 'unique', [])
+            map ($package_list) | $package | { "packages::${package}" }.include
+        }
+        default: {
+            fail("${::operatingsystem} not supported")
+        }
+    }
+
+
+}


### PR DESCRIPTION
This PR introduces the use of role data which will significantly simplify workers how are given custom data and should allow for future (soon) clean up of the multiple role/profile matches.  And all the duplicate code that comes with it.  This also gives a nice single file view of a roles data profile and will also allow for easier version bumping on various thing on a per-role basis.