### PR TITLE
Duo auth implemented on mac signing/notarizing hosts

### DIFF
--- a/modules/duo/files/pam_sshd
+++ b/modules/duo/files/pam_sshd
@@ -1,0 +1,12 @@
+# sshd: auth account password session
+auth       required       /usr/local/lib/pam/pam_duo.so
+#auth       optional       pam_krb5.so use_kcminit
+#auth       optional       pam_ntlm.so try_first_pass
+#auth       optional       pam_mount.so try_first_pass
+#auth       required       pam_opendirectory.so try_first_pass
+account    required       pam_nologin.so
+account    required       pam_sacl.so sacl_service=ssh
+account    required       pam_opendirectory.so
+password   required       pam_opendirectory.so
+session    required       pam_launchd.so
+session    optional       pam_mount.so

--- a/modules/duo/files/sshd_config
+++ b/modules/duo/files/sshd_config
@@ -1,0 +1,14 @@
+AuthorizedKeysFile      .ssh/authorized_keys
+PubkeyAuthentication yes
+PasswordAuthentication no
+AuthenticationMethods publickey,keyboard-interactive:pam
+
+UsePAM yes
+ChallengeResponseAuthentication yes
+UseDNS no
+
+# pass locale information
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem       sftp    /usr/libexec/sftp-server

--- a/modules/duo/files/sshd_config
+++ b/modules/duo/files/sshd_config
@@ -1,4 +1,4 @@
-AuthorizedKeysFile      .ssh/authorized_keys
+AuthorizedKeysFile .ssh/authorized_keys
 PubkeyAuthentication yes
 PasswordAuthentication no
 AuthenticationMethods publickey,keyboard-interactive:pam

--- a/modules/duo/manifests/duo_unix.pp
+++ b/modules/duo/manifests/duo_unix.pp
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class duo::duo_unix (
+    Boolean $enabled          = false,
+    String $ikey              = '',
+    String $skey              = '',
+    String $host              = '',
+    String $group             = '',
+    String $http_proxy        = '',
+    String $fallback_local_ip = 'no',
+    String $failmode          = 'safe',
+    String $pushinfo          = 'no',
+    String $autopush          = 'no',
+    String $prompts           = '3',
+    String $accept_env_factor = 'no',
+) {
+    if $enabled {
+        # Sanity Check
+        if $ikey == '' or $skey == '' or $host == '' {
+            fail('ikey, skey, and host must all be defined.')
+        }
+    }
+
+    include packages::openssl
+    include packages::duo_unix
+
+    # Do not leave duo config around if disabled
+    $conf_present = $enabled ? {
+        true => 'present',
+        default => 'absent',
+    }
+
+    file { '/etc/duo':
+        ensure => directory,
+    }
+
+    file { '/etc/duo/pam_duo.conf':
+        ensure    => $conf_present,
+        owner     => 'root',
+        group     => 'wheel',
+        mode      => '0600',
+        show_diff => false,
+        content   => template('duo/duo.conf.erb'),
+        require   => Class['packages::duo_unix'],
+    }
+
+    file { '/etc/duo/login_duo.conf':
+        ensure    => $conf_present,
+        owner     => '_sshd',
+        group     => 'wheel',
+        mode      => '0600',
+        show_diff => false,
+        content   => template('duo/duo.conf.erb'),
+        require   => Class['packages::duo_unix'],
+    }
+
+    file { '/etc/ssh/sshd_config':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0644',
+        source  => 'puppet:///modules/duo/sshd_config',
+        require => Class['packages::duo_unix'],
+    }
+
+    file { '/etc/pam.d/sshd':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0444',
+        source  => 'puppet:///modules/duo/pam_sshd',
+        require => Class['packages::duo_unix'],
+    }
+}

--- a/modules/duo/templates/duo.conf.erb
+++ b/modules/duo/templates/duo.conf.erb
@@ -1,0 +1,37 @@
+[duo]
+; Duo integration key
+ikey=<%= @ikey %>
+
+; Duo secret key
+skey=<%= @skey %>
+
+; Duo API host
+host=<%= @host %>
+
+; Fallback local IP
+fallback_local_ip=<%= @fallback_local_ip %>
+
+; Failure mode
+failmode=<%= @failmode %>
+
+; Push info
+pushinfo=<%= @pushinfo %>
+
+; Auto push
+autopush=<%= @autopush %>
+
+; Prompts
+prompts=<%= @prompts %>
+
+; Accept environment factor
+accept_env_factor=<%= @accept_env_factor %>
+<% if @group != '' -%>
+
+    ; Group restriction
+    groups=<%= @group %>
+<% end -%>
+<% if @http_proxy != '' -%>
+
+    ; HTTP proxy
+    http_proxy=<%= @http_proxy %>
+<% end -%>

--- a/modules/fw/manifests/networks.pp
+++ b/modules/fw/manifests/networks.pp
@@ -177,6 +177,9 @@ class fw::networks {
     $infra_corp_jumphost = [  '10.48.72.100/32',  # ssh1.corpdmz.mdc1.mozilla.com
                               '10.50.72.100/32' ] # ssh1.corpdmz.mdc2.mozilla.com
 
+    # Moz vpn + moz jumphosts
+    $moz_vpn = [ $infra_vpn_users, $infra_corp_jumphost ]
+
     # mtv2 qa network
     $mtv2_qa = [ '10.252.73.0/24' ] # *.qa.mtv2.mozilla.com
 }

--- a/modules/fw/manifests/profiles/ssh_from_mozvpn_logging.pp
+++ b/modules/fw/manifests/profiles/ssh_from_mozvpn_logging.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class fw::profiles::ssh_from_mozvpn_logging {
+    include fw::networks
+
+    fw::rules { 'allow_ssh_from_mozvpn_logging':
+        sources =>  $::fw::networks::moz_vpn,
+        app     => 'ssh',
+        log     => true
+    }
+}

--- a/modules/fw/manifests/roles/mac_signing.pp
+++ b/modules/fw/manifests/roles/mac_signing.pp
@@ -7,10 +7,8 @@ class fw::roles::mac_signing {
     case $::fqdn {
         /.*\.(mdc1|mdc2)\.mozilla\.com/: {
             include ::fw::profiles::ssh_from_rejh_logging
+            include ::fw::profiles::ssh_from_mozvpn_logging
             include ::fw::profiles::nrpe_from_nagios
-            include ::fw::profiles::dep_signing_from_osx
-            include ::fw::profiles::rel_signing_from_osx
-            include ::fw::profiles::nightly_signing_from_osx
         }
         default:{
             # Silently skip other DCs

--- a/modules/packages/manifests/duo_unix.pp
+++ b/modules/packages/manifests/duo_unix.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::duo_unix (
+    Pattern[/^\d+\.\d+\.\d+$/] $version = '1.11.4',
+) {
+
+    packages::macos_package_from_s3 { "duo_unix-${version}.pkg":
+        os_version_specific => true,
+        type                => 'pkg',
+    }
+}

--- a/modules/packages/manifests/openssl.pp
+++ b/modules/packages/manifests/openssl.pp
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::openssl (
+    String $version = '1.1.1k',
+) {
+
+    packages::macos_package_from_s3 { "openssl-${version}.pkg":
+        os_version_specific => true,
+        type                => 'pkg',
+    }
+}

--- a/modules/roles_profiles/manifests/profiles/duo.pp
+++ b/modules/roles_profiles/manifests/profiles/duo.pp
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::duo {
+
+    case $::operatingsystem {
+        'Darwin': {
+            class { 'duo::duo_unix':
+                enabled  => true,
+                ikey     => lookup('duo.ikey'),
+                skey     => lookup('duo.skey'),
+                host     => lookup('duo.host'),
+                pushinfo => 'yes',
+            }
+        }
+        default: {
+            fail("${::operatingsystem} not supported")
+        }
+    }
+}

--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -120,18 +120,18 @@ class roles_profiles::profiles::mac_v3_signing {
                 },
             }
 
-#            class { 'puppet::periodic':
-#                telegraf_user     => lookup('telegraf.user'),
-#                telegraf_password => lookup('telegraf.user'),
-#                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-#                puppet_branch     => 'production-mac-signing',
-#                meta_data         => {
-#                    workerType    => $worker_type,
-#                    workerGroup   => $worker_group,
-#                    provisionerId => 'scriptworker-prov-v1',
-#                    workerId      => $facts['networking']['hostname'],
-#                },
-#            }
+            class { 'puppet::periodic':
+                telegraf_user     => lookup('telegraf.user'),
+                telegraf_password => lookup('telegraf.user'),
+                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+                puppet_branch     => 'production-mac-signing',
+                meta_data         => {
+                    workerType    => $worker_type,
+                    workerGroup   => $worker_group,
+                    provisionerId => 'scriptworker-prov-v1',
+                    workerId      => $facts['networking']['hostname'],
+                },
+            }
         }
         default: {
             fail("${::operatingsystem} not supported")

--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -120,18 +120,18 @@ class roles_profiles::profiles::mac_v3_signing {
                 },
             }
 
-            class { 'puppet::periodic':
-                telegraf_user     => lookup('telegraf.user'),
-                telegraf_password => lookup('telegraf.user'),
-                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
-                puppet_branch     => 'production-mac-signing',
-                meta_data         => {
-                    workerType    => $worker_type,
-                    workerGroup   => $worker_group,
-                    provisionerId => 'scriptworker-prov-v1',
-                    workerId      => $facts['networking']['hostname'],
-                },
-            }
+#            class { 'puppet::periodic':
+#                telegraf_user     => lookup('telegraf.user'),
+#                telegraf_password => lookup('telegraf.user'),
+#                puppet_repo       => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
+#                puppet_branch     => 'production-mac-signing',
+#                meta_data         => {
+#                    workerType    => $worker_type,
+#                    workerGroup   => $worker_group,
+#                    provisionerId => 'scriptworker-prov-v1',
+#                    workerId      => $facts['networking']['hostname'],
+#                },
+#            }
         }
         default: {
             fail("${::operatingsystem} not supported")

--- a/modules/roles_profiles/manifests/roles/mac_v3_signing_ff_prod.pp
+++ b/modules/roles_profiles/manifests/roles/mac_v3_signing_ff_prod.pp
@@ -22,6 +22,7 @@ class roles_profiles::roles::mac_v3_signing_ff_prod {
     include ::roles_profiles::profiles::signing_users
     include ::roles_profiles::profiles::remove_bootstrap_user
     include ::roles_profiles::profiles::duo
+    include ::fw::roles::mac_signing
 
     include ::roles_profiles::profiles::mac_v3_signing
 }

--- a/modules/roles_profiles/manifests/roles/mac_v3_signing_ff_prod.pp
+++ b/modules/roles_profiles/manifests/roles/mac_v3_signing_ff_prod.pp
@@ -21,6 +21,7 @@ class roles_profiles::roles::mac_v3_signing_ff_prod {
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::signing_users
     include ::roles_profiles::profiles::remove_bootstrap_user
+    include ::roles_profiles::profiles::duo
 
     include ::roles_profiles::profiles::mac_v3_signing
 }


### PR DESCRIPTION
This implements duo_uinix auth on the mac-v3-signing hosts to allow access directly from the vpn and the ssh jumphosts.  I've tested this on mac-v3-signing7.  It also works on Catalina.

While looking at the fw::network file, it clearly needs some clean up.  I'll follow that up in a different PR.