### PR TITLE
1804: disable services

### DIFF
--- a/modules/disable_services/manifests/init.pp
+++ b/modules/disable_services/manifests/init.pp
@@ -30,7 +30,7 @@ class disable_services() {
                     # NetworkManager-wait-online.service depends on network-manager.service
                     # avahi-daemon.service depends on cups-browsed.service
                     # cups-browsed.service depends on cups.service
-                    $disable = ['cups-browsed', 'NetworkManager-wait-online']
+                    $disable = ['cups-browsed']
                     service {
                         $disable:
                             ensure   => stopped,

--- a/modules/disable_services/manifests/init.pp
+++ b/modules/disable_services/manifests/init.pp
@@ -26,6 +26,18 @@ class disable_services() {
                             require  => Package[$install_and_disable];
                     }
 
+                    # services we need to disable that depend of the above services
+                    # NetworkManager-wait-online.service depends on network-manager.service
+                    # avahi-daemon.service depends on cups-browsed.service
+                    # cups-browsed.service depends on cups.service
+                    $disable = ['cups-browsed', 'NetworkManager-wait-online']
+                    service {
+                        $disable:
+                            ensure   => stopped,
+                            provider => 'systemd',
+                            enable   => false
+                    }
+
                     # disable apport via defaults also
                     file {
                         '/etc/default/apport':

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -12,7 +12,6 @@ class roles_profiles::profiles::ntp {
             }
         }
         'Ubuntu': {
-            include ntp
             $ntp_server = lookup('ntp_server', String)
             class { 'ntp':
                 servers => [$ntp_server]

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -12,6 +12,7 @@ class roles_profiles::profiles::ntp {
             }
         }
         'Ubuntu': {
+            include ntp
             $ntp_server = lookup('ntp_server', String)
             class { 'ntp':
                 servers => [$ntp_server]

--- a/test/integration/linux/serverspec/ntp_spec.rb
+++ b/test/integration/linux/serverspec/ntp_spec.rb
@@ -5,3 +5,7 @@ describe command('timedatectl status') do
   # TODO: check clock sync... it doesn't work on freshly converged hosts though.
   its(:stdout) { should match /systemd-timesyncd.service active: yes/ }
 end
+
+describe service('ntp') do
+  it { should be_enabled }
+end

--- a/test/integration/linux/serverspec/services_disabled_spec.rb
+++ b/test/integration/linux/serverspec/services_disabled_spec.rb
@@ -34,6 +34,16 @@ describe service('whoopsie') do
   it { should_not be_enabled }
 end
 
+# services that require disabled services (also need to be stopped)
+
+describe service('NetworkManager-wait-online') do
+  it { should_not be_enabled }
+end
+
+describe service('cups-browsed') do
+  it { should_not be_enabled }
+end
+
 # bluez packages, but bluetooth service
 describe service('bluetooth') do
   it { should_not be_enabled }

--- a/test/integration/linux/serverspec/services_disabled_spec.rb
+++ b/test/integration/linux/serverspec/services_disabled_spec.rb
@@ -36,10 +36,6 @@ end
 
 # services that require disabled services (also need to be stopped)
 
-describe service('NetworkManager-wait-online') do
-  it { should_not be_enabled }
-end
-
 describe service('cups-browsed') do
   it { should_not be_enabled }
 end


### PR DESCRIPTION
Fixes #286.

- disable avahi dependencies
- disable cups dependencies
- add spec test for NTP

Leave NetworkManager alone. Due to the current dependecy issue (#286), it does seem to be being used on the 18.04 fleet. Additionally, it's what a users would most likely have on their systems. 