### PR TITLE
removed defective r8s

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -167,7 +167,6 @@ groups:
       - macmini-r8-174.test.releng.mdc1.mozilla.com
       - macmini-r8-175.test.releng.mdc1.mozilla.com
       - macmini-r8-176.test.releng.mdc1.mozilla.com
-      - macmini-r8-177.test.releng.mdc1.mozilla.com
       - macmini-r8-178.test.releng.mdc1.mozilla.com
       - macmini-r8-181.test.releng.mdc1.mozilla.com
       - macmini-r8-186.test.releng.mdc1.mozilla.com
@@ -265,8 +264,6 @@ groups:
 
   - name: gecko-t-osx-1015-r8-staging
     targets:
-      - macmini-r8-120.test.releng.mdc1.mozilla.com
-      - macmini-r8-121.test.releng.mdc1.mozilla.com
       - macmini-r8-123.test.releng.mdc1.mozilla.com
       - macmini-r8-124.test.releng.mdc1.mozilla.com
       - macmini-r8-125.test.releng.mdc1.mozilla.com


### PR DESCRIPTION
These nodes are unreachable via vnc/ssh. Removing to avoid puppet issues and issues running worker health scripts.