### PR TITLE
Added nodes to gecko-t-osx-1400-r8-staging per RELOPS-921

### DIFF
--- a/data/roles/gecko_t_osx_1400_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_staging.yaml
@@ -31,6 +31,7 @@ packages_classes:
   - python3_psutil
   - python3_zstandard
   - scres
+  - telegraf
   - tooltool
   - virtualenv
   - wget
@@ -48,10 +49,8 @@ packages::python3::version: 3.11.0
 packages::python3_zstandard::version: 0.22.0
 packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
-# Fix this later
-# packages::xcode_cmd_line_tools::version: '12.4'
+packages::xcode_cmd_line_tools::version: '15.1'
 packages::zstandard::version: 1.3.8
-# Ryan added
 packages::telegraf::version: 1.19.0
 packages::virt_audio_s3::version: 0.5.0
 

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -350,12 +350,7 @@ groups:
     targets:
       - macmini-r8-373.test.releng.mdc1.mozilla.com
       - macmini-r8-374.test.releng.mdc1.mozilla.com
-    facts:
-      puppet_role: gecko_t_osx_1400_r8_staging
-
-  - name: gecko-t-osx-1300-r8
-    targets:
       - macmini-r8-375.test.releng.mdc1.mozilla.com
       - macmini-r8-376.test.releng.mdc1.mozilla.com
     facts:
-      puppet_role: gecko_t_osx_1300_r8
+      puppet_role: gecko_t_osx_1400_r8_staging

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -23,8 +23,7 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::metrics
     include ::roles_profiles::profiles::worker
-    # Disabling for now
-    #include ::roles_profiles::profiles::safaridriver
+    include ::roles_profiles::profiles::safaridriver
     include ::roles_profiles::profiles::safariupdate
     include macos_utils::disable_bluetooth_setup
     include ::roles_profiles::profiles::pipconf


### PR DESCRIPTION
This modifies an existing pool to enable some packages that were previously left out, adds safaridriver, and new nodes