### PR TITLE
fix bitbar integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
   macos-1014: &1014
     macos:
-      xcode: 11.1.0
+      xcode: 11.7.0
   macos-1015: &1015
     macos:
       xcode: 12.4.0

--- a/test/integration/bitbar/inspec/bitbar_devicepool_spec.rb
+++ b/test/integration/bitbar/inspec/bitbar_devicepool_spec.rb
@@ -28,7 +28,7 @@ describe 'users' do
 end
 
 describe 'git repo' do
-  describe bash('cd /home/bitbar/mozilla-bitbar-devicepool && git status') do
+  describe bash("sudo -u bitbar bash -c 'cd /home/bitbar/mozilla-bitbar-devicepool && git status'") do
     its(:exit_status) { should eq 0 }
   end
 end


### PR DESCRIPTION
Windows tests are still broken (https://github.com/mozilla-platform-ops/ronin_puppet/issues/381 filed), but fixes bitbar and one mac suite.

notes:
- mac integration tests: was using an old version of Circle Xcode image