### PR TITLE
check_gw.service: disable systemd process control

### DIFF
--- a/modules/linux_generic_worker/files/check_gw.service
+++ b/modules/linux_generic_worker/files/check_gw.service
@@ -5,3 +5,5 @@ Description=check_gw
 Type=oneshot
 ExecStart=/opt/relops-check_gw/check_gw.py --reboot
 SuccessExitStatus=3 5
+# disable process control. otherwise systemd will kill our reboot command.
+KillMode=none


### PR DESCRIPTION
#291 didn't fix check_gw's problem of not rebooting bad systems. Even with a successful exit code, systemd is still killing check_gw's reboot command before it can run (by default it cleans up all process in the process group on service stop, not just errors or restarts).

Disable systemd's process management via the KillMode option. Same fix as in #269.

Tested on a node that was in a bad state. After applying the change and reloading systemd and running, the host rebooted.