### PR TITLE
remove timeout on log stream

### DIFF
--- a/modules/fluentd/templates/fluentd.conf.erb
+++ b/modules/fluentd/templates/fluentd.conf.erb
@@ -27,7 +27,6 @@
   command "\
     log stream --type log --level info --color none \
       --predicate '(process MATCHES \"(logger|sudo|su|sshd)\" || messageType >= <%= @mac_log_level %>)' \
-      --timeout 1d \
     | sed -l -e '2d' \
     "
     # messageType integers:


### PR DESCRIPTION
We don't want the log stream to timeout now that it is not re-executed on intervals.