### PR TITLE
r8 1015: enable safaridriver

### DIFF
--- a/modules/macos_safaridriver/files/add-safari-permissions.sh
+++ b/modules/macos_safaridriver/files/add-safari-permissions.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-# from https://circleci.com/developer/orbs/orb/circleci/macos#commands-add-safari-permissions
+# from https://blog.bytesguy.com/enabling-remote-automation-in-safari-14
+#   and https://circleci.com/developer/orbs/orb/circleci/macos#commands-add-safari-permissions
 
 if csrutil status | grep -q 'disabled'; then
     epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))

--- a/modules/macos_safaridriver/files/add-safari-permissions.sh
+++ b/modules/macos_safaridriver/files/add-safari-permissions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+# from https://circleci.com/developer/orbs/orb/circleci/macos#commands-add-safari-permissions
+
+if csrutil status | grep -q 'disabled'; then
+    epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
+    macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+    if [[ $macos_major_version -le 10 ]]; then
+      defaults write com.apple.Safari AllowRemoteAutomation 1
+    else
+      tcc_service_accessibility="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAccessibility\",\"/usr/sbin/sshd\",1,2,4,1,0,\"UNUSED\",0,$epochdate);"
+      tcc_service_events="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier_type,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceAppleEvents\",\"/usr/sbin/sshd\",1,2,4,1,0,\"com.apple.systemevents\",0,$epochdate);"
+      sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+      sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_accessibility"
+      sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
+      sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_service_events"
+      osascript -e '
+        tell application "System Events"
+          tell application "Safari" to activate
+          delay 15
+          tell process "Safari"
+            set frontmost to true
+            delay 5
+            click menu item "Preferences…" of menu 1 of menu bar item "Safari" of menu bar 1
+            delay 5
+            click button "Advanced" of toolbar 1 of window 1
+            delay 5
+            tell checkbox "Show Develop menu in menu bar" of group 1 of group 1 of window 1
+              if value is 0 then click it
+              delay 5
+            end tell
+            click button 1 of window 1
+            delay 5
+            click menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
+            delay 5
+          end tell
+        end tell'
+    fi
+    sudo safaridriver --enable
+else
+    echo "Unable to add permissions! System Integrity Protection is enabled."
+    exit 1
+fi

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -14,14 +14,15 @@ class macos_safaridriver {
       }
 
       # non-admin users need to be in _webdeveloper group for safaridriver to work
-      # if not, `safaridriver --diagnose` will complain with:
-      #   'ERROR: safaridriver could not launch because it is not configured'.
+      #   - https://developer.apple.com/forums/thread/124461
+      #   - if not, `safaridriver --diagnose` will complain with:
+      #       'ERROR: safaridriver could not launch because it is not configured'
       #
       # dseditgroup preferred to dscl
       #   - https://superuser.com/questions/214004/how-to-add-user-to-a-group-from-mac-os-x-command-line
       #
       # TODO: pull out user as param, i.e. don't hardcode cltbld user
-      $group = ['_webdeveloper']
+      $group = '_webdeveloper'
       exec { "cltbld_group_${group}":
         command => "/usr/sbin/dseditgroup -o edit -a cltbld -t user ${group}",
         unless  => "/usr/bin/groups cltbld | /usr/bin/grep -q -w ${group}",

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -4,7 +4,7 @@ class macos_safaridriver {
       $the_script = '/usr/local/bin/add-safari-permissions.sh'
 
       file { $the_script:
-        content => file('macos_safaridriver/mac_desktop_image.py'),
+        content => file('macos_safaridriver/add-safari-permissions.sh'),
       }
 
       exec { 'execute script':

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -1,0 +1,19 @@
+class macos_safaridriver {
+  case $facts['os']['name'] {
+    'Darwin': {
+      $the_script = '/usr/local/bin/add-safari-permissions.sh'
+
+      file { $the_script:
+        content => file('macos_safaridriver/mac_desktop_image.py'),
+      }
+
+      exec { 'execute script':
+        command => $the_script,
+        require => File[$the_script],
+      }
+    }
+    default: {
+      fail("${facts['os']['name']} not supported")
+    }
+  }
+}

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -5,6 +5,7 @@ class macos_safaridriver {
 
       file { $the_script:
         content => file('macos_safaridriver/add-safari-permissions.sh'),
+        mode    => '0755'
       }
 
       exec { 'execute script':

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -5,12 +5,27 @@ class macos_safaridriver {
 
       file { $the_script:
         content => file('macos_safaridriver/add-safari-permissions.sh'),
-        mode    => '0755'
+        mode    => '0755',
       }
 
       exec { 'execute script':
         command => $the_script,
         require => File[$the_script],
+      }
+
+      # non-admin users need to be in _webdeveloper group for safaridriver to work
+      # if not, `safaridriver --diagnose` will complain with:
+      #   'ERROR: safaridriver could not launch because it is not configured'.
+      #
+      # dseditgroup preferred to dscl
+      #   - https://superuser.com/questions/214004/how-to-add-user-to-a-group-from-mac-os-x-command-line
+      #
+      # TODO: pull out user as param, i.e. don't hardcode cltbld user
+      $group = ['_webdeveloper']
+      exec { "cltbld_group_${group}":
+        command => "/usr/sbin/dseditgroup -o edit -a cltbld -t user ${group}",
+        unless  => "/usr/bin/groups cltbld | /usr/bin/grep -q -w ${group}",
+        require => User['cltbld'],
       }
     }
     default: {

--- a/modules/roles_profiles/manifests/profiles/safaridriver.pp
+++ b/modules/roles_profiles/manifests/profiles/safaridriver.pp
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::safaridriver {
+  case $facts['os']['name'] {
+    'Darwin': {
+      include macos_safaridriver
+    }
+    default: {
+      fail("${facts['os']['name']} not supported")
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
@@ -23,4 +23,5 @@ class roles_profiles::roles::gecko_t_osx_1015_r8 {
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::metrics
     include ::roles_profiles::profiles::worker
+    include ::roles_profiles::profiles::safaridriver
 }


### PR DESCRIPTION
see https://mozilla-hub.atlassian.net/browse/RELOPS-220

Testing:
- Not adding a inspec test as our test infrastructure uses this exact script already (CircleCI Mac instances use this)... so we wouldn't be testing anything.
- Confirmed that the script runs (locally and in CI). 
- Confirmed that the script does enable safaridriver by running manually and testing Selenium w/ Safari on a few hosts.
- Confirmed that selenium tests with Safari work on a r8 host as `cltbld` user.
  - Previous testing was with an admin account (that have the `_webdeveloper` group membership by default) was working, but not with normal account until group was added. 

---

simple test script:

```python
#!/usr/bin/env python3

import time
import unittest

from selenium import webdriver
from selenium.webdriver.common.by import By


class WebKitFeatureStatusTest(unittest.TestCase):
    def setUp(self):
        # self.driver = webdriver.Safari(executable_path="/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver")
        self.driver = webdriver.Safari()
        # self.driver = webdriver.Chrome("./chromedriver")
        # self.driver = webdriver.Firefox()

    def tearDown(self):
        # self.driver.quit()
        self.driver.close()

    def test_feature_status_page_search(self):
        self.driver.get("https://en.wikipedia.org/wiki/Apple")

        time.sleep(2)

        # look for Malus domestica
        content = self.driver.find_element("id", "bodyContent")
        # content = self.driver.find_element(By.XPATH, "/html/body")

        # print(content.text)
        self.assertTrue("Malus domestica" in content.text)


if __name__ == "__main__":
    unittest.main()

```