### PR TITLE
linux 1804: bootstrap installs unversioned puppet release deb

### DIFF
--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -39,6 +39,8 @@ class linux_packages::puppet {
               ensure => 'file',
               path   => '/tmp/puppet.deb',
               mode   => 'a+r',
+              # if changing version, also ensure this is in sync with
+              # provisioners/linux/bootstrap_linux.sh
               source => 'https://apt.puppetlabs.com/puppet-release-bionic.deb',
           }
 

--- a/provisioners/linux/bootstrap_linux.sh
+++ b/provisioners/linux/bootstrap_linux.sh
@@ -13,8 +13,8 @@
 set -e
 # set -x
 
-# install puppet 7
-wget https://apt.puppetlabs.com/puppet7-release-bionic.deb -O /tmp/puppet.deb
+# install puppet
+wget https://apt.puppetlabs.com/puppet-release-bionic.deb -O /tmp/puppet.deb
 dpkg -i /tmp/puppet.deb
 apt-get update
 apt-get remove -y puppet


### PR DESCRIPTION
#312 caused a new problem. It installed the puppet7-release deb, but that just caused later convergence issues when the puppet code installs the puppet-release deb (they can't coexist) and code wasn't added to remove the puppet7 releasee deb.

I found the two nodes I had been testing with stuck in Puppet loops.

```bash
Error: /Stage[main]/Linux_packages::Puppet/Package[puppet repo deb]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/dpkg --force-confold -i /tmp/puppet.deb' returned 1: dpkg: regarding /tmp/puppet.deb containing puppet-release:
 puppet-release conflicts with puppet7-release
  puppet7-release (version 7.0.0-2bionic) is present and installed.

dpkg: error processing archive /tmp/puppet.deb (--install):
 conflicting packages - not installing puppet-release
```

Solution: Use the puppet-release deb just like the puppet code does.

Long-term solution: See #315.