### PR TITLE
Roll back python 3.11 for vpn

### DIFF
--- a/data/roles/mozillavpn_b_1_osx.yaml
+++ b/data/roles/mozillavpn_b_1_osx.yaml
@@ -49,8 +49,8 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.11.0
-packages::python3_zstandard::version: 0.22.0
+packages::python3::version: 3.7.9
+packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::xcode_cmd_line_tools::version: '14.3'

--- a/data/roles/mozillavpn_b_3_osx.yaml
+++ b/data/roles/mozillavpn_b_3_osx.yaml
@@ -49,8 +49,8 @@ packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
-packages::python3::version: 3.11.0
-packages::python3_zstandard::version: 0.22.0
+packages::python3::version: 3.7.9
+packages::python3_zstandard::version: 0.11.1
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::xcode_cmd_line_tools::version: '14.3'


### PR DESCRIPTION
VPN folks want to stay on Python 3.7.9. 3.11 wasn't deployed yet but reverting the code change