### PR TITLE
Various tweaks

### DIFF
--- a/data/roles/gecko_t_osx_1100_m1.yaml
+++ b/data/roles/gecko_t_osx_1100_m1.yaml
@@ -40,11 +40,11 @@ packages_classes:
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.6.1
+packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.9.1
+packages::python3::version: 3.7.9
 packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -40,11 +40,11 @@ packages_classes:
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.6.1
+packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.9.1
+packages::python3::version: 3.7.9
 packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -3,6 +3,40 @@ name: macmini-r8
 groups:
   - name: gecko-t-osx-1015-r8
     targets:
+      - macmini-r8-31.test.releng.mdc1.mozilla.com
+      - macmini-r8-32.test.releng.mdc1.mozilla.com
+      - macmini-r8-33.test.releng.mdc1.mozilla.com
+      - macmini-r8-34.test.releng.mdc1.mozilla.com
+      - macmini-r8-35.test.releng.mdc1.mozilla.com
+      - macmini-r8-36.test.releng.mdc1.mozilla.com
+      - macmini-r8-37.test.releng.mdc1.mozilla.com
+      - macmini-r8-38.test.releng.mdc1.mozilla.com
+      - macmini-r8-39.test.releng.mdc1.mozilla.com
+      - macmini-r8-40.test.releng.mdc1.mozilla.com
+      - macmini-r8-49.test.releng.mdc1.mozilla.com
+      #- macmini-r8-50.test.releng.mdc1.mozilla.com
+      - macmini-r8-51.test.releng.mdc1.mozilla.com
+      - macmini-r8-52.test.releng.mdc1.mozilla.com
+      - macmini-r8-53.test.releng.mdc1.mozilla.com
+      - macmini-r8-54.test.releng.mdc1.mozilla.com
+      - macmini-r8-55.test.releng.mdc1.mozilla.com
+      - macmini-r8-56.test.releng.mdc1.mozilla.com
+      - macmini-r8-57.test.releng.mdc1.mozilla.com
+      - macmini-r8-58.test.releng.mdc1.mozilla.com
+      - macmini-r8-59.test.releng.mdc1.mozilla.com
+      - macmini-r8-60.test.releng.mdc1.mozilla.com
+      - macmini-r8-61.test.releng.mdc1.mozilla.com
+      - macmini-r8-62.test.releng.mdc1.mozilla.com
+      - macmini-r8-63.test.releng.mdc1.mozilla.com
+      - macmini-r8-64.test.releng.mdc1.mozilla.com
+      - macmini-r8-65.test.releng.mdc1.mozilla.com
+      - macmini-r8-66.test.releng.mdc1.mozilla.com
+      - macmini-r8-67.test.releng.mdc1.mozilla.com
+      - macmini-r8-68.test.releng.mdc1.mozilla.com
+      - macmini-r8-69.test.releng.mdc1.mozilla.com
+      - macmini-r8-70.test.releng.mdc1.mozilla.com
+      - macmini-r8-71.test.releng.mdc1.mozilla.com
+      - macmini-r8-72.test.releng.mdc1.mozilla.com
       - macmini-r8-73.test.releng.mdc1.mozilla.com
       - macmini-r8-74.test.releng.mdc1.mozilla.com
       - macmini-r8-75.test.releng.mdc1.mozilla.com
@@ -15,7 +49,7 @@ groups:
       - macmini-r8-82.test.releng.mdc1.mozilla.com
       - macmini-r8-83.test.releng.mdc1.mozilla.com
       - macmini-r8-84.test.releng.mdc1.mozilla.com
-#     - macmini-r8-85.test.releng.mdc1.mozilla.com
+      - macmini-r8-85.test.releng.mdc1.mozilla.com
       - macmini-r8-86.test.releng.mdc1.mozilla.com
       - macmini-r8-87.test.releng.mdc1.mozilla.com
       - macmini-r8-88.test.releng.mdc1.mozilla.com
@@ -61,8 +95,8 @@ groups:
       - macmini-r8-130.test.releng.mdc1.mozilla.com
       - macmini-r8-131.test.releng.mdc1.mozilla.com
       - macmini-r8-132.test.releng.mdc1.mozilla.com
-#     - macmini-r8-133.test.releng.mdc1.mozilla.com
-#     - macmini-r8-134.test.releng.mdc1.mozilla.com
+      - macmini-r8-133.test.releng.mdc1.mozilla.com
+      - macmini-r8-134.test.releng.mdc1.mozilla.com
       - macmini-r8-135.test.releng.mdc1.mozilla.com
       - macmini-r8-136.test.releng.mdc1.mozilla.com
       - macmini-r8-137.test.releng.mdc1.mozilla.com

--- a/modules/packages/manifests/macos_package_from_s3.pp
+++ b/modules/packages/manifests/macos_package_from_s3.pp
@@ -24,9 +24,21 @@ define packages::macos_package_from_s3 (
         false => 'public'
     }
 
+    # Starting with MacOS Bigsur 11.0.0, the OS versioning scheme changed to where the first int now changes with
+    # each MacOS major version release.  This means that minor version changes in the increment the second and third
+    # int.  eg. in Catalina, minor versions would increment 10.15.0 -> 10.15.1 -> 10.15.2
+    # With Bigsur it now increments 11.0.0 -> 11.1.0 -> 11.2.4.  This seems to indicate the next major MacOS release
+    # will be 12.0.0.
+    $real_major_version = split($facts['os']['macosx']['version']['major'], '[.]')[0]
+    $os_ver = $real_major_version ? {
+        '10'    => $facts['os']['macosx']['version']['major'],
+        '11'    => '11.0',
+        default => $real_major_version
+    }
+
     # Set path os specific version or common
     $v = $os_version_specific ? {
-        true  => $facts['os']['macosx']['version']['major'],
+        true  => $os_ver,
         false => 'common'
     }
 

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -11,7 +11,7 @@ class packages::mercurial (
 
     packages::macos_package_from_s3 { "Mercurial-${version}-macosx10.14.pkg":
         private             => false,
-        os_version_specific => false,
+        os_version_specific => true,
         type                => 'pkg',
     }
 

--- a/modules/packages/manifests/python3.pp
+++ b/modules/packages/manifests/python3.pp
@@ -6,14 +6,15 @@ class packages::python3 (
     Pattern[/^\d+\.\d+\.\d+_?\d*$/] $version = '3.7.4',
 ) {
 
-    # As of puppet 7.0.0, facts.os.architecture still reports the M1 arm64 hardware as x86_64
-    # therfore, we check the mac model instead
-    if $facts['system_profiler']['model_identifier'] == 'Macmini9,1' {
-        $pkg_name = "python-${version}-macos11.0.pkg"
-    } else {
-        $pkg_name = "python-${version}-macosx10.9.pkg"
-    }
+#    # As of puppet 7.0.0, facts.os.architecture still reports the M1 arm64 hardware as x86_64
+#    # therfore, we check the mac model instead
+#    if $facts['system_profiler']['model_identifier'] == 'Macmini9,1' {
+#        $pkg_name = "python-${version}-macos11.0.pkg"
+#    } else {
+#        $pkg_name = "python-${version}-macosx10.9.pkg"
+#    }
 
+    $pkg_name = "python-${version}-macosx10.9.pkg"
     packages::macos_package_from_s3 { $pkg_name:
         private             => false,
         os_version_specific => false,


### PR DESCRIPTION
This PR does a few things:

- drops the version of both hg and python on the macmini m1s
- updates the bolt inventory with new r8s in mdc1
- macminis m1s will use the same python version as the r8s
- hg on m1s is a custom built package compiled against the default py2 on the bigsur m1s