### PR TITLE
Re-work some install packages

### DIFF
--- a/data/roles/win11642009azure.yaml
+++ b/data/roles/win11642009azure.yaml
@@ -39,11 +39,12 @@ win-worker:
   azure:
     vm_agent:
       version: '2.7.41491.1057_2205251057.fre'
-      name: "Windows Azure VM Agent - 2.7.41491.1057"
+      display_name: "Windows Azure VM Agent - 2.7.41491.1057"
   git:
     version: '2.36.1'
   gpu:
     name: "472.39_grid_win11_win10_64bit_Azure-SWL"
+    display_name: "NVIDIA Graphics Driver 472.39"
   hg:
     version: '6.2.1'
   nssm:

--- a/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
+++ b/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
@@ -6,7 +6,7 @@ class roles_profiles::profiles::azure_vm_agent {
   case $facts['os']['name'] {
     'Windows': {
       $agent_version = lookup('win-worker.azure.vm_agent.version')
-      $package       = lookup('win-worker.azure.vm_agent.name')
+      $package       = lookup('win-worker.azure.vm_agent.display_name')
       $msi           = "WindowsAzureVmAgent.${agent_version}.msi"
 
       class { 'win_packages::azure_vm_agent':

--- a/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
+++ b/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
@@ -3,21 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::profiles::azure_vm_agent {
+  case $facts['os']['name'] {
+    'Windows': {
+      $agent_version = lookup('win-worker.azure.vm_agent.version')
+      $package       = lookup('win-worker.azure.vm_agent.name')
+      $msi           = "WindowsAzureVmAgent.${agent_version}.msi"
 
-    case $facts['os']['name'] {
-        'Windows': {
-
-            $agent_version = lookup('win-worker.azure.vm_agent.version')
-            $package       = "Windows Azure VM Agent - ${agent_version}"
-            $msi           = "WindowsAzureVmAgent.${agent_version}.msi"
-
-            class { 'win_packages::azure_vm_agent':
-                package => $package,
-                msi     => $msi,
-            }
-        }
-        default: {
-            fail("${$facts['os']['name']} not supported")
-        }
+      class { 'win_packages::azure_vm_agent':
+        package => $package,
+        msi     => $msi,
+      }
     }
+    default: {
+      fail("${$facts['os']['name']} not supported")
+    }
+  }
 }

--- a/modules/roles_profiles/manifests/profiles/gpu_drivers.pp
+++ b/modules/roles_profiles/manifests/profiles/gpu_drivers.pp
@@ -7,14 +7,16 @@ class roles_profiles::profiles::gpu_drivers {
     ## Use https://docs.nvidia.com/grid/index.html & https://github.com/Azure/azhpc-extensions/blob/master/NvidiaGPU/resources.json as reference
     'win_11_2009':{
       class { 'win_packages::drivers::nvidia_grid':
-        driver_name => lookup('win-worker.gpu.name'),
-        srcloc      => lookup('windows.s3.ext_pkg_src'),
+        display_name => lookup('win-worker.gpu.display_name'),
+        driver_name  => lookup('win-worker.gpu.name'),
+        srcloc       => lookup('windows.s3.ext_pkg_src'),
       }
     }
     'win_10_2004':{
       class { 'win_packages::drivers::nvidia_grid':
-        driver_name => '391.81_grid_win10_server2016_64bit_international',
-        srcloc      => lookup('windows.s3.ext_pkg_src'),
+        display_name => lookup('win-worker.gpu.display_name'),
+        driver_name  => '391.81_grid_win10_server2016_64bit_international',
+        srcloc       => lookup('windows.s3.ext_pkg_src'),
       }
     }
 

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -4,6 +4,7 @@
 
 class win_packages::drivers::nvidia_grid (
   String $driver_name,
+  String $display_name,
   String $srcloc
 ) {
   $setup_exe   = "${facts['custom_win_systemdrive']}\\${driver_name}\\setup.exe"
@@ -25,10 +26,10 @@ class win_packages::drivers::nvidia_grid (
   }
 
   if $facts['custom_win_gpu'] == 'yes' {
-    exec { 'grid_install':
-      command     => "${facts['custom_win_system32']}\\cmd.exe /c ${setup_exe} -s -noreboot",
-      subscribe   => Exec['grid_unzip'],
-      refreshonly => true,
+    package { $display_name :
+      ensure          => '472.39',
+      source          => $setup_exe,
+      install_options => ['-s','-noreboot'],
     }
   }
 }

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -21,12 +21,14 @@ class win_packages::drivers::nvidia_grid (
   file { "${pkgdir}\\${zip_name}":
     source => "${srcloc}/${zip_name}",
   }
+
+  exec { 'grid_unzip':
+    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+    creates  => $setup_exe,
+    provider => powershell,
+  }
+
   if $facts['custom_win_gpu'] == 'yes' {
-    exec { 'grid_unzip':
-      command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
-      creates  => $setup_exe,
-      provider => powershell,
-    }
     exec { 'grid_install':
       command     => "${facts['custom_win_system32']}\\cmd.exe /c ${setup_exe} -s -noreboot",
       subscribe   => Exec['grid_unzip'],

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -6,11 +6,8 @@ class win_packages::drivers::nvidia_grid (
   String $driver_name,
   String $srcloc
 ) {
-  require win_packages::sevenzip
-
   $setup_exe   = "${facts['custom_win_systemdrive']}\\${driver_name}\\setup.exe"
   $working_dir = "${facts['custom_win_systemdrive']}\\${driver_name}"
-  $seven_zip   = "\"${facts['custom_win_programfiles']}\\7-Zip\\7z.exe\""
   $zip_name    = "${driver_name}.zip"
   $pkgdir      = $facts['custom_win_temp_dir']
   $src_file    = "\"${pkgdir}\\${zip_name}\""

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -25,30 +25,10 @@ class win_packages::drivers::nvidia_grid (
     source => "${srcloc}/${zip_name}",
   }
   if $facts['custom_win_gpu'] == 'yes' {
-    case $facts['custom_win_os_version'] {
-      'win_11_2009': {
-        exec { 'grid_unzip':
-          command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
-          creates  => $setup_exe,
-          provider => powershell,
-        }
-      }
-      'win_10_2004': {
-        exec { 'grid_unzip':
-          command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-          creates => $setup_exe,
-        }
-      }
-      default: {
-        exec { 'grid_unzip':
-          command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-          creates => $setup_exe,
-        }
-      }
-    }
     exec { 'grid_unzip':
-      command => "${seven_zip} x ${src_file} -o${working_dir} -y",
-      creates => $setup_exe,
+      command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+      creates  => $setup_exe,
+      provider => powershell,
     }
     exec { 'grid_install':
       command     => "${facts['custom_win_system32']}\\cmd.exe /c ${setup_exe} -s -noreboot",

--- a/modules/win_packages/manifests/drivers/nvidia_grid.pp
+++ b/modules/win_packages/manifests/drivers/nvidia_grid.pp
@@ -7,7 +7,6 @@ class win_packages::drivers::nvidia_grid (
   String $srcloc
 ) {
   $setup_exe   = "${facts['custom_win_systemdrive']}\\${driver_name}\\setup.exe"
-  $working_dir = "${facts['custom_win_systemdrive']}\\${driver_name}"
   $zip_name    = "${driver_name}.zip"
   $pkgdir      = $facts['custom_win_temp_dir']
   $src_file    = "\"${pkgdir}\\${zip_name}\""
@@ -15,15 +14,12 @@ class win_packages::drivers::nvidia_grid (
   # copy the installtion file during image build
   # only install if it is a gpu worker with gpu in the pool name
 
-  file { $working_dir:
-    ensure => directory,
-  }
   file { "${pkgdir}\\${zip_name}":
     source => "${srcloc}/${zip_name}",
   }
 
   exec { 'grid_unzip':
-    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${working_dir}",
+    command  => "Expand-Archive -Path ${src_file} -DestinationPath ${facts['custom_win_systemdrive']}\\",
     creates  => $setup_exe,
     provider => powershell,
   }


### PR DESCRIPTION
There are 2 issues:

1. Azure VM Agent continues to try and install itself over and over.
2. NVidia GPU never installs.

Since the [displayname](https://puppet.com/docs/puppet/6/resources_package_windows.html#resources_package_windows-displayname) of the package is not the same as it is when running `puppet resource package` [Handling Versions and Upgrades](https://puppet.com/docs/puppet/6/resources_package_windows.html#package_versions_and_upgrades-packages-with-real-versions), these packages are not consistently being installed

Output of `puppet resource package` and removed some extra packages

```Puppet
package { 'NVIDIA Graphics Driver 472.39':
  ensure => '472.39',
}
package { 'NVIDIA RTX Desktop Manager 202.21':
  ensure => '202.21',
}
package { 'NVIDIA WMI 2.36.0':
  ensure => '2.36.0',
}
..removed...
package { 'Windows Azure VM Agent - 2.7.41491.1057':
  ensure => '2.7.41491.1057',
}

```

Scenario: Clone a GPU VM, set `worker_pool_id` to `gpu`, and run puppet against  `jwmoss/ronin_puppet` and against current `mozilla-platform-ops/ronin_puppet`

Left shows nvidia drivers getting skipped entirely and Azure VM Agent trying to install over and over again using repo `mozilla-platform-ops/ronin_puppet`
Right shows nvidia drivers getting installed by native package installer + skipping Azure VM Agent using repo `jwmoss/ronin_puppet`

![image](https://user-images.githubusercontent.com/2729151/202087459-f62ec641-ed09-438f-956c-7098e3100a57.png)
