### PR TITLE
[RELENG-378] Periodic mac signer puppet

### DIFF
--- a/modules/puppet/files/com.mozilla.periodic_puppet.plist
+++ b/modules/puppet/files/com.mozilla.periodic_puppet.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+
+    <!-- This Source Code Form is subject to the terms of the Mozilla Public
+       - License, v. 2.0. If a copy of the MPL was not distributed with this
+       - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<dict>
+        <key>EnvironmentVariables</key>
+        <dict>
+                <key>LANG</key>
+                <string>en_US.UTF-8</string>
+                <key>PATH</key>
+                <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/puppetlabs/bin</string>
+        </dict>
+        <key>Label</key>
+        <string>com.mozilla.periodic_puppet</string>
+        <key>StartInterval</key>
+        <integer>900</integer>
+        <key>RunAtLoad</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+                <string>/bin/bash</string>
+                <string>/usr/local/bin/periodic-puppet.sh</string>
+        </array>
+        <key>ServiceIPC</key>
+        <false/>
+        <key>StandardErrorPath</key>
+        <string>/var/log/puppet/puppet.err</string>
+        <key>StandardOutPath</key>
+        <string>/var/log/puppet/puppet.out</string>
+</dict>
+</plist>

--- a/modules/puppet/files/periodic_launchctl_wrapper.sh
+++ b/modules/puppet/files/periodic_launchctl_wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Wrapper to [re]start the periodic puppet service
+
+/bin/launchctl list | grep -wq "com.mozilla.periodic"
+status=$?
+set -e
+if [ $status -eq 0 ] ; then
+    /bin/launchctl unload "/Library/LaunchDaemons/com.mozilla.periodic.plist"
+fi
+/bin/launchctl load "/Library/LaunchDaemons/com.mozilla.periodic.plist"

--- a/modules/puppet/manifests/periodic.pp
+++ b/modules/puppet/manifests/periodic.pp
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class puppet::periodic (
+    String $telegraf_user,
+    String $telegraf_password,
+    String $puppet_env          = 'production',
+    String $puppet_repo         = 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+    String $puppet_branch       = 'master',
+    String $puppet_notify_email = 'puppet-ronin-reports@mozilla.com',
+    String $smtp_relay_host     = 'localhost',
+    Hash $meta_data             = {},
+) {
+
+    include puppet::setup
+
+    case $::operatingsystem {
+        'Darwin': {
+            file {
+                '/Library/LaunchDaemons/com.mozilla.atboot_puppet.plist':
+                    ensure => absent;
+
+                '/usr/local/bin/run-puppet.sh':
+                    owner   => 'root',
+                    group   => 'wheel',
+                    mode    => '0755',
+                    content => template('puppet/puppet-darwin-run-puppet.sh.erb');
+
+                '/usr/local/bin/periodic-puppet.sh':
+                    owner   => 'root',
+                    group   => 'wheel',
+                    mode    => '0755',
+                    content => template('puppet/puppet-darwin-periodic-puppet.sh.erb');
+
+                '/usr/local/bin/periodic_launchctl_wrapper.sh':
+                    owner  => 'root',
+                    group  => 'wheel',
+                    mode   => '0755',
+                    source => 'puppet:///modules/puppet/periodic_launchctl_wrapper.sh';
+
+                '/Library/LaunchDaemons/com.mozilla.periodic.plist':
+                    owner  => 'root',
+                    group  => 'wheel',
+                    mode   => '0755',
+                    source => 'puppet:///modules/puppet/com.mozilla.periodic_puppet.plist';
+            }
+
+            exec { 'periodic_puppet_launchctl_load':
+                command     => '/bin/bash /usr/local/bin/periodic_launchctl_wrapper.sh',
+                refreshonly => true,
+                subscribe   => [
+                    File['/usr/local/bin/periodic_launchctl_wrapper.sh'],
+                    File['/Library/LaunchDaemons/com.mozilla.periodic.plist'],
+                ],
+            }
+        }
+        default: {
+            fail("${module_name} does not support ${::operatingsystem}")
+        }
+    }
+
+}

--- a/modules/puppet/templates/puppet-darwin-periodic-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-periodic-puppet.sh.erb
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# in the absence of `lockfile`, use a locking dir
+# https://unix.stackexchange.com/a/274
+LOCK_DIR="/tmp/.periodic-puppet"
+LOG_FILE="/tmp/.periodic-puppet.log"
+PUPPET="/usr/local/bin/run-puppet.sh"
+
+function fail {
+    # TODO: report failure to ext service
+    echo "${@}"
+    exit 1
+}
+
+function finish {
+    rm -rf $LOCK_DIR
+}
+
+mkdir "${LOCK_DIR}" || fail
+trap finish EXIT
+$PUPPET 2>&1 > $LOG_FILE

--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -10,8 +10,6 @@ class roles_profiles::profiles::mac_v3_signing {
             $worker_type  = 'mac-v3-signing'
             $worker_group = regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
-            include puppet::disable_atboot
-
             class { 'roles_profiles::profiles::logging':
                 # The logging module tags the logs with:
                 # hostname: hostname
@@ -119,6 +117,19 @@ class roles_profiles::profiles::mac_v3_signing {
                     puppetagent => {
                         location => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
                     },
+                },
+            }
+
+            class { 'puppet::periodic':
+                telegraf_user     => lookup('telegraf.user'),
+                telegraf_password => lookup('telegraf.user'),
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'production-mac-signing',
+                meta_data         => {
+                    workerType    => $worker_type,
+                    workerGroup   => $worker_group,
+                    provisionerId => 'scriptworker-prov-v1',
+                    workerId      => $facts['networking']['hostname'],
                 },
             }
         }

--- a/modules/signing_worker/templates/enable_scriptworker.sh.erb
+++ b/modules/signing_worker/templates/enable_scriptworker.sh.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Run this script manually to enable a scriptworker, once the signing secrets
+# are in place.
+
+set -e
+
+if [ -e <%= @scriptworker_base %>/.enabled ]; then
+    echo "<%= @scriptworker_base %>/.enabled already exists! exiting"
+    exit 1
+else
+    touch <%= @scriptworker_base %>/.enabled
+    /bin/bash "<%= @launchctl_wrapper %>"
+    if [ -d <%= @scriptworker_base %>/poller ] ; then
+        /bin/bash "<%= @poller_launchctl_wrapper %>"
+    fi
+fi

--- a/modules/signing_worker/templates/launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/launchctl_wrapper.sh.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Wrapper to [re]start a scriptworker
+
+set -e
+
+if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
+    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
+    sleep 60
+    exit 1
+else
+    set +e
+    /bin/launchctl list | grep -wq "<%= @launchd_script_name %>"
+    status=$?
+    set -e
+    if [ $status -eq 0 ] ; then
+        /bin/launchctl unload "<%= @launchd_script %>"
+    fi
+    /bin/launchctl load "<%= @launchd_script %>"
+fi

--- a/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Wrapper to [re]start a poller
+
+set -e
+
+if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
+    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
+    sleep 60
+    exit 1
+else
+    set +e
+    /bin/launchctl list | grep -wq "<%= @poller_launchd_script_name %>"
+    status=$?
+    set -e
+    if [ $status -eq 0 ] ; then
+        /bin/launchctl unload "<%= @poller_launchd_script %>"
+    fi
+    /bin/launchctl load "<%= @poller_launchd_script %>"
+fi


### PR DESCRIPTION
Supersedes #277. Fixes #267.

This PR:
- adds a `puppet::periodic` module with a "lockfile" directory to avoid concurrent puppet runs,
- enables `puppet::periodic` in the mac signers,
- prevents the mac signers from starting up on first image/puppet (we need to populate the signing secrets, or we'll burn the tree),
- adds wrapper scripts to help with maintenance