### PR TITLE
add one worker to gecko-3-b-osx-1015

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -138,7 +138,6 @@ groups:
       - macmini-r8-135.test.releng.mdc1.mozilla.com
       - macmini-r8-136.test.releng.mdc1.mozilla.com
       - macmini-r8-137.test.releng.mdc1.mozilla.com
-      - macmini-r8-140.test.releng.mdc1.mozilla.com
       - macmini-r8-141.test.releng.mdc1.mozilla.com
       - macmini-r8-142.test.releng.mdc1.mozilla.com
       - macmini-r8-143.test.releng.mdc1.mozilla.com
@@ -261,6 +260,7 @@ groups:
   - name: gecko-3-b-osx-1015
     targets:
       - macmini-r8-139.test.releng.mdc1.mozilla.com
+      - macmini-r8-140.test.releng.mdc1.mozilla.com
       - macmini-r8-198.test.releng.mdc1.mozilla.com
       - macmini-r8-199.test.releng.mdc1.mozilla.com
       - macmini-r8-200.test.releng.mdc1.mozilla.com

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -138,6 +138,9 @@ groups:
       - macmini-r8-135.test.releng.mdc1.mozilla.com
       - macmini-r8-136.test.releng.mdc1.mozilla.com
       - macmini-r8-137.test.releng.mdc1.mozilla.com
+      - macmini-r8-138.test.releng.mdc1.mozilla.com
+      - macmini-r8-139.test.releng.mdc1.mozilla.com
+      - macmini-r8-140.test.releng.mdc1.mozilla.com
       - macmini-r8-141.test.releng.mdc1.mozilla.com
       - macmini-r8-142.test.releng.mdc1.mozilla.com
       - macmini-r8-143.test.releng.mdc1.mozilla.com
@@ -190,10 +193,6 @@ groups:
       - macmini-r8-190.test.releng.mdc1.mozilla.com
       - macmini-r8-191.test.releng.mdc1.mozilla.com
       - macmini-r8-192.test.releng.mdc1.mozilla.com
-      - macmini-r8-193.test.releng.mdc1.mozilla.com
-      - macmini-r8-194.test.releng.mdc1.mozilla.com
-      - macmini-r8-201.test.releng.mdc1.mozilla.com
-      - macmini-r8-202.test.releng.mdc1.mozilla.com
       - macmini-r8-203.test.releng.mdc1.mozilla.com
       - macmini-r8-204.test.releng.mdc1.mozilla.com
       - macmini-r8-205.test.releng.mdc1.mozilla.com
@@ -250,7 +249,8 @@ groups:
 
   - name: gecko-1-b-osx-1015
     targets:
-      - macmini-r8-138.test.releng.mdc1.mozilla.com
+      - macmini-r8-193.test.releng.mdc1.mozilla.com
+      - macmini-r8-194.test.releng.mdc1.mozilla.com
       - macmini-r8-195.test.releng.mdc1.mozilla.com
       - macmini-r8-196.test.releng.mdc1.mozilla.com
       - macmini-r8-197.test.releng.mdc1.mozilla.com
@@ -259,10 +259,10 @@ groups:
 
   - name: gecko-3-b-osx-1015
     targets:
-      - macmini-r8-139.test.releng.mdc1.mozilla.com
-      - macmini-r8-140.test.releng.mdc1.mozilla.com
       - macmini-r8-198.test.releng.mdc1.mozilla.com
       - macmini-r8-199.test.releng.mdc1.mozilla.com
       - macmini-r8-200.test.releng.mdc1.mozilla.com
+      - macmini-r8-201.test.releng.mdc1.mozilla.com
+      - macmini-r8-202.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_3_b_osx_1015


### PR DESCRIPTION
re: discussion with releng and checking queue times for the last few months, https://sql.telemetry.mozilla.org/queries/80593?p_workerType=%28%27gecko-3-b-osx-1015%27%2C%27gecko-1-b-osx-1015%27%29#199884
I want to:

* add 1 worker to the gecko-3-b-osx-1015 pool to reduce queue times.
* consolidate to a single physical grouping of workers in sequence {193..202}
