### PR TITLE
Update signer access

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,7 @@ apple_firmware_acceptance:
 
 user_groups:
   relops:
+    # dhouse set to nologin shell in the relops user module.
     - dhouse
     - mcornmesser
     - aerickson
@@ -24,6 +25,7 @@ user_groups:
     - hneiva
     - jcristau
     - jlorenzo
+    - mgoossens
   cia: []
 
 scriptworker_users:
@@ -249,8 +251,7 @@ signingworker_roles:
 
 all_users:
   dhouse:
-    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfeLZeQj7V+K5XZA0YzxDHJiCt4iUvd6bkLFZR02fkVGsFt3639K955ycwspSoEDgqBHfO4UCv2cqBLQqI7EdYl0FcllVPeKL64XKvZA0cXqlzWmqfrnh9yw78Qw0XnYXTbTXVJDxYZC36VZaNFxUc28lr9r3BfMyrVJZ8v7Lz/2S4kYXtOgrqCbu/K2RiNiJ4uO0mAWivF+NsuWInlrH97YdohE/7kydslv0wGVf1rU1tQ0CYXNQBqir89+0Glshix2TtRdXn6HhNbFNFkkbja246fHt26W6COoF8t2R7Kh/Yvs0FLWLZe8xNWVmca2F+RDwpN9muydfVa0j+9iJu+GXBIsNbivqclcqhGHzTItM1GpGe9wgbugKtOMKQ02+OSGHmyAQhG4Fi675QG7yAz3gDH0DYiai/s032mMyqiOSH4JWFvq6dN32l/cbZMYfB/VMBJwbI0EJOb55Kqn6UDyYCaFZpfJq/w1gXEmpu7XtzuBbsFBum6c/248cGR+RtJ5N0EF098+3IRbDOq4t8cKcdy/rOu2O/iCIIfr3coBunFCUPVw6/r8I0qrFcLjCCKKjEBIpTrCv5ch1uj9P0BqJw+LWsalQsJeVQ/U71tHoUWqINrGXyjvVhHcTbeE22bALTq0iEqwZEPrZCusb5yqpow89zw+MqrT9SCz/S0w== dhouse.house
-
+    - ssh-rsa AAAA invalid@mozilla.com
   mcornmesser:
     - ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAgEAgl+gdJm/ugZQJhjWRldBMoijBAxX9aK4djspM+X+59SqdLidnHG7IyOyzniUVa5IgL8ak91v59zgTM4K9VmLdbH1EttiryJ2juYygBClFQC3p7NiHLhtuJOrrMbb7K53I6dJVxui8f3Rj58nV7Y3wvrdmoxKboVYGLNCWcVhEOFpfvr+RftMPfAgOTBgAXqWt3954OGmDLAPVCUruuNrZpFYZ4WBEVsZYFvljXz7eBZCS1HyeYtDDmNECGSKMvyR1C32kGpDfK+I8cngaZAdhUpEYVWJeIQmACUoilgx8A/K0GfPmnncfi3QJUrucFAmA8f87k4PczamTMszmdmOiXVzKCID2DtH/uunTtDe7toIuA2A0fCYeFGkvEgIUAIifhifduJdbvNuVJ/AmEcOAN9PIAzhGQh7WhPRagJeydgtB2hQihRSaVVQgSNUJA8trAQKAArB/cJSZgIu9PED6ZuRzUWpA3HPzVxyx9v73d/c0ZnacF8VP74ucOaqi+z/QUe3dPKg14x4kJQHthPJm8oVS04sWQjRVTyXgcEnHyYiEOhAq5XCd1Pss7hLICKuc9L4/AKMoKpzf2mqPuhfEHJ77MGHXfGFwY08rFpU54wRiO7tyX09w+S1CKImjoz3mjYZu42W6gIyLbCzxbMaV9aRK27Tn/A1j1NBcQvGEn0= rsa-key-20170619
     - ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA1zBG1hfe9OgISQxo0tQgy9VfTWk81mIadB90aSowIfdUZdGg0qoDKY5JHKMxi1BOwzN/UnEO+PeS3pIRY/2Xr7ywMgnoqYo9mkF/Q0EHnjVwjJxWfza9eEvI0SoBpPu1FlCgk+unzedEaJTc0KzNKEjRxVL4/XXvIgV4U/BukYAEYAsPFWXIvkSNi9GrNrAkKRuXCVOItBQjYGP+hg9vbnGOAmzIzgAmxxxos/LH7+z/59H0Cmm4wgzgm5JCRyIIHueYkHJYswx1crr1KQTooghJf+mGV1Iif+ymVylk2nnsdfQLqYHgSte4BnXV9NZGa1PIGmA/+wHVUfaiXNtjOQ== rsa-key-20170620

--- a/modules/users/manifests/global.pp
+++ b/modules/users/manifests/global.pp
@@ -12,4 +12,10 @@ class users::global {
             ensure  => 'present',
             content => 'export TMOUT=86400';  # Shells timeout after 1 day
     }
+
+    # disable login for departed users
+    User<| title == dhouse |> {
+      shell => '/usr/sbin/nologin',
+      groups => 'dhouse',
+    }
 }


### PR DESCRIPTION
Removes `dhouse`, adds me.
This access will be needed at some point with signer updates.