### PR TITLE
fix g-w reboot issue

### DIFF
--- a/modules/generic_worker/templates/generic-worker.config.erb
+++ b/modules/generic_worker/templates/generic-worker.config.erb
@@ -16,7 +16,7 @@
   "livelogKey": "<%= @livelog_key %>",
   "livelogPUTPort": 60022,
   "livelogSecret": "<%= @livelog_secret %>",
-  "numberOfTasksToRun": 0,
+  "numberOfTasksToRun": 1,
   "privateIP": "",
   "provisionerId": "releng-hardware",
   "publicIP": "<%= @ipaddress %>",

--- a/modules/worker_runner/templates/worker_runner_config.yaml.erb
+++ b/modules/worker_runner/templates/worker_runner_config.yaml.erb
@@ -21,7 +21,7 @@ workerConfig:
   ed25519SigningKeyLocation: "<%= @ed25519_signing_key %>"
   idleTimeoutSecs: <%= @idle_timeout_secs %>
   livelogExecutable: "/usr/local/bin/livelog"
-  numberOfTasksToRun: 0
+  numberOfTasksToRun: 1
   publicIP: "<%= @facts['networking']['ip'] %>"
   requiredDiskSpaceMegabytes: 10240
   sentryProject: "generic-worker"


### PR DESCRIPTION
These workers/configs are for simple g-w, not multiuser. We need this set to 1, or they will run indefinitely.

Currently affects r8 mac minis.