### PR TITLE
Bugfix for RELOPS-923

### DIFF
--- a/data/roles/gecko_1_b_osx_arm64.yaml
+++ b/data/roles/gecko_1_b_osx_arm64.yaml
@@ -38,6 +38,7 @@ packages_classes:
   - zstandard
   - telegraf
   - virt_audio_s3
+  - xcode_cmd_line_tools
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
@@ -52,6 +53,7 @@ packages::wget::version: 1.20.3_1
 packages::zstandard::version: 1.3.8
 packages::telegraf::version: 1.19.0
 packages::virt_audio_s3::version: 0.5.0
+packages::xcode_cmd_line_tools::version: '14.3'
 
 # Talos class parameters
 talos::user: cltbld


### PR DESCRIPTION
One of the two workers in gecko-1-b-osx-arm64 was failing all tests. The role was missing `xcode_cmd_line_tools`

Converged node with fixed configuration and it's now [passing](https://firefox-ci-tc.services.mozilla.com/provisioners/releng-hardware/worker-types/gecko-1-b-osx-arm64/workers/macstadium-vegas/macmini-m2-3?sortBy=started&sortDirection=desc) all tests