### PR TITLE
Bug 1736416 - Enable hg sparse extension on Windows 10 2004 workers

### DIFF
--- a/modules/win_mozilla_build/files/mercurial.ini
+++ b/modules/win_mozilla_build/files/mercurial.ini
@@ -3,6 +3,7 @@ mq=
 purge=
 rebase=
 share=
+sparse=
 robustcheckout=C:\mozilla-build\robustcheckout.py
 
 [diff]


### PR DESCRIPTION
Enable the sparse hg extension to fix CI failures on Windows 10 x64 2004 workers.