### PR TITLE
kitchen inspec: only enable color if not in CI

### DIFF
--- a/.kitchen_configs/kitchen.docker.yml
+++ b/.kitchen_configs/kitchen.docker.yml
@@ -67,6 +67,7 @@ platforms:
 
 verifier:
   name: inspec
+  color: <%= !ENV.include?('CI') %>
 
 busser:
   sudo: true


### PR DESCRIPTION
inspec output in CircleCI is colored red (https://github.com/inspec/inspec/issues/1700) which is very confusing.

Disable colored output if in CI. See https://github.com/inspec/kitchen-inspec/issues/103.