### PR TITLE
bootstrap_linux: install puppet 7

### DIFF
--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -50,6 +50,8 @@ class linux_packages::puppet {
 
           # install latest puppet-agent
           package { 'install puppet agent':
+            # if changing version, also ensure this is in sync with
+            # provisioners/linux/bootstrap_linux.sh
             ensure  => '7.5.0-1bionic',
             name    => 'puppet-agent',
             require => Exec['apt_update'],

--- a/provisioners/linux/bootstrap_linux.sh
+++ b/provisioners/linux/bootstrap_linux.sh
@@ -13,8 +13,8 @@
 set -e
 # set -x
 
-# install puppet 6
-wget https://apt.puppetlabs.com/puppet6-release-bionic.deb -O /tmp/puppet.deb
+# install puppet 7
+wget https://apt.puppetlabs.com/puppet7-release-bionic.deb -O /tmp/puppet.deb
 dpkg -i /tmp/puppet.deb
 apt-get update
 apt-get remove -y puppet


### PR DESCRIPTION
#285 pinned the puppet version to 7.5.x and the bootstrap script was still installing the 6.0 release deb (which pins the version at 6.x), so bootstrapping would fail with a puppet version issue. 

Also add a note in the puppet module that we should keep the bootstrap script and the puppet module in sync.