### PR TITLE
fix semaphore dir race and add missing macs

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -195,7 +195,17 @@ groups:
       - macmini-r8-249.test.releng.mdc1.mozilla.com
       - macmini-r8-251.test.releng.mdc1.mozilla.com
       - macmini-r8-253.test.releng.mdc1.mozilla.com
+      - macmini-r8-256.test.releng.mdc1.mozilla.com
       - macmini-r8-257.test.releng.mdc1.mozilla.com
+      - macmini-r8-258.test.releng.mdc1.mozilla.com
+      - macmini-r8-259.test.releng.mdc1.mozilla.com
+      - macmini-r8-260.test.releng.mdc1.mozilla.com
+      - macmini-r8-261.test.releng.mdc1.mozilla.com
+      - macmini-r8-262.test.releng.mdc1.mozilla.com
+      - macmini-r8-263.test.releng.mdc1.mozilla.com
+      - macmini-r8-264.test.releng.mdc1.mozilla.com
+      - macmini-r8-265.test.releng.mdc1.mozilla.com
+      - macmini-r8-266.test.releng.mdc1.mozilla.com
       - macmini-r8-267.test.releng.mdc1.mozilla.com
       - macmini-r8-268.test.releng.mdc1.mozilla.com
       - macmini-r8-269.test.releng.mdc1.mozilla.com

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -38,7 +38,8 @@ class macos_safaridriver (
             #   - make a driver script that gets id of cltbld on each system?
             command => "/bin/launchctl asuser 36 sudo -u ${user_running_safari} ${enable_script}",
             require => File[$enable_script],
-            # semaphore created in script
+            cwd     => "/Users/${user_running_safari}",
+            # semaphore and semaphore dir are created in script
             unless  => "/bin/test -f /Users/${user_running_safari}/Library/Preferences/semaphore/safari-enable-remote-automation-has-run",
             # logoutput => true,
           }

--- a/modules/macos_safariupdate/files/update_safari.sh
+++ b/modules/macos_safariupdate/files/update_safari.sh
@@ -5,6 +5,9 @@ set -e
 semaphore_file="/Users/cltbld/Library/Preferences/semaphore/safari-update-has-run"
 semaphore_version="2"
 mkdir -p "$(dirname "$semaphore_file")"
+# this script runs as root, but other scripts write files to this dir
+#   and run as cltbld, so fix ownership
+chown cltbld "$(dirname "$semaphore_file")"
 touch "$semaphore_file"
 if [[ "$(cat "$semaphore_file")" == "$semaphore_version" ]]; then
   echo "$0: file indicates this version of the script has already run. exiting..."


### PR DESCRIPTION
The race condition wasn't noticed until now because my `safaridriver` class's enable script ran before the `safariupdate` class existed/ran on most macs, but these 'lost' macs didn't have the semaphore dir created as the correct user. This PR fixes that issue by chmodding in the earlier `safariupdate` class's script invocation.

RE: missing macs, Not sure how these were found, but rcurran sent me the list. They weren't converging (due to no role).