### PR TITLE
1804: add check_gw script and systemd timer

### DIFF
--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -145,8 +145,7 @@ if __name__ == "__main__":
         print("Host in operator_hold mode. Exiting...")
         sys.exit(rc)
 
-    # rsw_procs = find_procs_by_cmdline("run-start-worker.sh")
-    # print("rsw process: %s" % rsw_procs)
+    #
     gw_procs = find_procs_by_name("generic-worker")
     print("gw process: %s" % gw_procs)
     if len(gw_procs) == 1:
@@ -173,11 +172,6 @@ if __name__ == "__main__":
         if args.reboot:
             seconds_before_reboot = 10
             this_script = os.path.basename(__file__)
-            # wall fails with: 'wall: cannot get tty name: Inappropriate ioctl for device'
-            # os.system(
-            #     "wall '%s: Failure to launch generic-worker detected. Rebooting in %s seconds...'"
-            #     % (this_script, seconds_before_reboot)
-            # )
 
             # write to syslog
             # the argument to openlog() is the topic

--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -21,6 +21,14 @@ import psutil
 #                   0: everything ok
 #                   others: error
 
+# problematic scenarios currently:
+#   - operator hold
+#       - TODO: check for operator_hold... if present, don't do anything
+#   - test kitchen testing
+#       - meh... 15 minutes is fine for testing...?
+#           - if not, use operator hold
+
+# TODO: telegraf event logging (if clock fixed, if rebooted).
 
 def is_sys_date_ok():
     n = pendulum.now()

--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -47,7 +47,7 @@ def is_in_operator_hold():
 
 def is_puppet_role_set():
     # TODO: template the puppet role path in
-    if os.path.existsz('/etc/puppet_role'):
+    if os.path.exists('/etc/puppet_role'):
         return True
     return False
 

--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -11,6 +11,10 @@ import psutil
 # pseudocode for check_gw
 # - colord xsession workaround didn't seem to work
 #
+# if operator_hold (/home/cltbld/operator_hold)
+#   exit
+# if no puppet role (kitchen testing and new node setup)
+#   exit
 # if date bad
 #   fix date
 # if load_zero and no_generic_worker and uptime_15min:
@@ -21,15 +25,8 @@ import psutil
 #                   0: everything ok
 #                   others: error
 
-# problematic scenarios currently:
-#   - operator hold
-#       - TODO: check for operator_hold... if present, don't do anything
-#   - test kitchen testing
-#       - check to see if puppet role set in /etc/puppet_role
-#       - meh... 15 minutes is fine for testing...?
-#           - if not, use operator hold
-
 # TODO: telegraf event logging (if clock fixed, if rebooted).
+
 
 def is_sys_date_ok():
     n = pendulum.now()
@@ -40,14 +37,14 @@ def is_sys_date_ok():
 
 def is_in_operator_hold():
     # TODO: template the operator hold path in
-    if os.path.exists('/home/cltbld/operator_hold'):
+    if os.path.exists("/home/cltbld/operator_hold"):
         return True
     return False
 
 
 def is_puppet_role_set():
     # TODO: template the puppet role path in
-    if os.path.exists('/etc/puppet_role'):
+    if os.path.exists("/etc/puppet_role"):
         return True
     return False
 

--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -9,13 +9,12 @@ import pendulum
 import psutil
 
 # pseudocode for check_gw
-# - colord xsession workaround didn't seem to work
 #
-# if operator_hold (/home/cltbld/operator_hold)
+# if operator_hold (/home/cltbld/operator_hold):
 #   exit
-# if no puppet role (kitchen testing and new node setup)
+# if no puppet role (kitchen testing and new node setup):
 #   exit
-# if date bad
+# if date bad:
 #   fix date
 # if load_zero and no_generic_worker and uptime_15min:
 #   reboot

--- a/modules/linux_generic_worker/files/check_gw.py
+++ b/modules/linux_generic_worker/files/check_gw.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+import syslog
+
+import pendulum
+import psutil
+
+# pseudocode for check_gw
+# - colord xsession workaround didn't seem to work
+#
+# if date bad
+#   fix date and reboot
+# if load_zero and no_generic_worker and uptime_15min:
+#   reboot
+#
+# a result code of: 5: host in bad state, rebooting
+#                   3: clock fixing done
+#                   0: everything ok
+#                   others: error
+
+
+def is_sys_date_ok():
+    n = pendulum.now()
+    if n.year >= 2020:
+        return True
+    return False
+
+
+def fix_sys_date():
+    # get clock synced. if clock is way off, run-puppet.sh will never finish
+    # it's git clone because the SSL cert will appear invalid.
+    os.system("/etc/init.d/ntp stop > /dev/null 2>&1")
+    os.system("ntpd -q -g")  # runs once and force allows huge skews
+    os.system("/etc/init.d/ntp start > /dev/null 2>&1")
+
+    # now check that it's ok or raise
+    if not is_sys_date_ok():
+        print("couldn't get system datetime synced to reality!")
+        sys.exit(1)
+
+    # should we reboot here?
+    # print("system clock fixed. rebooting...")
+    # reboot_system()
+
+    # exit non-zero, we'll get the host next pass
+    # sys.exit(3)
+
+    # delay exit
+    return 3
+
+
+def get_boot_time():
+    return pendulum.from_timestamp(psutil.boot_time())
+
+
+def find_procs_by_name(name):
+    "Return a list of processes matching 'name'."
+    ls = []
+    for p in psutil.process_iter(["name", "exe", "cmdline"]):
+        if (
+            name == p.info["name"]
+            or p.info["exe"]
+            and os.path.basename(p.info["exe"]) == name
+            or p.info["cmdline"]
+            and p.info["cmdline"][0] == name
+        ):
+            ls.append(p)
+    return ls
+
+
+# looks for the name in the full command line argument (vs just the name)
+def find_procs_by_cmdline(name):
+    "Return a list of processes matching 'name'."
+    ls = []
+    for p in psutil.process_iter(["cmdline"]):
+        # print(p)
+        if p.info["cmdline"]:
+            for item in p.info["cmdline"]:
+                # print(item)
+                if name in item:
+                    ls.append(p)
+    return ls
+
+
+def reboot_system():
+    cmd = "sleep %s && reboot" % seconds_before_reboot
+    # orig
+    # os.system(cmd)
+    # try to have script return before the reboot occurs
+    os.system("nohup bash -c '%s' &" % cmd)
+
+
+if __name__ == "__main__":
+    rc = 0
+    load_low = False
+    proc_present = False
+    uptime_high = False
+
+    parser = argparse.ArgumentParser(
+        description="check talos worker health and reboot if needed."
+    )
+    parser.add_argument(
+        "--reboot",
+        action="store_true",
+        default=False,
+        help="do the reboot if the host is bad",
+    )
+    args = parser.parse_args()
+
+    if not is_sys_date_ok():
+        rc = fix_sys_date()
+
+    #
+    # rsw_procs = find_procs_by_cmdline("run-start-worker.sh")
+    gw_procs = find_procs_by_name("generic-worker")
+    # print("rsw process: %s" % rsw_procs)
+    print("gw process: %s" % gw_procs)
+    if len(gw_procs) == 1:
+        proc_present = True
+    elif len(gw_procs) > 1:
+        raise Exception("strange")
+
+    #
+    uptime_minutes = (pendulum.now() - get_boot_time()).in_minutes()
+    print("uptime: %s minutes" % uptime_minutes)
+    if uptime_minutes > 15:
+        uptime_high = True
+
+    #
+    load1, load5, load15 = os.getloadavg()
+    load_sum = load1 + load5 + load15
+    print("load1, 5, 15: %s %s %s" % (load1, load5, load15))
+    print("load sum: %s" % load_sum)
+    if load1 <= 0.2:
+        load_low = True
+
+    print("--")
+    if uptime_high and load_low and not gw_procs:
+        if args.reboot:
+            seconds_before_reboot = 10
+            this_script = os.path.basename(__file__)
+            # wall fails with: 'wall: cannot get tty name: Inappropriate ioctl for device'
+            # os.system(
+            #     "wall '%s: Failure to launch generic-worker detected. Rebooting in %s seconds...'"
+            #     % (this_script, seconds_before_reboot)
+            # )
+
+            # write to syslog
+            # the argument to openlog() is the topic
+            syslog.openlog(this_script)
+            msg = (
+                "Failure to launch generic-worker detected. Rebooting in %s seconds...'"
+                % seconds_before_reboot
+            )
+            syslog.syslog(msg)
+
+            print("BAD HOST: rebooting in %s seconds..." % seconds_before_reboot)
+            reboot_system()
+        else:
+            print("BAD HOST: recommend rebooting")
+        sys.exit(5)
+    else:
+        print("host seems ok")
+
+    sys.exit(rc)

--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Check that generic_worker is running
+Description=check_gw
 
 [Service]
 Type=oneshot

--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check that generic_worker is running
+
+[Service]
+Type=oneshot
+ExecStart=/opt/relops-check_gw/venv/bin/ run /opt/relops-check_gw/check_gw.py
+RemainAfterExit=true
+StandardOutput=journal

--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -4,5 +4,3 @@ Description=Check that generic_worker is running
 [Service]
 Type=oneshot
 ExecStart=/opt/relops-check_gw/venv/bin/ run /opt/relops-check_gw/check_gw.py
-RemainAfterExit=true
-StandardOutput=journal

--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -3,4 +3,4 @@ Description=check_gw
 
 [Service]
 Type=oneshot
-ExecStart=/opt/relops-check_gw/check_gw.py
+ExecStart=/opt/relops-check_gw/check_gw.py --reboot

--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -3,4 +3,4 @@ Description=Check that generic_worker is running
 
 [Service]
 Type=oneshot
-ExecStart=/opt/relops-check_gw/venv/bin/ run /opt/relops-check_gw/check_gw.py
+ExecStart=/opt/relops-check_gw/check_gw.py

--- a/modules/linux_generic_worker/files/check_gw.timer
+++ b/modules/linux_generic_worker/files/check_gw.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run check_gw every 10m
+Description=Run check_gw
 After=default.target
 
 [Timer]

--- a/modules/linux_generic_worker/files/check_gw.timer
+++ b/modules/linux_generic_worker/files/check_gw.timer
@@ -12,6 +12,5 @@ OnBootSec=17min
 # - leave disabled for now (monitor and see if needed)
 # OnUnitActiveSec=10min
 
-
 [Install]
 WantedBy=timers.target

--- a/modules/linux_generic_worker/files/check_gw.timer
+++ b/modules/linux_generic_worker/files/check_gw.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run check_gw every 10m
+
+[Timer]
+OnUnitActiveSec=10m
+
+[Install]
+WantedBy=timers.target

--- a/modules/linux_generic_worker/files/check_gw.timer
+++ b/modules/linux_generic_worker/files/check_gw.timer
@@ -1,8 +1,17 @@
 [Unit]
 Description=Run check_gw every 10m
+After=default.target
 
 [Timer]
-OnUnitActiveSec=10m
+# record last run on disk
+Persistent=true
+# first run X minutes after boot
+# - check_gw won't act until 15m of uptime
+OnBootSec=17min
+# after first run, run every...
+# - leave disabled for now (monitor and see if needed)
+# OnUnitActiveSec=10min
+
 
 [Install]
 WantedBy=timers.target

--- a/modules/linux_generic_worker/manifests/check_gw.pp
+++ b/modules/linux_generic_worker/manifests/check_gw.pp
@@ -11,14 +11,14 @@
 
 class linux_generic_worker::check_gw () {
 
-    require packages::python3
+    require linux_packages::py3
     require linux_packages::psutil_py3
 
-    $pips = [ 'pendulum' ];
+    $pips = [ 'pendulum' ]
     package { $pips:
         ensure   => installed,
         provider => pip3,
-        require  => Class['packages::python3'],
+        require  => Class['linux_packages::py3'],
     }
 
     file {

--- a/modules/linux_generic_worker/manifests/check_gw.pp
+++ b/modules/linux_generic_worker/manifests/check_gw.pp
@@ -13,7 +13,8 @@ class linux_generic_worker::check_gw () {
 
     require packages::python3
 
-    $pips = [ 'pendulum', 'psutil' ]
+    # psutil is already installed
+    $pips = [ 'pendulum' ];
     package { $pips:
         ensure   => installed,
         provider => pip3,
@@ -37,7 +38,7 @@ class linux_generic_worker::check_gw () {
         source => "puppet:///modules/${module_name}/check_gw.service",
         notify => Exec['reload systemd'];
 
-      '/lib/systemd/system/check_gw.service':
+      '/lib/systemd/system/check_gw.timer':
         source => "puppet:///modules/${module_name}/check_gw.timer",
         notify => Exec['reload systemd'];
     }

--- a/modules/linux_generic_worker/manifests/check_gw.pp
+++ b/modules/linux_generic_worker/manifests/check_gw.pp
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# the workaround for https://bugs.launchpad.net/ubuntu/+source/gnome-settings-daemon/+bug/1764417
+# in init.pp didn't work... run this script regularly to detect hosts where g-w not running
+# due to the bug and restart
+#
+# also:
+#   - fix hosts with bad ntp
+
+class linux_generic_worker::check_gw () {
+
+    require packages::python3
+
+    $pips = [ 'pendulum', 'psutil' ]
+    package { $pips:
+        ensure   => installed,
+        provider => pip3,
+        require  => Class['packages::python3'],
+    }
+
+    file {
+      default:
+          owner => 'root',
+          group => 'root',
+          mode  => '0755';
+
+      ['/opt/relops-check_gw']:
+        ensure => directory;
+
+      '/opt/relops-check_gw/check_gw.py':
+        ensure => present,
+        source => "puppet:///modules/${module_name}/check_gw.py";
+
+      '/lib/systemd/system/check_gw.service':
+        source => "puppet:///modules/${module_name}/check_gw.service",
+        notify => Exec['reload systemd'];
+
+      '/lib/systemd/system/check_gw.service':
+        source => "puppet:///modules/${module_name}/check_gw.timer",
+        notify => Exec['reload systemd'];
+    }
+
+    service { 'check_gw.timer':
+      enable   => true,
+      provider => 'systemd',
+      require  => File['/lib/systemd/system/check_gw.timer'];
+    }
+
+}

--- a/modules/linux_generic_worker/manifests/check_gw.pp
+++ b/modules/linux_generic_worker/manifests/check_gw.pp
@@ -12,8 +12,8 @@
 class linux_generic_worker::check_gw () {
 
     require packages::python3
+    require linux_packages::psutil_py3
 
-    # psutil is already installed
     $pips = [ 'pendulum' ];
     package { $pips:
         ensure   => installed,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,8 +29,9 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-                puppet_branch     => 'master',
+                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
+                puppet_branch     => 'check_gw',
+                puppet_env        => 'aerickson',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -69,6 +69,9 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
                 user                      => 'cltbld',
                 user_homedir              => '/home/cltbld',
             }
+
+            require linux_generic_worker::check_gw
+
         }
         default: {
             fail("${::operatingsystem} not supported")

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,9 +29,8 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
-                puppet_branch     => 'check_gw',
-                puppet_env        => 'aerickson',
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'master',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/test/integration/linux/serverspec/g_w_spec.rb
+++ b/test/integration/linux/serverspec/g_w_spec.rb
@@ -55,3 +55,7 @@ describe file('/opt/relops-check_gw/check_gw.py') do
   it { should exist }
   it { should be_executable }
 end
+
+describe service('check_gw.timer') do
+  it { should be_enabled }
+end

--- a/test/integration/linux/serverspec/g_w_spec.rb
+++ b/test/integration/linux/serverspec/g_w_spec.rb
@@ -48,3 +48,10 @@ end
 describe file('/etc/start-worker.yml') do
   it { should exist }
 end
+
+# check_gw
+
+describe file('/opt/relops-check_gw/check_gw.py') do
+  it { should exist }
+  it { should be_executable }
+end


### PR DESCRIPTION
We're still seeing nodes not running generic-worker (as a result of the bug mentioned in #273, the fix in that PR didn't work).

Add a script that detects hosts not doing work and reboots them. It runs only once via a systemd timer around 20 minutes after boot. Also detect the system clock being out of sync and fix. 

View run results: `sudo journalctl -u check_gw`

Testing on `t-linux64-ms-001.test.releng.mdc1.mozilla.com`.