### PR TITLE
Make it so scriptworker{,-scripts} pulls revision

### DIFF
--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -144,7 +144,7 @@ define signing_worker (
     }
 
     vcsrepo { $scriptworker_clone_dir:
-        ensure   => present,
+        ensure   => latest,
         provider => git,
         source   => 'https://github.com/mozilla-releng/scriptworker',
         revision => $worker_config['scriptworker_revision'],
@@ -163,7 +163,7 @@ define signing_worker (
     }
 
     vcsrepo { $scriptworker_scripts_clone_dir:
-        ensure   => present,
+        ensure   => latest,
         provider => git,
         source   => 'https://github.com/mozilla-releng/scriptworker-scripts',
         revision => $worker_config['scriptworker_scripts_revision'],


### PR DESCRIPTION
[Documentation](https://forge.puppet.com/modules/puppetlabs/vcsrepo#git) indicates that `ensure` should be `latest` to make sure a `pull` happens, not quite clear that's the behavior, but worth trying.