### PR TITLE
Handle different versions of Safari

### DIFF
--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -26,5 +26,5 @@ class roles_profiles::roles::gecko_t_osx_1100_m1 {
     include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
     include ::roles_profiles::profiles::macos_tcc_perms
-    include ::roles_profiles::profiles::safaridriver
+    #include ::roles_profiles::profiles::safaridriver
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -26,5 +26,5 @@ class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
     include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
     include ::roles_profiles::profiles::macos_tcc_perms
-    include ::roles_profiles::profiles::safaridriver
+    #include ::roles_profiles::profiles::safaridriver
 }


### PR DESCRIPTION
This update to macos_safaridriver retrofits @aerickson 's original solution for macOS Catalina to latter OS's.

This is currently not fully functional for the M1s as cltbld has an inconsistent userid (35 and 36 respectively). But the request was to get this working for the M2s.

This update enables safaridriver for the M2s and also supports Safari v16 and v17, as Apple moved the buttons in the UI to enable.