### PR TITLE
fix shellcheck on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,8 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
-      - run: shellcheck --version
-      - run: ls -la
-      - run: pre-commit run --all-files --verbose
+      #- run: pre-commit run --all-files --verbose
+      - run: pre-commit run --files `git diff --name-only HEAD HEAD~1`
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ workflows:
   ci_test:
     jobs:
       - pre_commit
-        #- r10k_install
-        #- kitchen_converge_and_verify:
-        # matrix:
-        #   parameters:
-        #     # "maas-region" and "maas-rack" removed as we're not using them currently
-        #     kitchen_target: ["bitbar", "linux"]
+      - r10k_install
+      - kitchen_converge_and_verify:
+          matrix:
+            parameters:
+              # "maas-region" and "maas-rack" removed as we're not using them currently
+              kitchen_target: ["bitbar", "linux"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       #- run: pre-commit run --all-files --verbose
       - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
       - run: git fetch --all
-      - run: pre-commit run --from-ref original/HEAD --to-ref HEAD --verbose
+      - run: pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,9 @@ jobs:
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
       #- run: pre-commit run --all-files --verbose
-      - run: pre-commit run --from-ref origin/HEAD --to-ref HEAD
+      - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
+      - run: git fetch --all
+      - run: pre-commit run --from-ref original/HEAD --to-ref HEAD
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
       #- run: pre-commit run --all-files --verbose
-      - run: pre-commit run --files `git diff --name-only HEAD HEAD~1`
+      - run: pre-commit run --files `git diff --name-only HEAD master`
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
       - run: shellcheck --version
-      - run: shellcheck -e SC1091 modules/**/*.sh provisioners/**/*.sh
       - run: pre-commit run --all-files --verbose
   r10k_install:
     machine:
@@ -35,9 +34,3 @@ workflows:
   ci_test:
     jobs:
       - pre_commit
-      - r10k_install
-      - kitchen_converge_and_verify:
-          matrix:
-            parameters:
-              # "maas-region" and "maas-rack" removed as we're not using them currently
-              kitchen_target: ["bitbar", "linux"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,9 @@ workflows:
   ci_test:
     jobs:
       - pre_commit
+      - r10k_install
+      - kitchen_converge_and_verify:
+          matrix:
+            parameters:
+              # "maas-region" and "maas-rack" removed as we're not using them currently
+              kitchen_target: ["bitbar", "linux"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       #- run: pre-commit run --all-files --verbose
       - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
       - run: git fetch --all
-      - run: pre-commit run --from-ref original/HEAD --to-ref HEAD
+      - run: pre-commit run --from-ref original/HEAD --to-ref HEAD --verbose
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01
@@ -36,9 +36,9 @@ workflows:
   ci_test:
     jobs:
       - pre_commit
-      - r10k_install
-      - kitchen_converge_and_verify:
-          matrix:
-            parameters:
-              # "maas-region" and "maas-rack" removed as we're not using them currently
-              kitchen_target: ["bitbar", "linux"]
+        #- r10k_install
+        #- kitchen_converge_and_verify:
+        # matrix:
+        #   parameters:
+        #     # "maas-region" and "maas-rack" removed as we're not using them currently
+        #     kitchen_target: ["bitbar", "linux"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
+      - run: shellcheck --version
+      - run: shellcheck -e SC1091 modules/**/*.sh provisioners/**/*.sh
       - run: pre-commit run --all-files --verbose
   r10k_install:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
       - run: shellcheck --version
+      - run: ls -la
       - run: pre-commit run --all-files --verbose
   r10k_install:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: sudo apt-get install shellcheck
       - run: pip3 install pre-commit
       #- run: pre-commit run --all-files --verbose
-      - run: pre-commit run --files `git diff --name-only HEAD master`
+      - run: pre-commit run --from-ref origin/HEAD --to-ref HEAD
   r10k_install:
     machine:
       image: ubuntu-2004:202010-01

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - --fix
     - --fail-on-warnings
 
-- repo: https://github.com/aerickson/pre-commit-hooks
+- repo: https://github.com/mozilla-platform-ops/pre-commit-hooks
   rev: f5ccc6f
   hooks:
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - --fix
     - --fail-on-warnings
 
-- repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.7.1.1
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: 2.1.0
   hooks:
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - --fix
     - --fail-on-warnings
 
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.1.4
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.12 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
   hooks:
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - --fix
     - --fail-on-warnings
 
-- repo: https://github.com/gruntwork-io/pre-commit
-  rev: v0.1.12 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+- repo: https://github.com/aerickson/pre-commit-hooks
+  rev: f5ccc6f
   hooks:
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - --fix
     - --fail-on-warnings
 
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.1.0
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.7.1.1
   hooks:
     - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^r10k_modules/'
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v3.4.0
   hooks:
   - id: check-executables-have-shebangs
   - id: check-json
@@ -23,6 +23,6 @@ repos:
     - --fail-on-warnings
 
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.1.0
+  rev: 2.1.4
   hooks:
     - id: shellcheck


### PR DESCRIPTION
Fixes the current pre-commit failure on master (https://app.circleci.com/pipelines/github/mozilla-platform-ops/ronin_puppet).

- Switches to our fork of https://github.com/jumanjihouse/pre-commit-hooks that removes the additiionalDependency parameter to the pre-commit hook. It's implied/unecessary and causes pre-commit to explode on circleCI.
- Switches pre-commit to only run on the files changed between HEAD and master.
  - Runs much more quickly. 
  - More inline with the intent of pre-commit.

--

Research:

shellcheck-py recommendation: https://github.com/pre-commit/pre-commit/issues/1453. Exploded on circleCI (see 
838090d  below).

users of this hook complaining: https://github.com/jumanjihouse/pre-commit-hooks/issues/82. No solution found.