### PR TITLE
1804: network time tweaks

### DIFF
--- a/modules/linux_time/manifests/init.pp
+++ b/modules/linux_time/manifests/init.pp
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class linux_time (
+    String $servers,
+) {
+  case $::operatingsystem {
+    'Ubuntu': {
+      case $::operatingsystemrelease {
+        '18.04':  {
+          # 1804 uses timesyncd vs ntpd
+          file {
+              '/etc/systemd/timesyncd.conf':
+                  owner   => 'root',
+                  group   => 'wheel',
+                  mode    => '0644',
+                  content => template("${module_name}/timesyncd.conf.erb");
+          }
+        }
+        default: {
+          # previously the 'ntp' community r10k was used
+          # class { 'ntp':
+          #     servers => [$ntp_server]
+          # }
+          fail("Ubuntu ${::operatingsystemrelease} is not supported")
+        }
+      }
+    }
+    default: {
+      fail("Cannot install on ${::operatingsystem}")
+    }
+  }
+}

--- a/modules/linux_time/manifests/init.pp
+++ b/modules/linux_time/manifests/init.pp
@@ -13,7 +13,7 @@ class linux_time (
           file {
               '/etc/systemd/timesyncd.conf':
                   owner   => 'root',
-                  group   => 'wheel',
+                  group   => 'root',
                   mode    => '0644',
                   content => template("${module_name}/timesyncd.conf.erb");
           }

--- a/modules/linux_time/templates/timesyncd.conf.erb
+++ b/modules/linux_time/templates/timesyncd.conf.erb
@@ -1,0 +1,19 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+NTP=<%= @servers %>
+#FallbackNTP=ntp.ubuntu.com
+#RootDistanceMaxSec=5
+#PollIntervalMinSec=32
+#PollIntervalMaxSec=2048

--- a/modules/linux_time/templates/timesyncd.conf.orig
+++ b/modules/linux_time/templates/timesyncd.conf.orig
@@ -1,0 +1,19 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+#NTP=
+#FallbackNTP=ntp.ubuntu.com
+#RootDistanceMaxSec=5
+#PollIntervalMinSec=32
+#PollIntervalMaxSec=2048

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -12,9 +12,16 @@ class roles_profiles::profiles::ntp {
             }
         }
         'Ubuntu': {
-            $ntp_server = lookup('ntp_server', String)
-            class { 'ntp':
-                servers => [$ntp_server]
+            case $::operatingsystemrelease {
+                '18.04': {
+                    $ntp_server = lookup('ntp_server', String)
+                    class { 'linux_time':
+                        servers => [$ntp_server]
+                    }
+                }
+                default: {
+                    fail("Ubuntu ${::operatingsystemrelease} is not supported")
+                }
             }
         }
         'Windows': {

--- a/modules/roles_profiles/manifests/profiles/ntp.pp
+++ b/modules/roles_profiles/manifests/profiles/ntp.pp
@@ -16,7 +16,7 @@ class roles_profiles::profiles::ntp {
                 '18.04': {
                     $ntp_server = lookup('ntp_server', String)
                     class { 'linux_time':
-                        servers => [$ntp_server]
+                        servers => $ntp_server
                     }
                 }
                 default: {


### PR DESCRIPTION
18.04 (and 16.04) by default don't use ntp for network time, but timesyncd.

- Place a timesyncd config file with our local NTP server.