### PR TITLE
mac m2 fixes

### DIFF
--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -13,7 +13,7 @@ class roles_profiles::profiles::cltbld_user {
                     # GROSS HACK FOR TESTING, DO NOT LAND
                     # lookup('cltbld_user.salt'),
                     'Use a s@lt h3r3 th@t is 32 byt3s',
-                    lookup('cltbld_user.iterations')
+                    Integer(lookup('cltbld_user.iterations'))
                 )
                 $password = $pw_info['password_hex']
                 $salt = $pw_info['salt_hex']

--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -7,7 +7,7 @@ class roles_profiles::profiles::cltbld_user {
         'Darwin': {
             # OS X 13+ wants a salted SHA512 PBKDF2 password hash
             # see https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/REFERENCE.md#str2saltedpbkdf2
-            if $facts['os']['macosx']['version']['major'] > 13 {
+            if member(['13'], $facts['os']['macosx']['version']['major']) {
                 $pw_info = str2saltedpbkdf2(
                     lookup('cltbld_user.password'),
                     lookup('cltbld_user.salt'),

--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -10,7 +10,9 @@ class roles_profiles::profiles::cltbld_user {
             if member(['13'], $facts['os']['macosx']['version']['major']) {
                 $pw_info = str2saltedpbkdf2(
                     lookup('cltbld_user.password'),
-                    lookup('cltbld_user.salt'),
+                    # GROSS HACK FOR TESTING, DO NOT LAND
+                    # lookup('cltbld_user.salt'),
+                    'Use a s@lt h3r3 th@t is 32 byt3s',
                     lookup('cltbld_user.iterations')
                 )
                 $password = $pw_info['password_hex']


### PR DESCRIPTION
WIP: not working, do not land.

- handle OS X 13's demand for a salted SHA512 PBKDF2 password hash