### PR TITLE
linux puppet: notify apt_update after installing repo deb

### DIFF
--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -49,7 +49,7 @@ class linux_packages::puppet {
             # 2. if upgrading, make sure to purge the old versioned release deb (see above)
             ensure    => '7.7.0-1bionic',
             name      => 'puppet-agent',
-            require   => Exec['apt_update'],
+            notify    => Exec['apt_update'],
             subscribe => Package['puppet repo deb']
           }
 

--- a/modules/linux_packages/manifests/puppet.pp
+++ b/modules/linux_packages/manifests/puppet.pp
@@ -39,6 +39,7 @@ class linux_packages::puppet {
             ensure    => installed,
             provider  => dpkg,
             source    => "/tmp/${deb_name}",
+            notify    => Exec['apt_update'],
             subscribe => File['puppet_repo_deb']
           }
 
@@ -49,7 +50,7 @@ class linux_packages::puppet {
             # 2. if upgrading, make sure to purge the old versioned release deb (see above)
             ensure    => '7.7.0-1bionic',
             name      => 'puppet-agent',
-            notify    => Exec['apt_update'],
+            require   => Exec['apt_update'],
             subscribe => Package['puppet repo deb']
           }
 


### PR DESCRIPTION
#316 had deployment issues (details below). `apt update` didn't seem to run before puppet-agent was installed. Running `apt update` and rerunning puppet fixed the nodes.

I think this is due to requiring vs notifying apt_update per https://forge.puppet.com/modules/puppetlabs/apt#update-the-list-of-packages.

```
Warning: /etc/puppet/environments/production/code/data/os/Debian.yaml: file does not contain a valid yaml hash
Warning: /etc/puppet/environments/production/code/r10k_modules/timezone/data/common.yaml: file does not contain a valid yaml hash
Notice: Compiled catalog for t-linux64-ms-136.test.releng.mdc1.mozilla.com in environment production in 0.73 seconds
Notice: /Stage[main]/Ntp::Service/Service[ntp]/ensure: ensure changed 'stopped' to 'running'
Notice: /Stage[main]/Disable_services/Package[apport]/ensure: ensure changed '2.20.9-0ubuntu7.23' to '2.20.9-0ubuntu7.24'
Notice: /Stage[main]/Disable_services/Service[cups]/ensure: ensure changed 'running' to 'stopped'
Notice: /Stage[main]/Disable_services/Service[avahi-daemon]/ensure: ensure changed 'running' to 'stopped'
Notice: /Stage[main]/Disable_services/Service[network-manager]/ensure: ensure changed 'running' to 'stopped'
Notice: /Stage[main]/Linux_gui/Exec[set systemctl default to multi-user vs graphical]/returns: executed successfully
Notice: /Stage[main]/Linux_packages::Xvfb/Package[xvfb]/ensure: ensure changed '2:1.19.6-1ubuntu4.8' to '2:1.19.6-1ubuntu4.9'
Notice: /Stage[main]/Linux_packages::Gstreamer/Package[gstreamer1.0-plugins-base]/ensure: ensure changed '1.14.5-0ubuntu1~18.04.1' to '1.14.5-0ubuntu1~18.04.3'
Notice: /Stage[main]/Linux_packages::Gstreamer/Package[gstreamer1.0-plugins-good]/ensure: ensure changed '1.14.5-0ubuntu1~18.04.1' to '1.14.5-0ubuntu1~18.04.2'
Notice: /Stage[main]/Linux_talos/Package[linux-generic]/ensure: ensure changed '4.15.0.137.124' to '4.15.0.144.131'
Notice: /Stage[main]/Linux_packages::Puppet/Package[puppet-release]/ensure: purged
Notice: /Stage[main]/Linux_packages::Puppet/File[puppet_repo_deb]/ensure: defined content as '{mtime}2021-02-04 22:24:37 UTC'
Notice: /Stage[main]/Linux_packages::Puppet/Package[puppet repo deb]/ensure: created
Notice: /Stage[main]/Linux_packages::Puppet/Package[puppet repo deb]: Triggered 'refresh' from 1 event
Error: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install puppet-agent=7.7.0-1bionic' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
W: --force-yes is deprecated, use one of the options starting with --allow instead.
E: Version '7.7.0-1bionic' for 'puppet-agent' was not found
Error: /Stage[main]/Linux_packages::Puppet/Package[install puppet agent]/ensure: change from '7.5.0-1bionic' to '7.7.0-1bionic' failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install puppet-agent=7.7.0-1bionic' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
W: --force-yes is deprecated, use one of the options starting with --allow instead.
E: Version '7.7.0-1bionic' for 'puppet-agent' was not found
Notice: /Stage[main]/Linux_packages::Puppet/Package[install puppet agent]: Triggered 'refresh' from 2 events
Notice: /Stage[main]/Puppet::Atboot/File[/lib/systemd/system/run-puppet.service]: Dependency Package[install puppet agent] has failures: true
Warning: /Stage[main]/Puppet::Atboot/File[/lib/systemd/system/run-puppet.service]: Skipping because of failed dependencies
Warning: /Stage[main]/Puppet::Atboot/Exec[reload systemd]: Skipping because of failed dependencies
Warning: /Stage[main]/Puppet::Atboot/Service[run-puppet]: Skipping because of failed dependencies
Notice: Applied catalog in 99.62 seconds
```