### PR TITLE
test fixing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,18 @@ executors:
       xcode: 12.5.1
 
 commands:
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing credentials.
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
   install_macos_puppet:
     parameters:
       puppet_version:
@@ -221,6 +233,7 @@ jobs:
         type: string
     executor: docker-ruby
     steps:
+      - early_return_for_forked_pull_requests
       - export_env_vars
       - checkout
       - gem_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,16 +266,16 @@ workflows:
           requires:
             - pre_commit
             - r10k_install
-      - macos_integration_tests:
-          matrix:
-            parameters:
-              os: [macos-1015]
-              suite: ["default"]
-              role: ["gecko_t_osx_1015_r8"]
-          context: slack-secrets
-          requires:
-            - pre_commit
-            - r10k_install
+      # - macos_integration_tests:
+      #     matrix:
+      #       parameters:
+      #         os: [macos-1015]
+      #         suite: ["default"]
+      #         role: ["gecko_t_osx_1015_r8"]
+      #     context: slack-secrets
+      #     requires:
+      #       - pre_commit
+      #       - r10k_install
       - macos_integration_tests:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ executors:
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
   macos-1014: &1014
     macos:
-      xcode: 11.7.0
+      xcode: 11.7.0  # 9/1/22: this is now 10.15, no 10.14 images available
   macos-1015: &1015
     macos:
-      xcode: 12.4.0
+      xcode: 11.7.0  # 9/1/22: os x 10.15.5
   macos-1100: &1100
     macos:
-      xcode: 12.5.1
+      xcode: 13.2.1  # 9/1/22: os x 11.6.2
 
 commands:
   early_return_for_forked_pull_requests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
   macos-1014: &1014
     macos:
-      xcode: 11.7.0  # 9/1/22: this is now 10.15, no 10.14 images available
+      xcode: 11.7.0  # 9/1/22: os x 10.15.5, no 10.14 images available
   macos-1015: &1015
     macos:
       xcode: 11.7.0  # 9/1/22: os x 10.15.5
@@ -279,16 +279,16 @@ workflows:
           requires:
             - pre_commit
             - r10k_install
-      # - macos_integration_tests:
-      #     matrix:
-      #       parameters:
-      #         os: [macos-1015]
-      #         suite: ["default"]
-      #         role: ["gecko_t_osx_1015_r8"]
-      #     context: slack-secrets
-      #     requires:
-      #       - pre_commit
-      #       - r10k_install
+      - macos_integration_tests:
+          matrix:
+            parameters:
+              os: [macos-1015]
+              suite: ["default"]
+              role: ["gecko_t_osx_1015_r8"]
+          context: slack-secrets
+          requires:
+            - pre_commit
+            - r10k_install
       - macos_integration_tests:
           matrix:
             parameters:


### PR DESCRIPTION
Run OS X 10.14 builds on 10.15 since no 10.14 images are available on CCI. See https://mozilla-hub.atlassian.net/browse/RELOPS-235 and https://circleci.com/docs/testing-ios#supported-xcode-versions for more info.

Also short-circuits/auto-passes the windows tests on forked PRs (they will always fail due to no secrets being available). 
- The solution to get testing on Windows changes is to push the branch to mozilla-platform-ops/ronin-puppet and create a PR from the repo (then the tests can access secrets).
- We could also switch to windows docker images on windows executors (which wouldn't require secrets/credentials). https://circleci.com/docs/using-windows#windows-machine-executor-images