### PR TITLE
Add forgotten puppet fact to vpn level 3

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -283,3 +283,5 @@ groups:
     targets:
       - macmini-r8-180.test.releng.mdc1.mozilla.com
       - macmini-r8-184.test.releng.mdc1.mozilla.com
+    facts:
+      puppet_role: mozillavpn_b_3_osx


### PR DESCRIPTION
I had forgotten to add this in a previous commit.