### PR TITLE
RELENG-502 Update mac signing certs

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -37,6 +37,7 @@ scriptworker_users:
       worker_id_suffix: "a"
       cot_product: "firefox"
       widevine_filename: "widevine_dep.crt"
+      keychain_file: "certs/dep-signing.keychain"
     depbld2:
       home: /builds/dep2
       supported_behaviors:
@@ -48,6 +49,7 @@ scriptworker_users:
       worker_id_suffix: "b"
       cot_product: "firefox"
       widevine_filename: "widevine_dep.crt"
+      keychain_filename: "dep-signing.keychain"
     tbbld:
       home: /builds/tb-dep
       supported_behaviors:
@@ -60,6 +62,7 @@ scriptworker_users:
       worker_id_suffix: "tb"
       cot_product: "thunderbird"
       widevine_filename: "widevine_dep.crt"
+      keychain_filename: "dep-signing.keychain"
   tb-prod:
     cltbld:
       home: /builds/scriptworker
@@ -74,6 +77,7 @@ scriptworker_users:
       dmg_prefix: "prod"
       cot_product: "thunderbird"
       widevine_filename: "widevine_prod.crt"
+      keychain_filename: "mozilla.20220330.keychain"
       ed_key_filename: "ed25519_privkey"
       notarization_users:
         - notary1
@@ -100,6 +104,7 @@ scriptworker_users:
       dmg_prefix: "prod"
       cot_product: "firefox"
       widevine_filename: "widevine_prod.crt"
+      keychain_filename: "mozilla.20220330.keychain"
       ed_key_filename: "ed25519_privkey"
       notarization_users:
         - notary1

--- a/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
+++ b/modules/roles_profiles/manifests/profiles/mac_v3_signing.pp
@@ -64,6 +64,7 @@ class roles_profiles::profiles::mac_v3_signing {
                     widevine_user       => $widevine_user,
                     widevine_key        => $widevine_key,
                     widevine_filename   => $user_data['widevine_filename'],
+                    keychain_filename   => $user_data['keychain_filename'],
                     worker_config       => $worker_config,
                     role_config         => $role_config,
                     notarization_users  => $user_data['notarization_users'],

--- a/modules/signing_worker/manifests/init.pp
+++ b/modules/signing_worker/manifests/init.pp
@@ -14,6 +14,7 @@ define signing_worker (
     String $widevine_user,
     String $widevine_key,
     String $widevine_filename,
+    String $keychain_filename,
     Hash $worker_config,
     Hash $role_config,
     Hash $poller_config,
@@ -53,6 +54,7 @@ define signing_worker (
       default => "${certs_dir}/${ed_key_filename}",
     }
     $widevine_cert_path = "${certs_dir}/${widevine_filename}"
+    $keychain_path = "${certs_dir}/${keychain_filename}"
 
     signing_worker::system_user { "create_user_${user}":
         user       => $user,

--- a/modules/signing_worker/templates/script_config.yaml.erb
+++ b/modules/signing_worker/templates/script_config.yaml.erb
@@ -17,7 +17,7 @@ mac_config:
 <% @role_config.each do |role, role_data| -%>
     <%= role %>:
         notarize_type: single_zip
-        signing_keychain: "<%= @certs_dir %>/<%= role %>-signing.keychain"
+        signing_keychain: "<%= @keychain_path %>"
         supported_behaviors:
 <% @supported_behaviors.each do |behavior| -%>
             - <%= behavior %>


### PR DESCRIPTION
Updates how keychain naming convention, this allows easier keychain rollover in the future by updating keychain path in user data.