### PR TITLE
remove bitbar 1804 from circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ workflows:
       - linux_integration_tests:
           matrix:
             parameters:
-              kitchen_target: ["bitbar-ubuntu-1804", "bitbar-ubuntu-2204", "linux-ubuntu-1804"]
+              kitchen_target: ["bitbar-ubuntu-2204", "linux-ubuntu-1804"]
           requires:
             - pre_commit
             - r10k_install


### PR DESCRIPTION
#468 removed the config from test-kitchen, but missed the circleci config. Fix that.