### PR TITLE
First round of package classes versioning

### DIFF
--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::python2_zstandard {
+class packages::python2_zstandard (
+    String $version = '0.11.1',
+) {
     require packages::python2
 
     package { 'python2-zstandard':
-        ensure   => '0.11.1',
+        ensure   => $version,
         name     => 'zstandard',
         provider => pip,
         require  => Class['packages::python2'],

--- a/modules/packages/manifests/python3_zstandard.pp
+++ b/modules/packages/manifests/python3_zstandard.pp
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::python3_zstandard {
+class packages::python3_zstandard (
+    String $version = '0.11.1',
+) {
     require packages::python3
 
     package { 'python3-zstandard':
-        ensure   => '0.11.1',
+        ensure   => $version,
         name     => 'zstandard',
         provider => pip3,
         require  => Class['packages::python3'],

--- a/modules/packages/manifests/virtualenv.pp
+++ b/modules/packages/manifests/virtualenv.pp
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::virtualenv {
+class packages::virtualenv (
+    String $version = '16.4.3',
+) {
     require packages::python3
 
     package { 'virtualenv':
-        ensure   => '16.4.3',
+        ensure   => $version,
         provider => pip3,
         require  => Class['packages::python3'],
     }


### PR DESCRIPTION
There should be a `version` parameter on any package class where there might be a version to specify.  This PR is the first effort to make that happen.  It won't cover everything but slowly chip away at this PR by PR.