### PR TITLE
Update macstadium m1 roles and inventory

### DIFF
--- a/data/roles/gecko_t_osx_1100_m1.yaml
+++ b/data/roles/gecko_t_osx_1100_m1.yaml
@@ -1,0 +1,77 @@
+---
+ntp_server: time.apple.org
+
+# Common worker metadata conveniently aliased to generic worker data from above
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+worker:
+  taskcluster_version: 40.0.3
+  provider_type: standalone
+  worker_pool_id: releng-hardware/gecko-t-osx-1100-m1
+  worker_group: macstadium-vegas
+  worker_id: "%{facts.networking.hostname}"
+  client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+  access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+  generic_worker_engine: simple
+  idle_timeout_secs: 3600
+
+packages_classes:
+    #  - google_chrome
+    #  - java_developer_package_for_osx
+  - mercurial
+  - nodejs
+  - python2
+  - python2_psutil
+  - python2_zstandard
+  - python3
+  - python3_psutil
+  - python3_zstandard
+  - rosetta_2
+  - scres
+  - tooltool
+  - virtualenv
+  - wget
+  - xcode_cmd_line_tools
+  - zstandard
+
+# Package class parameters
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: 5.6.1
+packages::nodejs::version: 12.11.1
+packages::python2::version: 2.7.18
+packages::python2_zstandard::version: 0.11.1
+packages::python3::version: 3.9.1
+packages::python3_zstandard::version: 0.11.1
+packages::virtualenv::version: 16.4.3
+packages::wget::version: 1.20.3_1
+packages::xcode_cmd_line_tools::version: '12.2'
+packages::zstandard::version: 1.3.8
+
+# Talos class parameters
+talos::user: cltbld
+
+# Determines how puppet should be executed
+# ( atboot, cron, never )
+puppet_run_strategy: never
+
+# Firewall role to include
+#firewall_role: osx_taskcluster_worker
+
+# Override secrets with vault secrets
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -11,7 +11,7 @@ worker_metadata:
 worker:
   taskcluster_version: 40.0.3
   provider_type: standalone
-  worker_pool_id: releng-hardware/gecko-t-osx-1100-m1-qa
+  worker_pool_id: releng-hardware/gecko-t-osx-1100-m1-staging
   worker_group: macstadium-vegas
   worker_id: "%{facts.networking.hostname}"
   client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"

--- a/inventory.d/macmini-m1.yaml
+++ b/inventory.d/macmini-m1.yaml
@@ -1,23 +1,61 @@
 ---
 name: macmini-m1
 groups:
-  - name: gecko-t-osx-1100-m1-qa
+  - name: gecko-t-osx-1100-m1-staging
     targets:
-      - 10.155.0.11
+      - macmini-m1-1.test.releng.mslv.mozilla.com
     facts:
-      puppet_role: gecko_t_osx_1100_m1_qa
+      puppet_role: gecko_t_osx_1100_m1_staging
   - name: gecko-t-osx-1100-m1
     targets:
-      - 10.155.0.12
-      - 10.155.0.13
-      - 10.155.0.14
-      - 10.155.0.15
-      - 10.155.0.16
-      - 10.155.0.17
-      - 10.155.0.18
-      - 10.155.0.19
-      - 10.155.0.20
-      - 10.155.0.21
-      - 10.155.0.22
+      - macmini-m1-2.test.releng.mslv.mozilla.com
+      - macmini-m1-3.test.releng.mslv.mozilla.com
+      - macmini-m1-4.test.releng.mslv.mozilla.com
+      - macmini-m1-5.test.releng.mslv.mozilla.com
+      - macmini-m1-6.test.releng.mslv.mozilla.com
+      - macmini-m1-7.test.releng.mslv.mozilla.com
+      - macmini-m1-8.test.releng.mslv.mozilla.com
+      - macmini-m1-9.test.releng.mslv.mozilla.com
+      - macmini-m1-10.test.releng.mslv.mozilla.com
+      - macmini-m1-11.test.releng.mslv.mozilla.com
+      - macmini-m1-12.test.releng.mslv.mozilla.com
+      - macmini-m1-13.test.releng.mslv.mozilla.com
+      - macmini-m1-14.test.releng.mslv.mozilla.com
+      - macmini-m1-15.test.releng.mslv.mozilla.com
+      - macmini-m1-16.test.releng.mslv.mozilla.com
+      - macmini-m1-17.test.releng.mslv.mozilla.com
+      - macmini-m1-18.test.releng.mslv.mozilla.com
+      - macmini-m1-19.test.releng.mslv.mozilla.com
+      - macmini-m1-20.test.releng.mslv.mozilla.com
+      - macmini-m1-21.test.releng.mslv.mozilla.com
+      - macmini-m1-22.test.releng.mslv.mozilla.com
+      - macmini-m1-23.test.releng.mslv.mozilla.com
+      - macmini-m1-24.test.releng.mslv.mozilla.com
+      - macmini-m1-25.test.releng.mslv.mozilla.com
+      - macmini-m1-26.test.releng.mslv.mozilla.com
+      - macmini-m1-27.test.releng.mslv.mozilla.com
+      - macmini-m1-28.test.releng.mslv.mozilla.com
+      - macmini-m1-29.test.releng.mslv.mozilla.com
+      - macmini-m1-30.test.releng.mslv.mozilla.com
+      - macmini-m1-31.test.releng.mslv.mozilla.com
+      - macmini-m1-32.test.releng.mslv.mozilla.com
+      - macmini-m1-33.test.releng.mslv.mozilla.com
+      - macmini-m1-34.test.releng.mslv.mozilla.com
+      - macmini-m1-35.test.releng.mslv.mozilla.com
+      - macmini-m1-36.test.releng.mslv.mozilla.com
+      - macmini-m1-37.test.releng.mslv.mozilla.com
+      - macmini-m1-38.test.releng.mslv.mozilla.com
+      - macmini-m1-39.test.releng.mslv.mozilla.com
+      - macmini-m1-40.test.releng.mslv.mozilla.com
+      - macmini-m1-41.test.releng.mslv.mozilla.com
+      - macmini-m1-42.test.releng.mslv.mozilla.com
+      - macmini-m1-43.test.releng.mslv.mozilla.com
+      - macmini-m1-44.test.releng.mslv.mozilla.com
+      - macmini-m1-45.test.releng.mslv.mozilla.com
+      - macmini-m1-46.test.releng.mslv.mozilla.com
+      - macmini-m1-47.test.releng.mslv.mozilla.com
+      - macmini-m1-48.test.releng.mslv.mozilla.com
+      - macmini-m1-49.test.releng.mslv.mozilla.com
+      - macmini-m1-50.test.releng.mslv.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1100_m1

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class roles_profiles::roles::gecko_t_osx_1100_m1_qa {
+class roles_profiles::roles::gecko_t_osx_1100_m1 {
 
     include ::roles_profiles::profiles::timezone
     include ::roles_profiles::profiles::ntp

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
+
+    include ::roles_profiles::profiles::timezone
+    include ::roles_profiles::profiles::ntp
+    include ::roles_profiles::profiles::network
+#    include ::roles_profiles::profiles::disable_services
+    include ::roles_profiles::profiles::vnc
+#    include ::roles_profiles::profiles::suppress_dialog_boxes
+#    include ::roles_profiles::profiles::power_management
+#    include ::roles_profiles::profiles::screensaver
+#    include ::roles_profiles::profiles::gui
+    include ::roles_profiles::profiles::sudo
+#    include ::roles_profiles::profiles::software_updates
+#    include ::roles_profiles::profiles::hardware
+    include ::roles_profiles::profiles::motd
+    include ::roles_profiles::profiles::users
+    include ::roles_profiles::profiles::relops_users
+    include ::roles_profiles::profiles::cltbld_user
+    include ::roles_profiles::profiles::packages_installed
+    include ::roles_profiles::profiles::worker
+}


### PR DESCRIPTION
This PR updates bolt inventory with the additional M1 macminis and changes names on the related roles.