### PR TITLE
puppet: linux: don't let systemd control our puppet script

### DIFF
--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -13,24 +13,24 @@ class linux_packages::puppet {
           # remove puppet 5 repo, puppet-agent, and puppet if present
           # - will conflict later if not removed
           package { 'remove old puppet repo deb':
-            ensure => absent,
+            ensure => purged,
             name   => 'puppet5-release',
           }
 
           # puppet 7 is out, this explodes now
           package { 'remove old puppet repo deb, 2':
-            ensure => absent,
+            ensure => purged,
             name   => 'puppet6-release',
           }
 
           package { 'remove old puppet-agent deb':
-            ensure => absent,
+            ensure => purged,
             name   => 'puppet5-agent',
           }
 
           # we don't need the full package and it conflicts with puppet-agent
           package { 'remove puppet deb':
-            ensure => absent,
+            ensure => purged,
             name   => 'puppet',
           }
 

--- a/modules/puppet/files/puppet.service
+++ b/modules/puppet/files/puppet.service
@@ -6,9 +6,8 @@ After=network-online.target
 [Service]
 ExecStart=/usr/local/bin/run-puppet.sh
 Type=oneshot
-# we're using systemd just as a way to start a script, please no process
-# control. by default systemd can kill puppet during a dpkg command (and other
-# horrible things).
+# we're using systemd only to start the script. disable process control.
+# - we don't want puppet killed mid-run.
 KillMode=none
 
 [Install]

--- a/modules/puppet/files/puppet.service
+++ b/modules/puppet/files/puppet.service
@@ -5,6 +5,10 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/run-puppet.sh
+# we're using systemd just as a way to start a script, please no process
+# control. by default systemd can kill puppet during a dpkg command (and other
+# horrible things).
+KillMode=none
 
 [Install]
 WantedBy=default.target

--- a/modules/puppet/files/puppet.service
+++ b/modules/puppet/files/puppet.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/run-puppet.sh
+Type=oneshot
 # we're using systemd just as a way to start a script, please no process
 # control. by default systemd can kill puppet during a dpkg command (and other
 # horrible things).


### PR DESCRIPTION
The default systemd service Type `simple` kills the entire process chain when restarting a service. That's not the behavior we want for run-puppet.sh. Nodes were having puppet killed mid-run. Example log below. 

Unit file changes tested on a 1804 pool host.

Also:
- purge puppet packages we had previously marked absent
  - they can leave init files that run agents we don't need

ref links:
- https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=
- https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=

log output of puppet run getting killed:
```
-- Reboot --
Feb 11 05:34:14 t-linux64-ms-100 systemd[1]: Started masterless puppet run.
Feb 11 05:34:14 t-linux64-ms-100 run-puppet.sh[850]: Fetching origin
Feb 11 05:34:15 t-linux64-ms-100 run-puppet.sh[850]: HEAD is now at 2702c02 Merge pull request #266 from escapewindow/fix-dep-pkg
Feb 11 05:34:19 t-linux64-ms-100 run-puppet.sh[850]: Warning: /etc/puppet/environments/production/code/data/os/Debian.yaml: file does not contain a valid yaml hash
Feb 11 05:34:19 t-linux64-ms-100 run-puppet.sh[850]: Warning: /etc/puppet/environments/production/code/r10k_modules/timezone/data/common.yaml: file does not contain a valid yaml hash
Feb 11 05:34:19 t-linux64-ms-100 run-puppet.sh[850]: Notice: Compiled catalog for t-linux64-ms-100.test.releng.mdc1.mozilla.com in environment production in 0.68 seconds
Feb 11 05:34:20 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Ntp::Service/Service[ntp]/ensure: ensure changed 'stopped' to 'running'
Feb 11 05:34:22 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Disable_services/Service[cups]/ensure: ensure changed 'running' to 'stopped'
Feb 11 05:34:22 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Disable_services/Service[avahi-daemon]/ensure: ensure changed 'running' to 'stopped'
Feb 11 05:34:22 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Disable_services/Service[network-manager]/ensure: ensure changed 'running' to 'stopped'
Feb 11 05:34:23 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Linux_gui/Exec[set systemctl default to multi-user vs graphical]/returns: executed successfully
Feb 11 05:34:26 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Linux_packages::Puppet/File[puppet_repo_deb]/ensure: defined content as '{mtime}2020-11-19 21:10:57 UTC'
Feb 11 05:34:26 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Linux_packages::Puppet/Package[puppet repo deb]/ensure: created
Feb 11 05:34:41 t-linux64-ms-100 systemd[1]: puppet.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: Stopping Puppet agent...
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: Stopped Puppet agent.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 1076 (puppet) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 1077 (tee) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 1889 (apt-get) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 1998 (dpkg) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 1999 (puppet-agent.po) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: puppet.service: Found left-over process 2003 (systemctl) in control group while starting unit. Ignoring.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
Feb 11 05:34:42 t-linux64-ms-100 systemd[1]: Started Puppet agent.
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Linux_packages::Puppet/Package[install puppet agent]/ensure: ensure changed '6.21.0-1bionic' to '7.4.0-1bionic'
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Puppet::Atboot/File[/lib/systemd/system/puppet.service]/content: content changed '{md5}d543c0a2ec2478e5d470504a01e89661' to '{md5}179a889f8a1ec7b64143fa9cbf2bcbe9'
Feb 11 05:34:44 t-linux64-ms-100 systemd[1]: puppet.service: Current command vanished from the unit file, execution of the command list won't be resumed.
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Puppet::Atboot/Exec[reload systemd]/returns: executed successfully
Feb 11 05:34:44 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Notice: /Stage[main]/Puppet::Atboot/Exec[reload systemd]: Triggered 'refresh' from 1 event
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
Feb 11 05:34:44 t-linux64-ms-100 run-puppet.sh[850]: Error: Could not run: cannot load such file -- digest/sha2
Feb 11 05:36:44 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request
Feb 11 05:38:44 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request
Feb 11 05:40:44 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request
Feb 11 05:42:44 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request
Feb 11 05:44:45 t-linux64-ms-100 puppet-agent[2004]: Could not download CA certificate: Bad Request

```