### PR TITLE
Don't loop forever in run-puppet.sh on mac

### DIFF
--- a/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-darwin-run-puppet.sh.erb
@@ -183,10 +183,18 @@ function run_puppet {
 
 block_on_network
 
-# Call the run_puppet function in a endless loop
-while ! run_puppet; do
-    echo "Puppet run failed; re-trying after 10m"
-    sleep 600
+# Call the run_puppet function in a loop
+MAX_PUPPET_ATTEMPTS=5
+for i in `seq $MAX_PUPPET_ATTEMPTS`; do
+    if run_puppet; then
+        break
+    fi
+    if [ $i -lt $MAX_PUPPET_ATTEMPTS ]; then
+        echo "Puppet run failed; re-trying after 10m"
+        sleep 600
+    else
+        exit 1
+    fi
 done
 
 # Touch the semaphore to allow launchd to start generic worker (if applicable)


### PR DESCRIPTION
When using the puppet::periodic class we can end up in a situation where
run-puppet.sh is buggy and instead of fixing itself on a later periodic
run when it pulls a fix from git, it just keeps failing until it's
manually killed or the host gets rebooted.

So limit the loop to 5 iterations, then give up.