### PR TITLE
add safaridriver to r8 staging config

### DIFF
--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
@@ -23,4 +23,5 @@ class roles_profiles::roles::gecko_t_osx_1015_r8_staging {
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::metrics
     include ::roles_profiles::profiles::worker
+    include ::roles_profiles::profiles::safaridriver
 }


### PR DESCRIPTION
The staging r8 macs never had the safaridriver role/profile added to them. Fix that.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1812409 for more info.