### PR TITLE
macmini vault user+pass

### DIFF
--- a/bolt-project.yaml
+++ b/bolt-project.yaml
@@ -4,3 +4,6 @@ modulepath:
 - "./modules"
 - "./r10k_modules"
 concurrency: 8
+plugins:
+  vault:
+    version: 2

--- a/inventory.d/macmini-m1.yaml
+++ b/inventory.d/macmini-m1.yaml
@@ -1,5 +1,15 @@
 ---
 name: macmini-m1
+config:
+  ssh:
+    username:
+      _plugin: vault
+      path: hiera/common/macmini_m1
+      field: username
+    password:
+      _plugin: vault
+      path: hiera/common/macmini_m1
+      field: password
 groups:
   - name: gecko-t-osx-1100-m1-dhouse
     targets:

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -1,5 +1,15 @@
 ---
 name: macmini-r8
+config:
+  ssh:
+    username:
+      _plugin: vault
+      path: hiera/common/macmini_r8
+      field: username
+    password:
+      _plugin: vault
+      path: hiera/common/macmini_r8
+      field: password
 groups:
   - name: gecko-t-osx-1015-r8
     targets:


### PR DESCRIPTION
What do you think about adding the admin user+pass for the macminis into vault and then it can be used like:
```
$ export VAULT_ADDR="https://vault.relops.mozops.net:8200"
$ export VAULT_SKIP_VERIFY=false
$ vault login -method=oidc role="hiera_admin"
$ export VAULT_TOKEN=$(cat ~/.vault-token)
$ export VAULT_CACERT=/etc/ssl/cert.pem
$ bolt command run "hostname; date; uptime" --targets macmini-m1-10.test.releng.mslv.mozilla.com
[...]
Finished on macmini-m1-10.test.releng.mslv.mozilla.com:
  macmini-m1-10.local
  Wed Oct 13 16:35:59 GMT 2021
  16:35  up 16 mins, 1 user, load averages: 1.52 1.69 1.50                                                                                                                                    Successful on 1 target: macmini-m1-10.test.releng.mslv.mozilla.com
Ran on 1 target in 1.55 sec
```
