### PR TITLE
Bug1714200 m1 arm64 native

### DIFF
--- a/data/roles/gecko_t_osx_1100_m1.yaml
+++ b/data/roles/gecko_t_osx_1100_m1.yaml
@@ -9,7 +9,7 @@ worker_metadata:
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
 worker:
-  taskcluster_version: 40.0.3
+  taskcluster_version: 44.0.0
   provider_type: standalone
   worker_pool_id: releng-hardware/gecko-t-osx-1100-m1
   worker_group: macstadium-vegas
@@ -37,6 +37,7 @@ packages_classes:
   - wget
   - xcode_cmd_line_tools
   - zstandard
+  - telegraf
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
@@ -44,12 +45,13 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.7.9
+packages::python3::version: 3.9.6
 packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::xcode_cmd_line_tools::version: '12.2'
 packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
 
 # Talos class parameters
 talos::user: cltbld

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -9,7 +9,7 @@ worker_metadata:
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
 worker:
-  taskcluster_version: 40.0.3
+  taskcluster_version: 44.0.0
   provider_type: standalone
   worker_pool_id: releng-hardware/gecko-t-osx-1100-m1-staging
   worker_group: macstadium-vegas

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -37,6 +37,7 @@ packages_classes:
   - wget
   - xcode_cmd_line_tools
   - zstandard
+  - telegraf
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
@@ -50,6 +51,7 @@ packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::xcode_cmd_line_tools::version: '12.2'
 packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
 
 # Talos class parameters
 talos::user: cltbld

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -44,7 +44,7 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.7.9
+packages::python3::version: 3.9.6
 packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -18,7 +18,7 @@ class packages::mercurial (
     # libdir = '../../Library/Python/2.7/site-packages/'   # 5.1 pkg hg (LIBDIR)
     # libdir = '../../../Library/Python/2.7/site-packages' # 5.5+ pkg hg
     if ! '11' == $facts['os']['macosx']['version']['major']
-       and $version == '5.1' {
+      and $version == '5.1' {
         file { '/usr/Library':
             ensure  => 'link',
             target  => '/Library',

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -17,7 +17,7 @@ class packages::mercurial (
 
     # libdir = '../../Library/Python/2.7/site-packages/'   # 5.1 pkg hg (LIBDIR)
     # libdir = '../../../Library/Python/2.7/site-packages' # 5.5+ pkg hg
-    if ! '11' == $facts['os']['macosx']['version']['major'] \
+    if ! '11' == $facts['os']['macosx']['version']['major']
        and $version == '5.1' {
         file { '/usr/Library':
             ensure  => 'link',

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -15,14 +15,10 @@ class packages::mercurial (
         type                => 'pkg',
     }
 
-    # pkg installs /usr/local/bin/hg
-    # which looks for the mercurial packages in:
-    # libdir = '../../Library/Python/2.7/site-packages/'
-    # but installs them in:
-    # /Library/Python/2.7/site-packages/
-    # So, link /Library under /usr to make hg find it.
-    # Not needed for bigsur on M1
-    if ! '11' == $facts['os']['macosx']['version']['major'] {
+    # libdir = '../../Library/Python/2.7/site-packages/'   # 5.1 pkg hg (LIBDIR)
+    # libdir = '../../../Library/Python/2.7/site-packages' # 5.5+ pkg hg
+    if ! '11' == $facts['os']['macosx']['version']['major'] \
+       and $version == '5.1' {
         file { '/usr/Library':
             ensure  => 'link',
             target  => '/Library',

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -17,11 +17,11 @@ class packages::mercurial (
 
     # pkg installs /usr/local/bin/hg
     # which looks for the mercurial packages in:
-    # libdir = '../../Library/Python/2.7/site-packages/'
-    # but installs them in:
+    # libdir = '../../Library/Python/2.7/site-packages/'   # 5.1 pkg hg (LIBDIR)
+    # libdir = '../../../Library/Python/2.7/site-packages' # 5.5+ pkg hg
+    # On 10.14, we install hg 5.1 which is off by one for site-packages:
     # /Library/Python/2.7/site-packages/
     # So, link /Library under /usr to make hg find it.
-    # Not needed for bigsur on M1
     if member(['10.14'], $facts['os']['macosx']['version']['major']) {
         file { '/usr/Library':
             ensure  => 'link',

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -22,7 +22,7 @@ class packages::mercurial (
     # /Library/Python/2.7/site-packages/
     # So, link /Library under /usr to make hg find it.
     # Not needed for bigsur on M1
-    if ! member(['10.15', '11.0', '11.1', '11.2'], $facts['os']['macosx']['version']['major']) {
+    if ! '11' == $facts['os']['macosx']['version']['major'] {
         file { '/usr/Library':
             ensure  => 'link',
             target  => '/Library',

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -7,9 +7,9 @@ class packages::telegraf (
 ) {
     # arm64 if Apple processor
     if /^Apple.*/ in $facts['processors']['models'] {
-        $suffix = "-arm64"
+        $suffix = '-arm64'
     } else {
-        $suffix = ""
+        $suffix = ''
     }
 
     packages::macos_package_from_s3 { "telegraf-${version}${suffix}.dmg":

--- a/modules/packages/manifests/telegraf.pp
+++ b/modules/packages/manifests/telegraf.pp
@@ -2,9 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class packages::telegraf {
+class packages::telegraf (
+    Pattern[/^\d+\.\d+\.\d+_?\d*$/] $version = '1.12.3',
+) {
+    # arm64 if Apple processor
+    if /^Apple.*/ in $facts['processors']['models'] {
+        $suffix = "-arm64"
+    } else {
+        $suffix = ""
+    }
 
-    packages::macos_package_from_s3 { 'telegraf-1.12.3.dmg':
+    packages::macos_package_from_s3 { "telegraf-${version}${suffix}.dmg":
         private             => false,
         os_version_specific => false,
         type                => 'dmg',

--- a/modules/telegraf/manifests/init.pp
+++ b/modules/telegraf/manifests/init.pp
@@ -40,7 +40,7 @@ class telegraf (
         },
         puppetagent => {
             location => $facts['os']['name'] ? {
-                'Darwin' => '/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml',
+                'Darwin' => '/opt/puppetlabs/puppet/public/last_run_summary.yaml',
                 default  => '/var/lib/puppet/state/last_run_summary.yaml',
             },
         },

--- a/modules/worker_runner/manifests/init.pp
+++ b/modules/worker_runner/manifests/init.pp
@@ -91,10 +91,8 @@ class worker_runner (
                 $launch_plist = "/Users/${task_user}/Library/LaunchAgents/org.mozilla.worker-runner.plist"
             }
 
-            # note copied from packages python3:
-            # As of puppet 7.0.0, facts.os.architecture still reports the M1 arm64 hardware as x86_6
-            # therfore, we check the mac model instead
-            if $facts['system_profiler']['model_identifier'] == 'Macmini9,1' {
+            # arm64 if Apple processor
+            if /^Apple.*/ in $facts['processors']['models'] {
                 $arch_name = "arm64"
             } else {
                 $arch_name = "amd64"

--- a/modules/worker_runner/manifests/init.pp
+++ b/modules/worker_runner/manifests/init.pp
@@ -93,9 +93,9 @@ class worker_runner (
 
             # arm64 if Apple processor
             if /^Apple.*/ in $facts['processors']['models'] {
-                $arch_name = "arm64"
+                $arch_name = 'arm64'
             } else {
-                $arch_name = "amd64"
+                $arch_name = 'amd64'
             }
 
             $taskcluster_binaries = [ 'start-worker', 'generic-worker-multiuser', 'generic-worker-simple', 'livelog', 'taskcluster-proxy' ]


### PR DESCRIPTION
macmini m1 apple silicon native firefox testing
* arm64 python3 3.9.6 from s3 (from python.org)
* arm64 taskcluster binaries 44.0.0 from s3 (latest release; works with services current at v43.2.0)
* telegraf (monitoring and system+taskcluster logs) -- full configuration in a later PR
  * fixed path to puppet last_run_summary.yaml