### PR TITLE
bump scriptworker-scripts to 8f95f3b92777e6238c4e97b045e87d782f4679d4

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -122,7 +122,7 @@ scriptworker_config:
         verify_cot_signature: true
         worker_type: 'signing-mac-v1'
         scriptworker_revision: "a76a16da95e0d2483907b8a327b7a3f69743fbff"
-        scriptworker_scripts_revision: "0ac27f13cc443cdadbaa715442ee720aec1da7a7"
+        scriptworker_scripts_revision: "8f95f3b92777e6238c4e97b045e87d782f4679d4"
     tb-prod:
         tb_taskcluster_scope_prefix: 'project:comm:thunderbird:releng:signing:'
         sign_chain_of_trust: true
@@ -130,7 +130,7 @@ scriptworker_config:
         verify_cot_signature: true
         worker_type: 'tb-signing-mac-v1'
         scriptworker_revision: "a76a16da95e0d2483907b8a327b7a3f69743fbff"
-        scriptworker_scripts_revision: "0ac27f13cc443cdadbaa715442ee720aec1da7a7"
+        scriptworker_scripts_revision: "8f95f3b92777e6238c4e97b045e87d782f4679d4"
     dep:
         taskcluster_scope_prefix: 'project:releng:signing:'
         tb_taskcluster_scope_prefix: 'project:comm:thunderbird:releng:signing:'
@@ -139,7 +139,7 @@ scriptworker_config:
         verify_cot_signature: false
         worker_type: 'depsigning-mac-v1'
         scriptworker_revision: "a76a16da95e0d2483907b8a327b7a3f69743fbff"
-        scriptworker_scripts_revision: "0ac27f13cc443cdadbaa715442ee720aec1da7a7"
+        scriptworker_scripts_revision: "8f95f3b92777e6238c4e97b045e87d782f4679d4"
 
 poller_config:
     ff-prod:


### PR DESCRIPTION
This is to enable `notarization_poller` to obey a timeout (https://github.com/mozilla-releng/scriptworker-scripts/pull/369)

@escapewindow 