### PR TITLE
disable 1804 kitchen tests for bitbar

### DIFF
--- a/.kitchen_configs/kitchen.docker.yml
+++ b/.kitchen_configs/kitchen.docker.yml
@@ -81,4 +81,6 @@ suites:
   - name: bitbar
     provisioner:
       custom_options: '-e "include roles_profiles::roles::bitbar_devicepool"'
+    includes:
+      - ubuntu-22.04  # no more 1804 bitbar
     attributes:

--- a/.kitchen_configs/kitchen.yml
+++ b/.kitchen_configs/kitchen.yml
@@ -86,4 +86,6 @@ suites:
   - name: bitbar
     provisioner:
       custom_options: '-e "include roles_profiles::roles::bitbar_devicepool"'
+    includes:
+      - ubuntu2204
     attributes:


### PR DESCRIPTION
Bitbar devicepool hosts are now all on 22.04. Disable 18.04 tests.