### PR TITLE
Extract Zip to systemdrive

### DIFF
--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -21,12 +21,14 @@ class win_packages::drivers::nvidia_grid (
   file { "${pkgdir}\\${zip_name}":
     source => "${srcloc}/${zip_name}",
   }
+
+  exec { 'grid_unzip':
+    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+    creates  => $setup_exe,
+    provider => powershell,
+  }
+
   if $facts['custom_win_gpu'] == 'yes' {
-    exec { 'grid_unzip':
-      command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
-      creates  => $setup_exe,
-      provider => powershell,
-    }
     exec { 'grid_install':
       command     => "${facts['custom_win_system32']}\\cmd.exe /c ${setup_exe} -s -noreboot",
       subscribe   => Exec['grid_unzip'],

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -6,11 +6,8 @@ class win_packages::drivers::nvidia_grid (
   String $driver_name,
   String $srcloc
 ) {
-  require win_packages::sevenzip
-
   $setup_exe   = "${facts['custom_win_systemdrive']}\\${driver_name}\\setup.exe"
   $working_dir = "${facts['custom_win_systemdrive']}\\${driver_name}"
-  $seven_zip   = "\"${facts['custom_win_programfiles']}\\7-Zip\\7z.exe\""
   $zip_name    = "${driver_name}.zip"
   $pkgdir      = $facts['custom_win_temp_dir']
   $src_file    = "\"${pkgdir}\\${zip_name}\""

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -25,30 +25,10 @@ class win_packages::drivers::nvidia_grid (
     source => "${srcloc}/${zip_name}",
   }
   if $facts['custom_win_gpu'] == 'yes' {
-    case $facts['custom_win_os_version'] {
-      'win_11_2009': {
-        exec { 'grid_unzip':
-          command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
-          creates  => $setup_exe,
-          provider => powershell,
-        }
-      }
-      'win_10_2004': {
-        exec { 'grid_unzip':
-          command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-          creates => $setup_exe,
-        }
-      }
-      default: {
-        exec { 'grid_unzip':
-          command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-          creates => $setup_exe,
-        }
-      }
-    }
     exec { 'grid_unzip':
-      command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-      creates => $setup_exe,
+      command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+      creates  => $setup_exe,
+      provider => powershell,
     }
     exec { 'grid_install':
       command     => "${facts['custom_win_system32']}\\cmd.exe /c ${setup_exe} -s -noreboot",

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -7,7 +7,6 @@ class win_packages::drivers::nvidia_grid (
   String $srcloc
 ) {
   $setup_exe   = "${facts['custom_win_systemdrive']}\\${driver_name}\\setup.exe"
-  $working_dir = "${facts['custom_win_systemdrive']}\\${driver_name}"
   $zip_name    = "${driver_name}.zip"
   $pkgdir      = $facts['custom_win_temp_dir']
   $src_file    = "\"${pkgdir}\\${zip_name}\""
@@ -15,15 +14,12 @@ class win_packages::drivers::nvidia_grid (
   # copy the installtion file during image build
   # only install if it is a gpu worker with gpu in the pool name
 
-  file { $working_dir:
-    ensure => directory,
-  }
   file { "${pkgdir}\\${zip_name}":
     source => "${srcloc}/${zip_name}",
   }
 
   exec { 'grid_unzip':
-    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${facts['custom_win_systemdrive']}\\",
     creates  => $setup_exe,
     provider => powershell,
   }


### PR DESCRIPTION
Currently, it's creating a folder `C:\472.39_grid_win11_win10_64bit_Azure-SWL\472.39_grid_win11_win10_64bit_Azure-SWL` instead of `C:\472.39_grid_win11_win10_64bit_Azure-SWL`

This fixes it so that it installs to `C:\472.39_grid_win11_win10_64bit_Azure-SWL`