### PR TITLE
CircleCI: fix pre-commit job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   vault: jmingtan/hashicorp-vault@0.2.1
-  terraform: suzuki-shunsuke/terraform@0.2.8
+  tfutils: ukslee/tfutils@0.0.5
 
 executors:
   default:
@@ -155,13 +155,7 @@ jobs:
     executor: default
     steps:
       - checkout
-      - terraform/install_tflint:
-        install_dir: .orb-terraform/bin
-      - run:
-          name: tfenv install
-          shell: /bin/bash -eu -o pipefail
-          command: |
-            tfenv install
+      - tfutils/install
       # - run: apt-get update
       # - run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
       # - run:
@@ -177,8 +171,8 @@ jobs:
       - run:
           name: Run pre-commit
           command: |
-            export PATH="$HOME/.tfenv/bin:$PATH"
-            # tfenv use 1.0.3
+            #export PATH="$HOME/.tfenv/bin:$PATH"
+            tfenv use 1.0.3
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ orbs:
   terraform: suzuki-shunsuke/terraform@0.2.8
 
 executors:
+  default:
+    docker:
+      - image: cimg/base:stable
   docker-base:
     docker:
       - image: cimg/base:2022.09
@@ -149,7 +152,7 @@ commands:
             terraform -chdir=test/integration/<< parameters.role >>/terraform/ apply -var="role=<< parameters.role >>" -input=false -auto-approve
 jobs:
   pre_commit:
-    executor: docker-ruby
+    executor: default
     steps:
       - checkout
       - terraform/install_tflint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             export PATH="$HOME/.tfenv/bin:$PATH"
             tfenv install 1.0.3
             tfenv use 1.0.3
-            pip install pre-commit==2.20.2
+            pip install pre-commit==2.20.0
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ jobs:
             pip install pre-commit
             pre-commit run --from-ref original/master --to-ref HEAD --verbose || true
             cat /home/circleci/.cache/pre-commit/pre-commit.log
+            exit 1
   r10k_install:
     executor: ubuntu-2004
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   vault: jmingtan/hashicorp-vault@0.2.1
+  terraform: suzuki-shunsuke/terraform@0.2.8
 
 executors:
   docker-base:
@@ -151,23 +152,30 @@ jobs:
     executor: docker-ruby
     steps:
       - checkout
-      - run: apt-get update
-      - run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
+      - terraform/install_tflint:
+        install_dir: .orb-terraform/bin
       - run:
-        name: Install tfenv and terraform
-        command: |
-          git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-          export PATH="$HOME/.tfenv/bin:$PATH"
-          tfenv install 1.0.3
-        #- run: pip3 install pre-commit
-#     - run: pre-commit run --all-files --verbose
-      - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
-      - run: git fetch --all
+          name: tfenv install
+          shell: /bin/bash -eu -o pipefail
+          command: |
+            tfenv install
+      # - run: apt-get update
+      # - run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
+      # - run:
+      #   name: Install tfenv and terraform
+      #   command: |
+      #     cd /tmp
+      #     git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+      #     export PATH="$HOME/.tfenv/bin:$PATH"
+      #     tfenv install 1.0.3
+      #     cd -
+      # - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
+      # - run: git fetch --all
       - run:
           name: Run pre-commit
           command: |
             export PATH="$HOME/.tfenv/bin:$PATH"
-            tfenv use 1.0.3
+            # tfenv use 1.0.3
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,14 +151,14 @@ jobs:
     executor: docker-ruby
     steps:
       - checkout
-        #- run: apt-get update
-        #- run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
-        #- run:
-        #  name: Install tfenv and terraform
-        #  command: |
-        #    git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-        #    export PATH="$HOME/.tfenv/bin:$PATH"
-        #    tfenv install 1.0.3
+      - run: apt-get update
+      - run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
+      - run:
+        name: Install tfenv and terraform
+        command: |
+          git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+          export PATH="$HOME/.tfenv/bin:$PATH"
+          tfenv install 1.0.3
         #- run: pip3 install pre-commit
 #     - run: pre-commit run --all-files --verbose
       - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,22 +156,11 @@ jobs:
     steps:
       - checkout
       - tfutils/install
-      # - run: apt-get update
-      # - run: apt-get -y install shellcheck git curl unzip python3-pip ruby-full
-      # - run:
-      #   name: Install tfenv and terraform
-      #   command: |
-      #     cd /tmp
-      #     git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-      #     export PATH="$HOME/.tfenv/bin:$PATH"
-      #     tfenv install 1.0.3
-      #     cd -
-      # - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
-      # - run: git fetch --all
       - run:
           name: Run pre-commit
           command: |
-            #export PATH="$HOME/.tfenv/bin:$PATH"
+            export PATH="$HOME/.tfenv/bin:$PATH"
+            tfenv install 1.0.3
             tfenv use 1.0.3
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: cimg/base:2022.09
   docker-ruby:
     docker:
-      - image: cimg/ruby:3.0
+      - image: cimg/ruby:3.2.2
   ubuntu-2004-docker:
     docker:
       # see https://github.com/mozilla-platform-ops/relops_infra_as_code/tree/master/docker/dockerfiles/circleci-ubuntu-2004
@@ -148,7 +148,7 @@ commands:
             terraform -chdir=test/integration/<< parameters.role >>/terraform/ apply -var="role=<< parameters.role >>" -input=false -auto-approve
 jobs:
   pre_commit:
-    executor: ubuntu-2004-docker
+    executor: docker-ruby
     steps:
       - checkout
         #- run: apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,11 @@ jobs:
       - checkout
       - tfutils/install
       - run:
+          name: setup
+          command: |
+            sudo apt update
+            sudo apt install -y ruby-full
+      - run:
           name: Run pre-commit
           command: |
             export PATH="$HOME/.tfenv/bin:$PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,10 +168,11 @@ jobs:
           name: Run pre-commit
           command: |
             export PATH="$HOME/.tfenv/bin:$PATH"
-            tfenv install 1.0.3
-            tfenv use 1.0.3
-            pip install pre-commit==2.20.0
-            pre-commit run --from-ref original/master --to-ref HEAD --verbose
+            tfenv install
+            # tfenv use 1.0.3
+            pip install pre-commit
+            pre-commit run --from-ref original/master --to-ref HEAD --verbose || true
+            cat /home/circleci/.cache/pre-commit/pre-commit.log
   r10k_install:
     executor: ubuntu-2004
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,14 +165,14 @@ jobs:
           command: |
             sudo apt update
             sudo apt install -y ruby-full
+      - run: git remote add original https://github.com/mozilla-platform-ops/ronin_puppet.git
+      - run: git fetch --all
       - run:
           name: Run pre-commit
           command: |
             export PATH="$HOME/.tfenv/bin:$PATH"
             pip install pre-commit
-            pre-commit run --from-ref original/master --to-ref HEAD --verbose || true
-            cat /home/circleci/.cache/pre-commit/pre-commit.log
-            exit 1
+            pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ executors:
   default:
     docker:
       - image: cimg/base:stable
+  python:
+    docker:
+      - image: cimg/python:3.11.2
   docker-base:
     docker:
       - image: cimg/base:2022.09
@@ -152,7 +155,7 @@ commands:
             terraform -chdir=test/integration/<< parameters.role >>/terraform/ apply -var="role=<< parameters.role >>" -input=false -auto-approve
 jobs:
   pre_commit:
-    executor: default
+    executor: python
     steps:
       - checkout
       - tfutils/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             export PATH="$HOME/.tfenv/bin:$PATH"
             tfenv install 1.0.3
             tfenv use 1.0.3
-            pip install pre-commit
+            pip install pre-commit==2.20.2
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
             export PATH="$HOME/.tfenv/bin:$PATH"
             tfenv install 1.0.3
             tfenv use 1.0.3
+            pip install pre-commit
             pre-commit run --from-ref original/master --to-ref HEAD --verbose
   r10k_install:
     executor: ubuntu-2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,8 @@ jobs:
     executor: python
     steps:
       - checkout
-      - tfutils/install
+      - tfutils/install:
+          tf_version: 'latest'
       - run:
           name: setup
           command: |
@@ -168,8 +169,6 @@ jobs:
           name: Run pre-commit
           command: |
             export PATH="$HOME/.tfenv/bin:$PATH"
-            tfenv install
-            # tfenv use 1.0.3
             pip install pre-commit
             pre-commit run --from-ref original/master --to-ref HEAD --verbose || true
             cat /home/circleci/.cache/pre-commit/pre-commit.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^r10k_modules/'
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: check-executables-have-shebangs
   - id: check-json
@@ -29,7 +29,7 @@ repos:
     - id: shellcheck
 
 - repo: https://github.com/gruntwork-io/pre-commit
-  rev: v0.1.17
+  rev: v0.1.21
   hooks:
     - id: terraform-fmt
     - id: terraform-validate


### PR DESCRIPTION
Fixes current master breakage.

Puppet wanted a newer version of Ruby. We've built a custom image previously, but it's a pain to maintain. 

Switch to using a provided image and install required bits.