### PR TITLE
green up integration tests

### DIFF
--- a/data/roles/gecko_t_osx_1015_r8.yaml
+++ b/data/roles/gecko_t_osx_1015_r8.yaml
@@ -42,7 +42,7 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.11
+packages::python3::version: 3.11.0
 packages::python3_zstandard::version: 0.22.0
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1

--- a/data/roles/gecko_t_osx_1015_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1015_r8_staging.yaml
@@ -42,7 +42,7 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.11
+packages::python3::version: 3.11.0
 packages::python3_zstandard::version: 0.22.0
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1


### PR DESCRIPTION
- change python3 version to 3.11.0 from 3.11 in some yamls