### PR TITLE
bug 1737566 - dep2 signing instance should use a dep2 dmg_prefix

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -45,7 +45,7 @@ scriptworker_users:
         - mac_sign_and_pkg
         - mac_geckodriver
         - mac_single_file
-      dmg_prefix: "dep1"
+      dmg_prefix: "dep2"
       worker_id_suffix: "b"
       cot_product: "firefox"
       widevine_filename: "widevine_dep.crt"


### PR DESCRIPTION
We hit an intermittent issue with hdiutil, trying to mount
`/tmp/dmg1-...` in the dep2 instance of dep-mac-v3-signing2.

The dmg prefix is there so we don't clobber other workers' mounts;
fixing the dep2 one to use dep2, rather than sharing dep1...