### PR TITLE
RELOPS-425 - Update current running inventory

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -32,7 +32,7 @@ groups:
       - macmini-r8-27.test.releng.mdc1.mozilla.com
       - macmini-r8-28.test.releng.mdc1.mozilla.com
       - macmini-r8-29.test.releng.mdc1.mozilla.com
-      - macmini-r8-30.test.releng.mdc1.mozilla.com
+      #- macmini-r8-30.test.releng.mdc1.mozilla.com
       - macmini-r8-31.test.releng.mdc1.mozilla.com
       - macmini-r8-32.test.releng.mdc1.mozilla.com
       - macmini-r8-33.test.releng.mdc1.mozilla.com
@@ -75,14 +75,14 @@ groups:
       - macmini-r8-70.test.releng.mdc1.mozilla.com
       - macmini-r8-71.test.releng.mdc1.mozilla.com
       - macmini-r8-72.test.releng.mdc1.mozilla.com
-      - macmini-r8-73.test.releng.mdc1.mozilla.com
+      #- macmini-r8-73.test.releng.mdc1.mozilla.com
       - macmini-r8-74.test.releng.mdc1.mozilla.com
       - macmini-r8-75.test.releng.mdc1.mozilla.com
       - macmini-r8-76.test.releng.mdc1.mozilla.com
       - macmini-r8-77.test.releng.mdc1.mozilla.com
       - macmini-r8-78.test.releng.mdc1.mozilla.com
       - macmini-r8-79.test.releng.mdc1.mozilla.com
-      - macmini-r8-80.test.releng.mdc1.mozilla.com
+      #- macmini-r8-80.test.releng.mdc1.mozilla.com
       - macmini-r8-81.test.releng.mdc1.mozilla.com
       - macmini-r8-82.test.releng.mdc1.mozilla.com
       - macmini-r8-83.test.releng.mdc1.mozilla.com
@@ -103,14 +103,14 @@ groups:
       - macmini-r8-98.test.releng.mdc1.mozilla.com
       - macmini-r8-99.test.releng.mdc1.mozilla.com
       - macmini-r8-100.test.releng.mdc1.mozilla.com
-      - macmini-r8-101.test.releng.mdc1.mozilla.com
+      #- macmini-r8-101.test.releng.mdc1.mozilla.com
       - macmini-r8-102.test.releng.mdc1.mozilla.com
       - macmini-r8-103.test.releng.mdc1.mozilla.com
       - macmini-r8-104.test.releng.mdc1.mozilla.com
       - macmini-r8-105.test.releng.mdc1.mozilla.com
-      - macmini-r8-106.test.releng.mdc1.mozilla.com
+      #- macmini-r8-106.test.releng.mdc1.mozilla.com
       - macmini-r8-107.test.releng.mdc1.mozilla.com
-      - macmini-r8-108.test.releng.mdc1.mozilla.com
+      #- macmini-r8-108.test.releng.mdc1.mozilla.com
       - macmini-r8-109.test.releng.mdc1.mozilla.com
       - macmini-r8-110.test.releng.mdc1.mozilla.com
       - macmini-r8-111.test.releng.mdc1.mozilla.com
@@ -153,7 +153,7 @@ groups:
       - macmini-r8-159.test.releng.mdc1.mozilla.com
       - macmini-r8-160.test.releng.mdc1.mozilla.com
       - macmini-r8-161.test.releng.mdc1.mozilla.com
-      - macmini-r8-162.test.releng.mdc1.mozilla.com
+      #- macmini-r8-162.test.releng.mdc1.mozilla.com
       - macmini-r8-163.test.releng.mdc1.mozilla.com
       - macmini-r8-164.test.releng.mdc1.mozilla.com
       - macmini-r8-165.test.releng.mdc1.mozilla.com
@@ -180,7 +180,7 @@ groups:
       - macmini-r8-186.test.releng.mdc1.mozilla.com
       - macmini-r8-187.test.releng.mdc1.mozilla.com
       - macmini-r8-188.test.releng.mdc1.mozilla.com
-      - macmini-r8-189.test.releng.mdc1.mozilla.com
+      #- macmini-r8-189.test.releng.mdc1.mozilla.com
       - macmini-r8-190.test.releng.mdc1.mozilla.com
       - macmini-r8-191.test.releng.mdc1.mozilla.com
       - macmini-r8-192.test.releng.mdc1.mozilla.com
@@ -217,26 +217,26 @@ groups:
       - macmini-r8-249.test.releng.mdc1.mozilla.com
       - macmini-r8-251.test.releng.mdc1.mozilla.com
       - macmini-r8-253.test.releng.mdc1.mozilla.com
-      - macmini-r8-254.test.releng.mdc1.mozilla.com
+      #- macmini-r8-254.test.releng.mdc1.mozilla.com
       - macmini-r8-255.test.releng.mdc1.mozilla.com
-      - macmini-r8-256.test.releng.mdc1.mozilla.com
+      #- macmini-r8-256.test.releng.mdc1.mozilla.com
       - macmini-r8-257.test.releng.mdc1.mozilla.com
-      - macmini-r8-258.test.releng.mdc1.mozilla.com
-      - macmini-r8-259.test.releng.mdc1.mozilla.com
-      - macmini-r8-260.test.releng.mdc1.mozilla.com
-      - macmini-r8-261.test.releng.mdc1.mozilla.com
+      #- macmini-r8-258.test.releng.mdc1.mozilla.com
+      #- macmini-r8-259.test.releng.mdc1.mozilla.com
+      #- macmini-r8-260.test.releng.mdc1.mozilla.com
+      #- macmini-r8-261.test.releng.mdc1.mozilla.com
       - macmini-r8-262.test.releng.mdc1.mozilla.com
       - macmini-r8-263.test.releng.mdc1.mozilla.com
       - macmini-r8-264.test.releng.mdc1.mozilla.com
       - macmini-r8-265.test.releng.mdc1.mozilla.com
-      - macmini-r8-266.test.releng.mdc1.mozilla.com
+      #- macmini-r8-266.test.releng.mdc1.mozilla.com
       - macmini-r8-267.test.releng.mdc1.mozilla.com
       - macmini-r8-268.test.releng.mdc1.mozilla.com
       - macmini-r8-269.test.releng.mdc1.mozilla.com
-      - macmini-r8-270.test.releng.mdc1.mozilla.com
-      - macmini-r8-271.test.releng.mdc1.mozilla.com
+      #- macmini-r8-270.test.releng.mdc1.mozilla.com
+      #- macmini-r8-271.test.releng.mdc1.mozilla.com
       - macmini-r8-272.test.releng.mdc1.mozilla.com
-      - macmini-r8-273.test.releng.mdc1.mozilla.com
+      #- macmini-r8-273.test.releng.mdc1.mozilla.com
       - macmini-r8-274.test.releng.mdc1.mozilla.com
       - macmini-r8-275.test.releng.mdc1.mozilla.com
       - macmini-r8-276.test.releng.mdc1.mozilla.com
@@ -248,10 +248,10 @@ groups:
       - macmini-r8-282.test.releng.mdc1.mozilla.com
       - macmini-r8-283.test.releng.mdc1.mozilla.com
       - macmini-r8-284.test.releng.mdc1.mozilla.com
-      - macmini-r8-285.test.releng.mdc1.mozilla.com
-      - macmini-r8-286.test.releng.mdc1.mozilla.com
-      - macmini-r8-287.test.releng.mdc1.mozilla.com
-      - macmini-r8-288.test.releng.mdc1.mozilla.com
+      #- macmini-r8-285.test.releng.mdc1.mozilla.com
+      #- macmini-r8-286.test.releng.mdc1.mozilla.com
+      #- macmini-r8-287.test.releng.mdc1.mozilla.com
+      #- macmini-r8-288.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1015_r8
 

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -265,6 +265,7 @@ groups:
       - macmini-r8-125.test.releng.mdc1.mozilla.com
       - macmini-r8-126.test.releng.mdc1.mozilla.com
       - macmini-r8-127.test.releng.mdc1.mozilla.com
+      - macmini-r8-246.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1015_r8_staging
 

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -122,13 +122,6 @@ groups:
       - macmini-r8-117.test.releng.mdc1.mozilla.com
       - macmini-r8-118.test.releng.mdc1.mozilla.com
       - macmini-r8-119.test.releng.mdc1.mozilla.com
-      - macmini-r8-120.test.releng.mdc1.mozilla.com
-      - macmini-r8-121.test.releng.mdc1.mozilla.com
-      - macmini-r8-122.test.releng.mdc1.mozilla.com
-      - macmini-r8-123.test.releng.mdc1.mozilla.com
-      - macmini-r8-124.test.releng.mdc1.mozilla.com
-      - macmini-r8-125.test.releng.mdc1.mozilla.com
-      - macmini-r8-126.test.releng.mdc1.mozilla.com
       - macmini-r8-130.test.releng.mdc1.mozilla.com
       - macmini-r8-131.test.releng.mdc1.mozilla.com
       - macmini-r8-132.test.releng.mdc1.mozilla.com
@@ -138,7 +131,6 @@ groups:
       - macmini-r8-136.test.releng.mdc1.mozilla.com
       - macmini-r8-137.test.releng.mdc1.mozilla.com
       - macmini-r8-138.test.releng.mdc1.mozilla.com
-      - macmini-r8-139.test.releng.mdc1.mozilla.com
       - macmini-r8-140.test.releng.mdc1.mozilla.com
       - macmini-r8-141.test.releng.mdc1.mozilla.com
       - macmini-r8-142.test.releng.mdc1.mozilla.com
@@ -265,13 +257,20 @@ groups:
 
   - name: gecko-t-osx-1015-r8-staging
     targets:
+      - macmini-r8-120.test.releng.mdc1.mozilla.com
+      - macmini-r8-121.test.releng.mdc1.mozilla.com
+      - macmini-r8-122.test.releng.mdc1.mozilla.com
+      - macmini-r8-123.test.releng.mdc1.mozilla.com
+      - macmini-r8-124.test.releng.mdc1.mozilla.com
+      - macmini-r8-125.test.releng.mdc1.mozilla.com
+      - macmini-r8-126.test.releng.mdc1.mozilla.com
       - macmini-r8-127.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1015_r8_staging
 
   - name: gecko-t-osx-1015-r8-loaner
     targets:
-      - macmini-r8-128.test.releng.mdc1.mozilla.com
+      - macmini-r8-128.test.releng.mdc1.mozilla.com # RELOPS-
       - macmini-r8-129.test.releng.mdc1.mozilla.com # Bug 1720937
     facts:
       puppet_role: gecko_t_osx_1015_r8_loaner
@@ -289,6 +288,7 @@ groups:
 
   - name: gecko-3-b-osx-1015
     targets:
+      - macmini-r8-139.test.releng.mdc1.mozilla.com
       - macmini-r8-198.test.releng.mdc1.mozilla.com
       - macmini-r8-199.test.releng.mdc1.mozilla.com
       - macmini-r8-200.test.releng.mdc1.mozilla.com

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -270,8 +270,8 @@ groups:
 
   - name: gecko-t-osx-1015-r8-loaner
     targets:
-      - macmini-r8-128.test.releng.mdc1.mozilla.com # RELOPS-
-      - macmini-r8-129.test.releng.mdc1.mozilla.com # Bug 1720937
+      - macmini-r8-128.test.releng.mdc1.mozilla.com # Unknown, to be returned
+      - macmini-r8-129.test.releng.mdc1.mozilla.com # Bug 1729549
     facts:
       puppet_role: gecko_t_osx_1015_r8_loaner
 

--- a/modules/roles_profiles/manifests/profiles/gecko_3_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_3_t_osx_1014_generic_worker.pp
@@ -21,7 +21,7 @@ class roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker {
                 telegraf_user       => lookup('telegraf.user'),
                 telegraf_password   => lookup('telegraf.password'),
                 puppet_env          => 'dev',
-                puppet_repo         => 'https://github.com/davehouse/ronin_puppet.git',
+                puppet_repo         => 'https://github.com/mozilla-platform-ops/ronin_puppet.git',
                 puppet_branch       => '1561956_generic-worker_15-recover',
                 puppet_notify_email => 'dhouse@mozilla.com',
                 meta_data           => $meta_data,


### PR DESCRIPTION
Technically `modules/roles_profiles/manifests/profiles/gecko_3_t_osx_1014_generic_worker.pp` isn't part of the ticket but it's something we have to land anyway..
This comments out the known bad Macs and syncs the staging and prod definitions.