### PR TITLE
CircleCI: add no_output_timeout option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,9 @@ jobs:
     steps:
       - checkout
       - run: BUNDLE_GEMFILE=.gemfile bundle install
-      - run: BUNDLE_GEMFILE=.gemfile KITCHEN_YAML=.kitchen.docker.yml bundle exec kitchen converge << parameters.kitchen_target >>
+      - run:
+          command: BUNDLE_GEMFILE=.gemfile KITCHEN_YAML=.kitchen.docker.yml bundle exec kitchen converge << parameters.kitchen_target >>
+          no_output_timeout: 30m
       - run: BUNDLE_GEMFILE=.gemfile KITCHEN_YAML=.kitchen.docker.yml bundle exec kitchen verify << parameters.kitchen_target >>
 
 workflows:


### PR DESCRIPTION
`apt install` is timing out on the linux convergence test occasionally. 

Try to avoid that by increasing the 'timeout if no output' option. It defaults to 10m.