### PR TITLE
Add scres package class

### DIFF
--- a/modules/packages/manifests/scres.pp
+++ b/modules/packages/manifests/scres.pp
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::scres (
+    Pattern[/^\d+\.\d+\.\d+$/] $version = '1.0.0',
+) {
+
+    packages::macos_package_from_s3 { "scres-${version}.pkg":
+        private             => false,
+        os_version_specific => false,
+        type                => 'pkg',
+    }
+}

--- a/modules/packages/manifests/scres.pp
+++ b/modules/packages/manifests/scres.pp
@@ -6,6 +6,8 @@ class packages::scres (
     Pattern[/^\d+\.\d+\.\d+$/] $version = '1.0.0',
 ) {
 
+    # https://github.com/th507/screen-resolution-switcher
+    # MacOS package is built and signed under munki_packages repo
     packages::macos_package_from_s3 { "scres-${version}.pkg":
         private             => false,
         os_version_specific => false,


### PR DESCRIPTION
This PR adds a package class for the `screen-resolution-switcher` aka `scres`, which is a nice little tool for inspecting and changing display resolution under MacOS.