### PR TITLE
Change from os.release.full to custom_win_os_version

### DIFF
--- a/modules/roles_profiles/manifests/profiles/windows_worker_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/windows_worker_runner.pp
@@ -38,20 +38,20 @@ class roles_profiles::profiles::windows_worker_runner {
             $provider              = lookup('win-worker.taskcluster.worker_runner.provider')
             $implementation        = lookup('win-worker.taskcluster.worker_runner.implementation')
 
-
-            # HERE
-            case $facts['os']['release']['full'] {
-                'win 10', '2012 R2': {
+            case $facts['custom_win_os_version'] {
+                'win_11_2009': {
+                    $init = 'task-user-init-win11.cmd'
+                }
+                'win_2012': {
                     $init = 'task-user-init-win10.cmd'
                 }
-                'win 11': {
-                    $init = 'task-user-init-win11.cmd'
+                'win_10_2004': {
+                    $init = 'task-user-init-win10.cmd'
                 }
                 default: {
                     $init = undef
-                }
+               }
             }
-            # HERE
 
             case $provider {
                 'standalone': {


### PR DESCRIPTION
Fixes `2022-10-31 17:42:38 +0000 Puppet (err): Evaluation Error: Error while evaluating a Resource Statement, Class[Win_taskcluster::Generic_worker]: parameter 'init_file' expects a String value, got Undef (file: C:/ronin/modules/roles_profiles/manifests/profiles/windows_worker_runner.pp, line: 82, column: 13) on node pkrvmfpnrfv75c2.c5yzhvpebboutpmq4gutoqblge.gx.internal.cloudapp.net ` where the case statement is incorrect.