### PR TITLE
18.04: add papertrail logging

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -18,6 +18,9 @@ provisioner:
         telegraf:
           user: telegraf
           password: telegraf4fun
+        papertrail:
+          host: localhost
+          port: 1111
         linux_vnc:
           user: cltbld
           group: cltbld

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,9 @@ provisioner:
         telegraf:
           user: telegraf
           password: telegraf4fun
+        papertrail:
+          host: localhost
+          port: 1111
         linux_vnc:
           user: cltbld
           group: cltbld

--- a/modules/linux_generic_worker/manifests/check_gw.pp
+++ b/modules/linux_generic_worker/manifests/check_gw.pp
@@ -25,13 +25,15 @@ class linux_generic_worker::check_gw () {
       default:
           owner => 'root',
           group => 'root',
-          mode  => '0755';
+          mode  => '0644';
 
       ['/opt/relops-check_gw']:
-        ensure => directory;
+        ensure => directory,
+        mode   => '0755';
 
       '/opt/relops-check_gw/check_gw.py':
         ensure => present,
+        mode   => '0755',
         source => "puppet:///modules/${module_name}/check_gw.py";
 
       '/lib/systemd/system/check_gw.service':

--- a/modules/linux_packages/manifests/nmap.pp
+++ b/modules/linux_packages/manifests/nmap.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class linux_packages::nmap {
+  case $::operatingsystem {
+    'Ubuntu': {
+      package {
+        'nmap':
+          ensure => latest;
+      }
+    }
+    default: {
+      fail("Cannot install on ${::operatingsystem}")
+    }
+  }
+}

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -6,9 +6,8 @@ class linux_papertrail (
     String $papertrail_host,  # e.g. logs5.papertrailapp.com
     Integer $papertrail_port,  # e.g. 11111
     Array   $systemd_units = [],  # optional, only show these units
+    Array   $syslog_identifiers = [],  # optional, display these syslog identifiers also
 ) {
-
-
     case $::operatingsystem {
         'Ubuntu': {
             case $::operatingsystemrelease {
@@ -16,6 +15,13 @@ class linux_papertrail (
                     # nmap provides ncat
                     include linux_packages::nmap
 
+                    # NOTE: puppet 6.1+ will reload systemd automatically
+
+                    # two papertrail systemd units:
+                    # - one to tail journalctl (and optionally specific units)
+                    # - an optional second to follow specific syslog topic/identifiers
+
+                    # if systemd_units is empty, all journalctl logs will be sent
                     file { '/etc/systemd/system/papertrail.service':
                         mode    => '0644',
                         owner   => 'root',
@@ -24,7 +30,6 @@ class linux_papertrail (
                         notify  => Service['papertrail'],
                     }
 
-                    # puppet 6.1+ will reload systemd automatically
                     service {
                         'papertrail':
                             ensure   => running,
@@ -33,6 +38,26 @@ class linux_papertrail (
                             require  => Package['nmap'];
                     }
 
+                    # if syslog_identifiers are empty, we don't need a second instance
+                    if ! $syslog_identifiers.empty {
+
+                        file { '/etc/systemd/system/papertrail-syslog.service':
+                            mode    => '0644',
+                            owner   => 'root',
+                            group   => 'root',
+                            content => template('linux_papertrail/papertrail-syslog.service.erb'),
+                            notify  => Service['papertrail-syslog'],
+                        }
+
+                        service {
+                            'papertrail-syslog':
+                                ensure   => running,
+                                provider => 'systemd',
+                                enable   => true,
+                                require  => Package['nmap'];
+                        }
+                    }
+                    # TODO: handle else (remove unit file and stop service)
                 }
                 default: {
                     fail ("Cannot install on Ubuntu version ${::operatingsystemrelease}")

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_papertrail (
-    String $papertrail_host,  # e.g. logs5.papertrailapp.com
+    String  $papertrail_host,  # e.g. logs5.papertrailapp.com
     Integer $papertrail_port,  # e.g. 11111
     Array   $systemd_units = [],  # optional, only show these units
     Array   $syslog_identifiers = [],  # optional, display these syslog identifiers also
@@ -13,7 +13,7 @@ class linux_papertrail (
             case $::operatingsystemrelease {
                 '18.04': {
                     # only configure if required variables are set
-                    if (! $papertrail_host.empty) and (! $papertrail_port.empty) {
+                    if (! $papertrail_host.empty) and (! $papertrail_port == undef) {
 
                         # nmap provides ncat
                         include linux_packages::nmap

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -5,6 +5,7 @@
 class linux_papertrail (
     String $papertrail_host,  # e.g. logs5.papertrailapp.com
     Integer $papertrail_port,  # e.g. 11111
+    Array   $systemd_units = [],  # optional, only show these units
 ) {
 
 

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class linux_papertrail (
+    String $papertrail_host,  # e.g. logs5.papertrailapp.com
+    Integer $papertrail_port,  # e.g. 11111
+) {
+
+
+    case $::operatingsystem {
+        'Ubuntu': {
+            case $::operatingsystemrelease {
+                '18.04': {
+                    # nmap provides ncat
+                    include linux_packages::nmap
+
+                    exec {
+                        'reload systemd':
+                            command => '/bin/systemctl daemon-reload';
+                    }
+
+                    file { '/etc/systemd/system/papertrail.service':
+                        mode    => '0644',
+                        owner   => 'root',
+                        group   => 'root',
+                        content => template('linux_papertrail/papertrail.service.erb'),
+                    }
+
+                    # puppet 6.1+ will reload systemd automatically
+                    service {
+                        'papertrail':
+                            ensure   => started,
+                            provider => 'systemd',
+                            enable   => true,
+                            require  => Package['nmap'];
+                    }
+
+                }
+                default: {
+                    fail ("Cannot install on Ubuntu version ${::operatingsystemrelease}")
+                }
+            }
+        }
+        default: {
+            fail("gui is not supported on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -12,10 +12,11 @@ class linux_papertrail (
         'Ubuntu': {
             case $::operatingsystemrelease {
                 '18.04': {
-                    # nmap provides ncat
-                    include linux_packages::nmap
-
+                    # only configure if required variables are set
                     if (! $papertrail_host.empty) and (! $papertrail_port.empty) {
+
+                        # nmap provides ncat
+                        include linux_packages::nmap
 
                         # NOTE: puppet 6.1+ will reload systemd automatically
 

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -13,7 +13,7 @@ class linux_papertrail (
             case $::operatingsystemrelease {
                 '18.04': {
                     # only configure if required variables are set
-                    if (! $papertrail_host.empty) and (! $papertrail_port == undef) {
+                    if (! $papertrail_host.empty) and ($papertrail_port != -1) {
 
                         # nmap provides ncat
                         include linux_packages::nmap
@@ -63,7 +63,7 @@ class linux_papertrail (
                         # TODO: handle else (remove unit file and stop service)
                     }
                     else {
-                        warning ( 'linux_papertrail: host and port not set, not configuring' )
+                        warning ( 'host and port not set, not configuring' )
                     }
                 }
                 default: {

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -21,6 +21,7 @@ class linux_papertrail (
                         owner   => 'root',
                         group   => 'root',
                         content => template('linux_papertrail/papertrail.service.erb'),
+                        notify  => Service['papertrail'],
                     }
 
                     # puppet 6.1+ will reload systemd automatically

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -25,7 +25,7 @@ class linux_papertrail (
                     # puppet 6.1+ will reload systemd automatically
                     service {
                         'papertrail':
-                            ensure   => started,
+                            ensure   => running,
                             provider => 'systemd',
                             enable   => true,
                             require  => Package['nmap'];

--- a/modules/linux_papertrail/manifests/init.pp
+++ b/modules/linux_papertrail/manifests/init.pp
@@ -15,11 +15,6 @@ class linux_papertrail (
                     # nmap provides ncat
                     include linux_packages::nmap
 
-                    exec {
-                        'reload systemd':
-                            command => '/bin/systemctl daemon-reload';
-                    }
-
                     file { '/etc/systemd/system/papertrail.service':
                         mode    => '0644',
                         owner   => 'root',

--- a/modules/linux_papertrail/templates/papertrail-syslog.service.erb
+++ b/modules/linux_papertrail/templates/papertrail-syslog.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=Papertrail-syslog
+After=systemd-journald.service
+Requires=systemd-journald.service
+[Service]
+ExecStart=/bin/sh -c "journalctl <% @syslog_identifiers.each do |identifier| %>-t <%= identifier %> <% end %> -f | ncat --ssl <%= @papertrail_host %> <%= @papertrail_port %>"
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=5s
+[Install]
+WantedBy=multi-user.target

--- a/modules/linux_papertrail/templates/papertrail.service.erb
+++ b/modules/linux_papertrail/templates/papertrail.service.erb
@@ -3,7 +3,7 @@ Description=Papertrail
 After=systemd-journald.service
 Requires=systemd-journald.service
 [Service]
-ExecStart=/bin/sh -c "journalctl -f | ncat --ssl <%= @papertrail_host %> <%= @papertrail_port %>"
+ExecStart=/bin/sh -c "journalctl <% @systemd_units.each do |unit| %>-u <%= unit %> <% end %> -f | ncat --ssl <%= @papertrail_host %> <%= @papertrail_port %>"
 TimeoutStartSec=0
 Restart=on-failure
 RestartSec=5s

--- a/modules/linux_papertrail/templates/papertrail.service.erb
+++ b/modules/linux_papertrail/templates/papertrail.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=Papertrail
+After=systemd-journald.service
+Requires=systemd-journald.service
+[Service]
+ExecStart=/bin/sh -c "journalctl -f | ncat --ssl <%= @papertrail_host %> <%= @papertrail_port %>"
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=5s
+[Install]
+WantedBy=multi-user.target

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -15,6 +15,7 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'roles_profiles::profiles::logging_papertrail':
                 papertrail_host => lookup('papertrail.host'),
                 papertrail_port => lookup('papertrail.port'),
+                systemd_units   => ['check_gw', 'generic-worker', 'run-puppet', 'run-start-worker', 'sudo', 'ssh'],
             }
 
             # TODO: move these lines to linux-base?

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -13,8 +13,8 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             require roles_profiles::profiles::cltbld_user
 
             class { 'roles_profiles::profiles::logging_papertrail':
-                papertrail_host    => lookup('papertrail.host'),
-                papertrail_port    => lookup('papertrail.port'),
+                papertrail_host    => lookup( { 'name' => 'papertrail.host', 'default_value' => '' } ),
+                papertrail_port    => lookup( { 'name' => 'papertrail.port', 'default_value' => '' } ),
                 systemd_units      => ['check_gw', 'run-puppet', 'ssh'],
                 syslog_identifiers => ['generic-worker', 'run-start-worker', 'sudo'],
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -36,9 +36,8 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
-                puppet_branch     => '1804_papertrail_logging',
-                puppet_env        => 'aerickson',
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'master',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -13,9 +13,10 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             require roles_profiles::profiles::cltbld_user
 
             class { 'roles_profiles::profiles::logging_papertrail':
-                papertrail_host => lookup('papertrail.host'),
-                papertrail_port => lookup('papertrail.port'),
-                systemd_units   => ['check_gw', 'generic-worker', 'run-puppet', 'run-start-worker', 'sudo', 'ssh'],
+                papertrail_host    => lookup('papertrail.host'),
+                papertrail_port    => lookup('papertrail.port'),
+                systemd_units      => ['check_gw', 'run-puppet', 'ssh'],
+                syslog_identifiers => ['generic-worker', 'run-start-worker', 'sudo'],
             }
 
             # TODO: move these lines to linux-base?

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -12,6 +12,11 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
         'Ubuntu': {
             require roles_profiles::profiles::cltbld_user
 
+            class { 'roles_profiles::profiles::logging_papertrail':
+                papertrail_host => lookup('papertrail.host'),
+                papertrail_port => lookup('papertrail.port'),
+            }
+
             # TODO: move these lines to linux-base?
             require linux_packages::py2
             require linux_packages::py3

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -34,8 +34,9 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
             class { 'puppet::atboot':
                 telegraf_user     => lookup('telegraf.user'),
                 telegraf_password => lookup('telegraf.password'),
-                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-                puppet_branch     => 'master',
+                puppet_repo       => 'https://github.com/aerickson/ronin_puppet.git',
+                puppet_branch     => '1804_papertrail_logging',
+                puppet_env        => 'aerickson',
                 # Note the camelCase key names
                 meta_data         => {
                     workerType    => $worker_type,

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -14,7 +14,7 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
 
             class { 'roles_profiles::profiles::logging_papertrail':
                 papertrail_host    => lookup( { 'name' => 'papertrail.host', 'default_value' => '' } ),
-                papertrail_port    => lookup( { 'name' => 'papertrail.port', 'default_value' => Undef } ),
+                papertrail_port    => lookup( { 'name' => 'papertrail.port', 'default_value' => -1 } ),
                 systemd_units      => ['check_gw', 'run-puppet', 'ssh'],
                 syslog_identifiers => ['generic-worker', 'run-start-worker', 'sudo'],
             }

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -14,7 +14,7 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
 
             class { 'roles_profiles::profiles::logging_papertrail':
                 papertrail_host    => lookup( { 'name' => 'papertrail.host', 'default_value' => '' } ),
-                papertrail_port    => lookup( { 'name' => 'papertrail.port', 'default_value' => '' } ),
+                papertrail_port    => lookup( { 'name' => 'papertrail.port', 'default_value' => Undef } ),
                 systemd_units      => ['check_gw', 'run-puppet', 'ssh'],
                 syslog_identifiers => ['generic-worker', 'run-start-worker', 'sudo'],
             }

--- a/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
+++ b/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
@@ -10,7 +10,6 @@ class roles_profiles::profiles::logging_papertrail (
         'Ubuntu': {
             # TODO: check release/version
 
-
             class { 'linux_papertrail':
                 papertrail_host => $papertrail_host,
                 papertrail_port => $papertrail_port,

--- a/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
+++ b/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
@@ -5,6 +5,7 @@
 class roles_profiles::profiles::logging_papertrail (
     String $papertrail_host,
     Integer $papertrail_port,
+    Array   $systemd_units = [],  # optional, only show these units
 ) {
     case $::operatingsystem {
         'Ubuntu': {
@@ -13,6 +14,7 @@ class roles_profiles::profiles::logging_papertrail (
             class { 'linux_papertrail':
                 papertrail_host => $papertrail_host,
                 papertrail_port => $papertrail_port,
+                systemd_units   => $systemd_units,  # optional, only show these units
             }
         }
         default: {

--- a/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
+++ b/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::logging_papertrail (
+    String $papertrail_host,
+    Integer $papertrail_port,
+) {
+    case $::operatingsystem {
+        'Ubuntu': {
+            # TODO: check release/version
+
+
+            class { 'linux_papertrail':
+                papertrail_host => $papertrail_host,
+                papertrail_port => $papertrail_port,
+            }
+        }
+        default: {
+            fail("${::operatingsystem} not supported")
+        }
+    }
+}

--- a/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
+++ b/modules/roles_profiles/manifests/profiles/logging_papertrail.pp
@@ -6,15 +6,17 @@ class roles_profiles::profiles::logging_papertrail (
     String $papertrail_host,
     Integer $papertrail_port,
     Array   $systemd_units = [],  # optional, only show these units
+    Array   $syslog_identifiers = [],  # optional, display these syslog identifiers also
 ) {
     case $::operatingsystem {
         'Ubuntu': {
             # TODO: check release/version
 
             class { 'linux_papertrail':
-                papertrail_host => $papertrail_host,
-                papertrail_port => $papertrail_port,
-                systemd_units   => $systemd_units,  # optional, only show these units
+                papertrail_host    => $papertrail_host,
+                papertrail_port    => $papertrail_port,
+                systemd_units      => $systemd_units,  # optional, only show these units
+                syslog_identifiers => $syslog_identifiers,  # optional, display these syslog identifiers also
             }
         }
         default: {

--- a/test/integration/linux/serverspec/papertrail_spec.rb
+++ b/test/integration/linux/serverspec/papertrail_spec.rb
@@ -1,8 +1,10 @@
 require_relative 'spec_helper'
 
-# test that systemd config is in place
 describe file('/etc/systemd/system/papertrail.service') do
+  # test that systemd config is in place
   it { should exist }
+  # verify that systemd unit file has proper entries/format
+  it { should contain 'ExecStart=/bin/sh -c "journalctl -u check_gw -u generic-worker -u run-puppet -u run-start-worker -u sudo -u ssh  -f | ncat --ssl localhost 1111"' }
 end
 
 # service is enabled

--- a/test/integration/linux/serverspec/papertrail_spec.rb
+++ b/test/integration/linux/serverspec/papertrail_spec.rb
@@ -1,14 +1,22 @@
 require_relative 'spec_helper'
 
+# systemd unit files are in place with proper content
 describe file('/etc/systemd/system/papertrail.service') do
-  # test that systemd config is in place
   it { should exist }
-  # verify that systemd unit file has proper entries/format
-  it { should contain 'ExecStart=/bin/sh -c "journalctl -u check_gw -u generic-worker -u run-puppet -u run-start-worker -u sudo -u ssh  -f | ncat --ssl localhost 1111"' }
+  it { should contain 'ExecStart=/bin/sh -c "journalctl -u check_gw -u run-puppet -u ssh  -f | ncat --ssl localhost 1111"' }
 end
 
-# service is enabled
+describe file('/etc/systemd/system/papertrail-syslog.service') do
+  it { should exist }
+  it { should contain 'ExecStart=/bin/sh -c "journalctl -t generic-worker -t run-start-worker -t sudo  -f | ncat --ssl localhost 1111"' }
+end
+
+# services are enabled
 describe service('papertrail') do
+  it { should be_enabled }
+end
+
+describe service('papertrail-syslog') do
   it { should be_enabled }
 end
 

--- a/test/integration/linux/serverspec/papertrail_spec.rb
+++ b/test/integration/linux/serverspec/papertrail_spec.rb
@@ -1,7 +1,16 @@
 require_relative 'spec_helper'
 
-# TODO: test that systemd config is in place
+# test that systemd config is in place
+describe file('/etc/systemd/system/papertrail.service') do
+  it { should exist }
+end
 
-# TODO: service is enabled
+# service is enabled
+describe service('papertrail') do
+  it { should be_enabled }
+end
 
-# TODO: nmap/ncat is installed
+# nmap/ncat is installed
+describe package('nmap') do
+  it { should be_installed }
+end

--- a/test/integration/linux/serverspec/papertrail_spec.rb
+++ b/test/integration/linux/serverspec/papertrail_spec.rb
@@ -1,0 +1,7 @@
+require_relative 'spec_helper'
+
+# TODO: test that systemd config is in place
+
+# TODO: service is enabled
+
+# TODO: nmap/ncat is installed


### PR DESCRIPTION
Adds logging to papertrail.

- papertrail.port and papertrail.host are hiera secrets that need to be set and sent out to all hosts
  - lookups have defaults, so nothing will explode if unset

#### links

https://documentation.solarwinds.com/en/Success_Center/papertrail/Content/kb/configuration/configuring-centralized-logging-from-systemd.htm#