### PR TITLE
restore multiuser user switching

### DIFF
--- a/modules/worker_runner/templates/worker_runner_config.yaml.erb
+++ b/modules/worker_runner/templates/worker_runner_config.yaml.erb
@@ -21,7 +21,7 @@ workerConfig:
   ed25519SigningKeyLocation: "<%= @ed25519_signing_key %>"
   idleTimeoutSecs: <%= @idle_timeout_secs %>
   livelogExecutable: "/usr/local/bin/livelog"
-  numberOfTasksToRun: 1
+  numberOfTasksToRun: 0
   publicIP: "<%= @facts['networking']['ip'] %>"
   requiredDiskSpaceMegabytes: 10240
   sentryProject: "generic-worker"


### PR DESCRIPTION
@bhearsum this should fix https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5828#issuecomment-1410665535 on the next reboot when puppet runs on each vpn worker.

I'll update the puppet module to set this correctly for multiuser vs singleuser in a separate PR to master.