### PR TITLE
1804 talos: update user pip.conf, add spec

### DIFF
--- a/modules/linux_gui/files/pip.conf
+++ b/modules/linux_gui/files/pip.conf
@@ -1,2 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+[install]
+no-index = true
+disable-pip-version-check = true
+find-links =
+    https://pypi.pub.build.mozilla.org/pub/
+trusted-host =
+    pypi.pub.build.mozilla.org
+
 [global]
 disable-pip-version-check = true

--- a/modules/linux_gui/manifests/init.pp
+++ b/modules/linux_gui/manifests/init.pp
@@ -105,7 +105,7 @@ class linux_gui(
                     group  => $builder_group,
                     mode   => '0644',
                     source => "puppet:///modules/${module_name}/pulse_client.conf";
-                "${builder_home}/.config/pip/pip.conf":
+                "${builder_home}/.pip/pip.conf":
                     owner  => $builder_user,
                     group  => $builder_group,
                     mode   => '0644',

--- a/modules/linux_gui/manifests/init.pp
+++ b/modules/linux_gui/manifests/init.pp
@@ -110,6 +110,12 @@ class linux_gui(
                     group  => $builder_group,
                     mode   => '0644',
                     source => "puppet:///modules/${module_name}/pip.conf";
+                # place pip.conf in /etc too
+                '/etc/pip.conf':
+                    owner  => 'root',
+                    group  => 'root',
+                    mode   => '0644',
+                    source => "puppet:///modules/${module_name}/pip.conf";
             }
 
             # disbale gdm (we run our own X server)

--- a/modules/linux_gui/manifests/init.pp
+++ b/modules/linux_gui/manifests/init.pp
@@ -110,12 +110,6 @@ class linux_gui(
                     group  => $builder_group,
                     mode   => '0644',
                     source => "puppet:///modules/${module_name}/pip.conf";
-                # place pip.conf in /etc too
-                '/etc/pip.conf':
-                    owner  => 'root',
-                    group  => 'root',
-                    mode   => '0644',
-                    source => "puppet:///modules/${module_name}/pip.conf";
             }
 
             # disbale gdm (we run our own X server)

--- a/modules/linux_gui/manifests/init.pp
+++ b/modules/linux_gui/manifests/init.pp
@@ -94,7 +94,7 @@ class linux_gui(
                 # from 1804 docker image
                 # silence pip version warnings
                 # TODO: should be in linux base
-                ["${builder_home}/.config/pip",
+                ["${builder_home}/.pip",
                   "${builder_home}/.config/pulse"  ]:
                     ensure => directory,
                     group  => $builder_group,

--- a/test/integration/linux/serverspec/python_spec.rb
+++ b/test/integration/linux/serverspec/python_spec.rb
@@ -43,10 +43,6 @@ end
 
 # config files
 
-describe file('/etc/pip.conf') do
-  it { should exist }
-end
-
 describe file('/home/cltbld/.pip/pip.conf') do
   it { should exist }
 end

--- a/test/integration/linux/serverspec/python_spec.rb
+++ b/test/integration/linux/serverspec/python_spec.rb
@@ -40,3 +40,13 @@ end
 describe command('/usr/bin/python3.9 -c "import distutils"') do
   its(:exit_status) { should eq 0 }
 end
+
+# config files
+
+describe file('/etc/pip.conf') do
+  it { should exist }
+end
+
+describe file('/home/cltbld/.pip/pip.conf') do
+  it { should exist }
+end


### PR DESCRIPTION
16.04 talos hosts place a pip.conf that only allows pulling from our pypi server. The new 18.04 hosts were missing that so jobs were installing more packages and failing (16.04 hosts fail sooner and just run tests for some reason).
- fix path of pip.conf
- fix content (restrict to moz pypi server)
- add spec test

failing on new 1804 talos:
  https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=8402c70b26b9b5a843e2fb9a31de5fbca427d891&selectedTaskRun=No_25FFMSO6rD11W6G35og.0&group_state=expanded

working on old 1604 talos:
  https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=394d54d8a0892111a8419899e0a8605a648ae38a&group_state=expanded&selectedTaskRun=dbA3Tbn2R362MgFveWiAfQ.0