### PR TITLE
linux gui: attempt to fix colord xsession issue

### DIFF
--- a/modules/linux_generic_worker/files/graphical.target
+++ b/modules/linux_generic_worker/files/graphical.target
@@ -1,0 +1,17 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Graphical Interface
+Documentation=man:systemd.special(7)
+Requires=multi-user.target
+Wants=display-manager.service colord.service
+Conflicts=rescue.service rescue.target
+After=multi-user.target rescue.service rescue.target display-manager.service colord.service
+AllowIsolate=yes

--- a/modules/linux_generic_worker/manifests/init.pp
+++ b/modules/linux_generic_worker/manifests/init.pp
@@ -122,6 +122,15 @@ class linux_generic_worker (
         '/var/log/genericworker':
             ensure => directory,
             mode   => '0777';
+
+        # fix for https://bugs.launchpad.net/ubuntu/+source/gnome-settings-daemon/+bug/1764417
+        # - happens occasionally. causes autostart scripts to not run.
+        '/etc/systemd/system/graphical.target':
+            ensure => present,
+            source => "puppet:///modules/${module_name}/graphical.target",
+            owner  => root,
+            group  => root,
+            mode   => '0644';
     }
 
     # TODO: cleanup

--- a/modules/linux_generic_worker/manifests/init.pp
+++ b/modules/linux_generic_worker/manifests/init.pp
@@ -123,7 +123,7 @@ class linux_generic_worker (
             ensure => directory,
             mode   => '0777';
 
-        # fix for https://bugs.launchpad.net/ubuntu/+source/gnome-settings-daemon/+bug/1764417
+        # workaround for https://bugs.launchpad.net/ubuntu/+source/gnome-settings-daemon/+bug/1764417
         # - happens occasionally. causes autostart scripts to not run.
         '/etc/systemd/system/graphical.target':
             ensure => present,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,8 +29,9 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-                puppet_branch     => 'master',
+                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
+                puppet_branch     => 'colormanager_fix',
+                puppet_env        => 'aerickson',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,9 +29,8 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
-                puppet_branch     => 'colormanager_fix',
-                puppet_env        => 'aerickson',
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'master',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/test/integration/linux/serverspec/linux_gui_spec.rb
+++ b/test/integration/linux/serverspec/linux_gui_spec.rb
@@ -47,7 +47,13 @@ describe file('/etc/xdg/autostart/gnome-software-service.desktop') do
 end
 
 # appearance: check ~cltbld files
-
 describe file('/home/cltbld/.config/gnome-initial-setup-done') do
   it { should exist }
+end
+
+# verify the colord fix is in place
+describe file('/etc/systemd/system/graphical.target') do
+  it { should exist }
+  it { should contain 'After=multi-user.target rescue.service rescue.target display-manager.service colord.service' }
+  it { should contain 'Wants=display-manager.service colord.service' }
 end


### PR DESCRIPTION
I think the bug mentioned causes gnome autostart files (what launches generic-worker) to not run occasionally (happens to a few hosts a day in a pool of 95).

Tested on t-linux64-ms-001.test.releng.mdc1.mozilla.com. Jobs still run and pass. 001 hasn't had the issue since running the branch. "attempt to fix" in the title because it's hard to verify that it works without a full rollout. 

Bug with workaround used: https://bugs.launchpad.net/ubuntu/+source/gnome-settings-daemon/+bug/1764417