### PR TITLE
add mac tc spec tests

### DIFF
--- a/test/integration/gecko_t_osx_1015_r8/serverspec/taskcluster_spec.rb
+++ b/test/integration/gecko_t_osx_1015_r8/serverspec/taskcluster_spec.rb
@@ -1,0 +1,21 @@
+require_relative 'spec_helper'
+
+describe file('/usr/local/bin/generic-worker-multiuser') do
+    it { should exist }
+end
+
+describe file('/usr/local/bin/generic-worker-simple') do
+    it { should exist }
+end
+
+describe file('/usr/local/bin/start-worker') do
+    it { should exist }
+end
+
+describe file('/usr/local/bin/taskcluster-proxy') do
+    it { should exist }
+end
+
+describe file('/usr/local/bin/livelog') do
+    it { should exist }
+end

--- a/test/integration/gecko_t_osx_1100_m1/serverspec/taskcluster_spec.rb
+++ b/test/integration/gecko_t_osx_1100_m1/serverspec/taskcluster_spec.rb
@@ -1,0 +1,1 @@
+../../gecko_t_osx_1015_r8/serverspec/taskcluster_spec.rb


### PR DESCRIPTION
We were debugging an issue where g-w wasn't being sent out and we realized we don't have a spec checking that it does get sent out. Remedy that.