### PR TITLE
Bug1595217 fix worker reboot

### DIFF
--- a/modules/linux_generic_worker/templates/generic-worker.config.erb
+++ b/modules/linux_generic_worker/templates/generic-worker.config.erb
@@ -10,7 +10,7 @@
   "instanceId": "",
   "instanceType": "",
   "livelogExecutable": "livelog",
-  "numberOfTasksToRun": 0,
+  "numberOfTasksToRun": 1,
   "privateIP": "",
   "provisionerId": "releng-hardware",
   "publicIP": "<%= @ipaddress %>",

--- a/modules/linux_generic_worker/templates/worker-runner-config.yml.erb
+++ b/modules/linux_generic_worker/templates/worker-runner-config.yml.erb
@@ -20,7 +20,7 @@ workerConfig:
     ed25519SigningKeyLocation:        "<%= @ed25519_signing_key %>"
     idleTimeoutSecs:                  345600
     livelogExecutable:                "/usr/local/bin/livelog"
-    numberOfTasksToRun:               0
+    numberOfTasksToRun:               1
     provisionerId:                    "releng-hardware"
     publicIP:                         "<%= @ipaddress %>"
     requiredDiskSpaceMegabytes:       10240


### PR DESCRIPTION
the linux perf workers are not rebooting now:
```
[dhouse@t-linux64-ms-004 ~]$ uptime
 20:04:21 up  3:28,  1 user,  load average: 0.95, 1.14, 1.22
```
(actively running a task, and the last task resolved 78min ago): https://firefox-ci-tc.services.mozilla.com/provisioners/releng-hardware/worker-types/gecko-t-linux-talos-1804/workers/mdc1/t-linux64-ms-004?sortBy=started&sortDirection=desc

This will restore the previous configuration where it did reboot between tasks (prior to 3hr ago).