### PR TITLE
Fix periodic puppet

### DIFF
--- a/modules/signing_worker/templates/launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/launchctl_wrapper.sh.erb
@@ -1,20 +1,11 @@
 #!/bin/bash
 # Wrapper to [re]start a scriptworker
 
+set +e
+/bin/launchctl list | grep -wq "<%= @launchd_script_name %>"
+status=$?
 set -e
-
-if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
-    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
-    sleep 60
-    # Exit 0 to avoid killing the puppet run
-    exit 0
-else
-    set +e
-    /bin/launchctl list | grep -wq "<%= @launchd_script_name %>"
-    status=$?
-    set -e
-    if [ $status -eq 0 ] ; then
-        /bin/launchctl unload "<%= @launchd_script %>"
-    fi
-    /bin/launchctl load "<%= @launchd_script %>"
+if [ $status -eq 0 ] ; then
+    /bin/launchctl unload "<%= @launchd_script %>"
 fi
+/bin/launchctl load "<%= @launchd_script %>"

--- a/modules/signing_worker/templates/launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/launchctl_wrapper.sh.erb
@@ -6,7 +6,8 @@ set -e
 if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
     echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
     sleep 60
-    exit 1
+    # Exit 0 to avoid killing the puppet run
+    exit 0
 else
     set +e
     /bin/launchctl list | grep -wq "<%= @launchd_script_name %>"

--- a/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
@@ -1,20 +1,11 @@
 #!/bin/bash
 # Wrapper to [re]start a poller
 
+set +e
+/bin/launchctl list | grep -wq "<%= @poller_launchd_script_name %>"
+status=$?
 set -e
-
-if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
-    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
-    sleep 60
-    # Exit 0 to avoid killing the puppet run
-    exit 0
-else
-    set +e
-    /bin/launchctl list | grep -wq "<%= @poller_launchd_script_name %>"
-    status=$?
-    set -e
-    if [ $status -eq 0 ] ; then
-        /bin/launchctl unload "<%= @poller_launchd_script %>"
-    fi
-    /bin/launchctl load "<%= @poller_launchd_script %>"
+if [ $status -eq 0 ] ; then
+    /bin/launchctl unload "<%= @poller_launchd_script %>"
 fi
+/bin/launchctl load "<%= @poller_launchd_script %>"

--- a/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
+++ b/modules/signing_worker/templates/poller_launchctl_wrapper.sh.erb
@@ -6,7 +6,8 @@ set -e
 if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
     echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
     sleep 60
-    exit 1
+    # Exit 0 to avoid killing the puppet run
+    exit 0
 else
     set +e
     /bin/launchctl list | grep -wq "<%= @poller_launchd_script_name %>"

--- a/modules/signing_worker/templates/poller_wrapper.sh.erb
+++ b/modules/signing_worker/templates/poller_wrapper.sh.erb
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-set +e
+set -e
+if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
+    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
+    sleep 60
+    exit 1
+fi
 
 source <%= @virtualenv_dir %>/bin/activate
 <%= @virtualenv_dir %>/bin/notarization_poller <%= @poller_config_file  %>

--- a/modules/signing_worker/templates/scriptworker_wrapper.sh.erb
+++ b/modules/signing_worker/templates/scriptworker_wrapper.sh.erb
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-set +e
+set -e
+if [ ! -e <%= @scriptworker_base %>/.enabled ]; then
+    echo "<%= @scriptworker_base %>/.enabled doesn't exist! sleeping 60 and exiting"
+    sleep 60
+    exit 1
+fi
 
 source <%= @virtualenv_dir %>/bin/activate
 <%= @virtualenv_dir %>/bin/scriptworker <%= @scriptworker_config_file  %>


### PR DESCRIPTION
When testing the periodic puppet rollout, I noticed that we reboot the mac 2x after imaging. This means that even though we don't load the `/Library/LaunchDaemons/*.plist` files during puppet time, we load them on boot, and we start up scriptworker before we populate the signing secrets.

This PR moves the `<%= scriptworker_base %>/.enabled` check into the poller+scriptworker wrapper scripts, rather than the launchd wrappers, so we don't start up scriptworker on boot before we're ready.