### PR TITLE
Extending GW idle timeout for gecko-t-osx-1400-m2

### DIFF
--- a/data/roles/gecko_t_osx_1400_m2.yaml
+++ b/data/roles/gecko_t_osx_1400_m2.yaml
@@ -17,7 +17,7 @@ worker:
   client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
   access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
   generic_worker_engine: simple
-  idle_timeout_secs: 3600
+  idle_timeout_secs: 21600
 
 packages_classes:
   #- google_chrome


### PR DESCRIPTION
Generic Worker's idle timeout on macOS pools seem to be set to either 3600 seconds or 21600 seconds, respectively. `gecko-t-osx-1400-m2` was set to 3600 and nodes would periodically disappear from that pool. Setting them to 21600 seconds seems to keep them alive.