### PR TITLE
Bug 1595217: ensure reboots between tasks in generic-worker config

### DIFF
--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -16,7 +16,7 @@
   "livelogKey": "<%= @livelog_key %>",
   "livelogPUTPort": 60022,
   "livelogSecret": "<%= @livelog_secret %>",
-  "numberOfTasksToRun": 1,
+  "numberOfTasksToRun": 0,
   "privateIP": "",
   "provisionerId": "releng-hardware",
   "publicIP": "<%= @ipaddress %>",

--- a/modules/linux_generic_worker/templates/generic-worker.config.erb
+++ b/modules/linux_generic_worker/templates/generic-worker.config.erb
@@ -10,7 +10,7 @@
   "instanceId": "",
   "instanceType": "",
   "livelogExecutable": "livelog",
-  "numberOfTasksToRun": 1,
+  "numberOfTasksToRun": 0,
   "privateIP": "",
   "provisionerId": "releng-hardware",
   "publicIP": "<%= @ipaddress %>",

--- a/modules/linux_generic_worker/templates/worker-runner-config.yml.erb
+++ b/modules/linux_generic_worker/templates/worker-runner-config.yml.erb
@@ -20,7 +20,7 @@ workerConfig:
     ed25519SigningKeyLocation:        "<%= @ed25519_signing_key %>"
     idleTimeoutSecs:                  345600
     livelogExecutable:                "/usr/local/bin/livelog"
-    numberOfTasksToRun:               1
+    numberOfTasksToRun:               0
     provisionerId:                    "releng-hardware"
     publicIP:                         "<%= @ipaddress %>"
     requiredDiskSpaceMegabytes:       10240

--- a/modules/worker_runner/templates/worker_runner_config.yaml.erb
+++ b/modules/worker_runner/templates/worker_runner_config.yaml.erb
@@ -21,7 +21,7 @@ workerConfig:
   ed25519SigningKeyLocation: "<%= @ed25519_signing_key %>"
   idleTimeoutSecs: <%= @idle_timeout_secs %>
   livelogExecutable: "/usr/local/bin/livelog"
-  numberOfTasksToRun: 1
+  numberOfTasksToRun: 0
   publicIP: "<%= @facts['networking']['ip'] %>"
   requiredDiskSpaceMegabytes: 10240
   sentryProject: "generic-worker"


### PR DESCRIPTION
See [bug 1595217 comment 398](https://bugzilla.mozilla.org/show_bug.cgi?id=1595217#c398) for context. If `numberOfTasksToRun` is `1`, after running one task, macOS multiuser generic-worker will exit, and then be automatically restarted by its launch daemon. If set to `0`, it will create a new task user, and reboot the worker with an automatic console login to that new task user. This ensures that a new OS user is used for each task, and therefore that each task runs in a clean user environment.