### PR TITLE
Include VAULT env in puppet apply script (to be merged direcly to production-mac-signing)

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -12,6 +12,9 @@ ROLE_FILE='/etc/puppet_role'
 PUPPET_BIN='/opt/puppetlabs/bin/puppet'
 FACTER_BIN='/opt/puppetlabs/bin/facter'
 FQDN=$(${FACTER_BIN} networking.fqdn)
+VAULT_ADDR=http://127.0.0.1:8200
+# If token doesn't exist, continue
+VAULT_TOKEN="$(cat /etc/vault_token 2> /dev/null)"
 
 export LANG=en_US.UTF-8
 
@@ -149,7 +152,7 @@ function run_puppet {
 
     PUPPET_OPTIONS=("--modulepath=${WORKING_DIR}/modules:${WORKING_DIR}/r10k_modules" '--hiera_config=./hiera.yaml' '--logdest=console' '--color=false' '--detailed-exitcodes' './manifests/')
     SECONDS=0
-    $PUPPET_BIN apply "${PUPPET_OPTIONS[@]}" 2>&1 | tee "${TMP_LOG}"
+    VAULT_ADDR=$VAULT_ADDR VAULT_TOKEN=$VAULT_TOKEN $PUPPET_BIN apply "${PUPPET_OPTIONS[@]}" 2>&1 | tee "${TMP_LOG}"
     PUPPET_RUN_DURATION=$SECONDS
     retval=$?
     # just in case, if there were any errors logged, flag it as an error run


### PR DESCRIPTION
 This PR is a single file fix to the run-puppet.sh script on darwin.  It matches what is on the master branch already.  The plan is to merge this directly to the production-mac-signing branch and then manually puppet apply each signing host against that branch in order to fix the current broken puppet state.  Once all the signing hosts are running puppet successfully, we should be able to safely merge master into the production-mac-signing branch.