### PR TITLE
circleci: fix mac executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,15 @@ executors:
   macos-1014: &1014
     macos:
       xcode: 12.5.1  # 8/15/23: os x 11.4.0, no older available
+    resource_class: macos.m1.medium.gen1
   macos-1015: &1015
     macos:
       xcode: 12.5.1  # 8/15/23: os x 11.4.0, no older available
+    resource_class: macos.m1.medium.gen1
   macos-1100: &1100
     macos:
       xcode: 12.5.1  # 8/15/23: os x 11.4.0
+    resource_class: macos.m1.medium.gen1
 
 commands:
   early_return_for_forked_pull_requests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
       #       - run: echo "ruby-2.6.4" > ~/.ruby-version
       - run: brew install gpg
       - ruby/install:
-          version: '3'
+          version: '3.0'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ commands:
         type: string
     steps:
       - vault/install:
+          arch: arm64
           verify: false
       - run: vault version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ commands:
             hdiutil mount "puppet-agent-${PUPPET_VER}-1.osx${OS_VER}.dmg"
             sudo -E installer -pkg "/Volumes/puppet-agent-${PUPPET_VER}-1.osx${OS_VER}/puppet-agent-${PUPPET_VER}-1-installer.pkg" -target /
             # Install bolt
-            curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/arm64/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
+            # not working on arm64 (no build for arm64 yet)
+            # curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/arm64/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
+            curl -s -O https://downloads.puppet.com/mac/puppet-tools/12/x86_64/puppet-bolt-latest.dmg
             hdiutil mount "puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
             sudo -E installer -pkg "/Volumes/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}/puppet-bolt-${BOLT_VER}-1-installer.pkg" -target /
             # Install gems needed for hiera vault

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # slack: circleci/slack@3.4.2
-  vault: jmingtan/hashicorp-vault@0.2.1
+  vault: jmingtan/hashicorp-vault@0.2.2
   tfutils: ukslee/tfutils@0.0.5
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,11 @@ jobs:
             equal: [ *1014, << parameters.os >> ]
           steps:
             - run: echo "ruby-2.6.4" > ~/.ruby-version
+      - run:
+          name: Set ruby version to 2.6.4
+          command: |
+              rvm install 2.6.4
+              echo . $(rvm 2.6.4 do rvm env --path) >> $BASH_ENV
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,9 +221,9 @@ jobs:
       #       equal: [ *1014, << parameters.os >> ]
       #     steps:
       #       - run: echo "ruby-2.6.4" > ~/.ruby-version
-      - run: brew install gpg
-      - ruby/install:
-          version: '3.0'
+      # - run: brew install gpg
+      # - ruby/install:
+      #     version: '3.0'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   # slack: circleci/slack@3.4.2
   vault: jmingtan/hashicorp-vault@0.2.2
   tfutils: ukslee/tfutils@0.0.5
+  ruby: circleci/ruby@2.1.2
 
 executors:
   default:
@@ -220,11 +221,8 @@ jobs:
             equal: [ *1014, << parameters.os >> ]
           steps:
             - run: echo "ruby-2.6.4" > ~/.ruby-version
-      - run:
-          name: Set ruby version to 2.6.4
-          command: |
-              rvm install 2.6.4
-              echo . $(rvm 2.6.4 do rvm env --path) >> $BASH_ENV
+      - ruby/install:
+          version: '2.6.4'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
             equal: [ *1014, << parameters.os >> ]
           steps:
             - run: echo "ruby-2.6.4" > ~/.ruby-version
+      - run: brew install gpg
       - ruby/install:
           version: '2.6.4'
       - gem_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,15 @@ executors:
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
   macos-1014: &1014
     macos:
-      xcode: 12.5.1  # 8/15/23: os x 11.4.0, no older available
+      xcode: 13.4.1  # 4/24/24: OS X 12.6.1, no older available
     resource_class: macos.m1.medium.gen1
   macos-1015: &1015
     macos:
-      xcode: 12.5.1  # 8/15/23: os x 11.4.0, no older available
+      xcode: 13.4.1  # 4/24/24: OS X 12.6.1, no older available
     resource_class: macos.m1.medium.gen1
   macos-1100: &1100
     macos:
-      xcode: 12.5.1  # 8/15/23: os x 11.4.0
+      xcode: 13.4.1  # 4/24/24: OS X 12.6.1, no older available
     resource_class: macos.m1.medium.gen1
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,14 +216,14 @@ jobs:
       - checkout
       - setup_vault:
           role: << parameters.role >>
-      - when:
-          condition:
-            equal: [ *1014, << parameters.os >> ]
-          steps:
-            - run: echo "ruby-2.6.4" > ~/.ruby-version
+      # - when:
+      #     condition:
+      #       equal: [ *1014, << parameters.os >> ]
+      #     steps:
+      #       - run: echo "ruby-2.6.4" > ~/.ruby-version
       - run: brew install gpg
       - ruby/install:
-          version: '2.6.4'
+          version: '2.7'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,10 @@ commands:
             # Install bolt
             # not working on arm64 (no build for arm64 yet)
             # curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/arm64/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
-            curl -s -O https://downloads.puppet.com/mac/puppet-tools/12/x86_64/puppet-bolt-latest.dmg
-            hdiutil mount "puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
-            sudo -E installer -pkg "/Volumes/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}/puppet-bolt-${BOLT_VER}-1-installer.pkg" -target /
+            # hdiutil mount "puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
+            curl -s -O https://downloads.puppet.com/mac/puppet-tools/12/x86_64/puppet-bolt-3.29.0-1.osx12.dmg
+            hdiutil mount puppet-bolt-3.29.0-1.osx12.dmg
+            sudo -E installer -pkg "/Volumes/puppet-bolt-3.29.0-1.osx12/puppet-bolt-3.29.0-1-installer.pkg" -target /
             # Install gems needed for hiera vault
             sudo /opt/puppetlabs/puppet/bin/gem install vault debouncer
   apt_cache_restore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
       - image: mozillarelops/circleci-ubuntu-2004:v0.1.0
   ubuntu-2004:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: default
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
   macos-1014: &1014
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,11 +79,11 @@ commands:
             fi
             echo OSX version is "${OS_VER}"
             # Install puppet agent
-            curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/x86_64/puppet-agent-${PUPPET_VER}-1.osx${OS_VER}.dmg"
+            curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/arm64/puppet-agent-${PUPPET_VER}-1.osx${OS_VER}.dmg"
             hdiutil mount "puppet-agent-${PUPPET_VER}-1.osx${OS_VER}.dmg"
             sudo -E installer -pkg "/Volumes/puppet-agent-${PUPPET_VER}-1.osx${OS_VER}/puppet-agent-${PUPPET_VER}-1-installer.pkg" -target /
             # Install bolt
-            curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/x86_64/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
+            curl -s -O "https://downloads.puppet.com/mac/puppet/${OS_VER}/arm64/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
             hdiutil mount "puppet-bolt-${BOLT_VER}-1.osx${OS_VER}.dmg"
             sudo -E installer -pkg "/Volumes/puppet-bolt-${BOLT_VER}-1.osx${OS_VER}/puppet-bolt-${BOLT_VER}-1-installer.pkg" -target /
             # Install gems needed for hiera vault

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
       #       - run: echo "ruby-2.6.4" > ~/.ruby-version
       - run: brew install gpg
       - ruby/install:
-          version: '2.7'
+          version: '3'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   # slack: circleci/slack@3.4.2
   vault: jmingtan/hashicorp-vault@0.2.2
   tfutils: ukslee/tfutils@0.0.5
-  ruby: circleci/ruby@2.1.2
 
 executors:
   default:
@@ -219,14 +218,6 @@ jobs:
       - checkout
       - setup_vault:
           role: << parameters.role >>
-      # - when:
-      #     condition:
-      #       equal: [ *1014, << parameters.os >> ]
-      #     steps:
-      #       - run: echo "ruby-2.6.4" > ~/.ruby-version
-      # - run: brew install gpg
-      # - ruby/install:
-      #     version: '3.0'
       - gem_cache
       - install_macos_puppet
       - run: bundle exec kitchen converge << parameters.suite >>

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -123,7 +123,8 @@ class macos_safaridriver (
           }
         }
         # # 22 == OS X 13
-        '22': {
+        #    - 21 is only for CircleCI Testing, might not work, but test applying at least
+        '21', '22': {
           $perm_script = '/usr/local/bin/add_tcc_perms_os11_13.sh'
           $enable_script = '/usr/local/bin/safari-enable-remote-automation3.sh'
           $tcc_script = '/usr/local/bin/tccutil.py'

--- a/modules/macos_tcc_perms/manifests/init.pp
+++ b/modules/macos_tcc_perms/manifests/init.pp
@@ -20,7 +20,9 @@ class macos_tcc_perms (
           user    => 'root',
         }
       }
-      '20': {
+      # 20 is the only verified config
+      #   - 21 is for CircleCI testing, not verified yet
+      '20', '21': {
         $tcc_script = '/usr/local/bin/tcc_perms2.sh'
 
         file { $tcc_script:

--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -36,7 +36,7 @@ class roles_profiles::profiles::cltbld_user {
             ensure => directory,
           }
         }
-        '22', '23': {
+        '21', '22', '23': {
           exec { 'create_macos_user':
             # UID needs to be > 501 for LaunchAgents to function
             command => "/usr/sbin/sysadminctl -addUser ${account_username} -UID 555 -password '${password_hash}'",

--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -16,7 +16,7 @@ class roles_profiles::profiles::cltbld_user {
 
       # Create the cltbld user
       case $facts['os']['release']['major'] {
-        '19', '20': {
+        '19', '20', '21': {
           users::single_user { 'cltbld':
             # Bug 1122875 - cltld needs to be in this group for debug tests
             password   => $password,
@@ -36,7 +36,7 @@ class roles_profiles::profiles::cltbld_user {
             ensure => directory,
           }
         }
-        '21', '22', '23': {
+        '22', '23': {
           exec { 'create_macos_user':
             # UID needs to be > 501 for LaunchAgents to function
             command => "/usr/sbin/sysadminctl -addUser ${account_username} -UID 555 -password '${password_hash}'",


### PR DESCRIPTION
We're experiencing rolling blackouts as part of https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718. See https://mozilla-hub.atlassian.net/browse/RELOPS-936.

Switch off the old mac instance types (by defining a current instance type).

Also:
- add tentative support for the OS X version CircleCI is running (21)
- upgrade linux instance types
- upgrade orbs
