### PR TITLE
py3.11 fixing

### DIFF
--- a/modules/packages/manifests/python3.pp
+++ b/modules/packages/manifests/python3.pp
@@ -13,6 +13,8 @@ class packages::python3 (
 #        $pkg_name = "python-${version}-macosx10.9.pkg"
 #    }
 
+  $short_version = $version.split('.')[0,2].join('.')
+
   $pkg_name = "python-${version}-macosx10.9.pkg"
   packages::macos_package_from_s3 { $pkg_name:
     private             => false,
@@ -23,9 +25,9 @@ class packages::python3 (
   # Install certifi's set of CAs to override the system set
   exec {
     'install python3 certs':
-      command => "\"/Applications/Python ${version[0,3]}/Install Certificates.command\"",
+      command => "\"/Applications/Python ${short_version}/Install Certificates.command\"",
       path    => ['/usr/bin', '/usr/sbin', '/bin'],
-      unless  => "test -L /Library/Frameworks/Python.framework/Versions/${version[0,3]}/etc/openssl/cert.pem",
+      unless  => "test -L /Library/Frameworks/Python.framework/Versions/${short_version}/etc/openssl/cert.pem",
       require => Packages::Macos_package_from_s3[$pkg_name],
   }
 }

--- a/modules/packages/manifests/python3.pp
+++ b/modules/packages/manifests/python3.pp
@@ -13,7 +13,8 @@ class packages::python3 (
 #        $pkg_name = "python-${version}-macosx10.9.pkg"
 #    }
 
-  $short_version = $version.split('.')[0,2].join('.')
+  $split_arr = split(String($version), '[.]')
+  $short_version = $split_arr[0,2].join('.')
 
   $pkg_name = "python-${version}-macosx10.9.pkg"
   packages::macos_package_from_s3 { $pkg_name:


### PR DESCRIPTION
Continuation of work in https://github.com/mozilla-platform-ops/ronin_puppet/pull/618.

error seen:

```
Finished: apply catalog with 1 failure in 26.14 sec
Finished: plan deploy::apply_no_verify in 54.2 sec
Failed on macmini-m2-5.test.releng.mslv.mozilla.com:
  Resources failed to apply for macmini-m2-5.test.releng.mslv.mozilla.com
    Exec[install python3 certs]: change from 'notrun' to ['0'] failed: Could not find command '/Applications/Python 3.1/Install Certificates.command'
  changed: 2, failed: 1, unchanged: 127 skipped: 3, noop: 0
Failed on 1 target: macmini-m2-5.test.releng.mslv.mozilla.com
```