### PR TITLE
1804: puppet refactoring, check_gw fix

### DIFF
--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -4,3 +4,4 @@ Description=check_gw
 [Service]
 Type=oneshot
 ExecStart=/opt/relops-check_gw/check_gw.py --reboot
+SuccessExitStatus=3 5

--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -51,8 +51,9 @@ class linux_packages::puppet {
 
           # install latest puppet-agent
           package { 'install puppet agent':
-            ensure => '7.5.0-1bionic',
-            name   => 'puppet-agent',
+            ensure  => '7.5.0-1bionic',
+            name    => 'puppet-agent',
+            require => Exec['apt_update'],
           }
 
         }

--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -46,7 +46,6 @@ class linux_packages::puppet {
             ensure   => installed,
             provider => dpkg,
             source   => '/tmp/puppet.deb',
-            notify   => Exec['apt_update'],
           }
 
           # install latest puppet-agent

--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -51,7 +51,7 @@ class linux_packages::puppet {
 
           # install latest puppet-agent
           package { 'install puppet agent':
-            ensure => latest,
+            ensure => '7.5.0-1bionic',
             name   => 'puppet-agent',
           }
 

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -79,6 +79,7 @@ class linux_packages::py3 {
 
     file {'/opt/relops_py3/':
         ensure => absent,
+        force  => true,
     }
 
 }

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -72,7 +72,7 @@ class linux_packages::py3 {
         path     => '/bin:/usr/bin/:/sbin:/usr/sbin',
         cwd      => '/opt/relops_py39/',
         provider => shell,
-        unless   => '/usr/bin/dpkg --list | /bin/grep python3.9 && /usr/bin/python3.9 -c "import disutils"',
+        unless   => '/usr/bin/dpkg --list | /bin/grep python3.9 && /usr/bin/python3.9 -c "import distutils"',
     }
 
     # remove old /opt/py3

--- a/modules/puppet/manifests/atboot.pp
+++ b/modules/puppet/manifests/atboot.pp
@@ -39,7 +39,7 @@ class puppet::atboot (
                     # On Ubuntu 18.04 puppet runs by systemd and on successful result
                     # notifies dependent services
                     file {
-                        '/lib/systemd/system/puppet.service':
+                        '/lib/systemd/system/run-puppet.service':
                             owner   => 'root',
                             group   => 'root',
                             source  => 'puppet:///modules/puppet/puppet.service',
@@ -58,10 +58,16 @@ class puppet::atboot (
                     }
                     # enable the service but not start it
                     service {
-                        'puppet':
+                        'run-puppet':
                             enable   => true,
                             provider => 'systemd',
-                            require  => File['/lib/systemd/system/puppet.service'];
+                            require  => File['/lib/systemd/system/run-puppet.service'];
+                    }
+                    # disable the deb provided service
+                    service {
+                        'puppet':
+                            enable   => false,
+                            provider => 'systemd';
                     }
                 }
                 default: {

--- a/modules/puppet/manifests/atboot.pp
+++ b/modules/puppet/manifests/atboot.pp
@@ -56,7 +56,7 @@ class puppet::atboot (
                         'reload systemd':
                             command => '/bin/systemctl daemon-reload';
                     }
-                    # enable the service but not start it
+                    # enable the run-puppet service
                     service {
                         'run-puppet':
                             enable   => true,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,8 +29,9 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-                puppet_branch     => 'master',
+                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
+                puppet_branch     => 'check_gw_fixes',
+                puppet_env        => 'aerickson',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -29,9 +29,8 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
-                puppet_branch     => 'check_gw_fixes',
-                puppet_env        => 'aerickson',
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'master',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/test/integration/linux/serverspec/puppet_spec.rb
+++ b/test/integration/linux/serverspec/puppet_spec.rb
@@ -10,4 +10,12 @@ describe package('puppet-release'), :if => os[:family] == 'ubuntu' do
   it { should be_installed }
 end
 
-# TODO: verify atboot service and script
+# verify run-puppet service and script
+describe service('run-puppet') do
+  it { should be_enabled }
+end
+
+# ensure puppet-agent isn't set to run
+describe service('puppet') do
+  it { should_not be_enabled }
+end


### PR DESCRIPTION
What we're seeing:
- hosts still not running g-w because puppet hasn't run.
  - puppet deb updates are still interrupting the run-puppet.sh execution (even with modified systemd type).
    - puppet-agent deb installs the service file we're using for run-puppet... ideally wouldn't be the same.
  - check_gw hasn't rebooted because systemd detects the non-zero exit code as failure (and reaps the nohup reboot before it can occur)

---

Does the following:
- check_gw service: add additional success exit codes
- pin puppet version so upgrades don't happen any longer
- use run-puppet.service vs puppet.service (don't step on deb's service file)
- fixes ordering issue in puppet class (apt update wasn't running before trying to install puppet 7)
- add a test for run-puppet service, ensure that puppet service is disabled
- unrelated:
  - fix typo in py39 unless statement (caused extra installs)
  - force clean old py3 directory

Tested on 005. Worker continued to work.

