### PR TITLE
Add a logrotation resource for macos

### DIFF
--- a/modules/macos_utils/manifests/logrotate.pp
+++ b/modules/macos_utils/manifests/logrotate.pp
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+define macos_utils::logrotate (
+    String $path,
+    String $mode                      = '600', # File mode of log file
+    String $count                     = '2',   # How many files to retain
+    String $size                      = '*',   # How big until rotation (Size in KB)
+    String $when                      = '$D0', # When to rotate (eg. every 24h)
+    String $flags                     = 'J',   # Flags (eg. J == bzip compression)
+    String $pid_file                  = '',
+    Enum['present', 'absent'] $ensure = 'present',
+) {
+
+    case $::operatingsystem {
+        'Darwin': {
+            file { "/etc/newsyslog.d/${title}.conf":
+                ensure  => $ensure,
+                content => template('macos_utils/newsyslog.conf.erb');
+            }
+        }
+        default: {
+            fail("${module_name} not supported under ${::operatingsystem}")
+        }
+    }
+
+}

--- a/modules/macos_utils/templates/newsyslog.conf.erb
+++ b/modules/macos_utils/templates/newsyslog.conf.erb
@@ -1,0 +1,2 @@
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+<%= @path -%> <%= @mode -%> <%= @count -%> <%= @size -%> <%= @when -%> <%= @flags -%> <%= @pid_file %>


### PR DESCRIPTION
This PR adds a simple macos resource for rotating log files using the MacOS newsyslog.  Which is essentially a log rotation cron job set to evaluate a `run-parts` style dir of conf files that describe log files and how to rotate them.