### PR TITLE
Add R8s to inventory and remove pip.conf from VPN builders

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -109,6 +109,7 @@ groups:
       - macmini-r8-104.test.releng.mdc1.mozilla.com
       - macmini-r8-105.test.releng.mdc1.mozilla.com
       - macmini-r8-106.test.releng.mdc1.mozilla.com
+      - macmini-r8-107.test.releng.mdc1.mozilla.com
       - macmini-r8-108.test.releng.mdc1.mozilla.com
       - macmini-r8-109.test.releng.mdc1.mozilla.com
       - macmini-r8-110.test.releng.mdc1.mozilla.com
@@ -167,6 +168,7 @@ groups:
       - macmini-r8-174.test.releng.mdc1.mozilla.com
       - macmini-r8-175.test.releng.mdc1.mozilla.com
       - macmini-r8-176.test.releng.mdc1.mozilla.com
+      - macmini-r8-177.test.releng.mdc1.mozilla.com
       - macmini-r8-178.test.releng.mdc1.mozilla.com
       - macmini-r8-181.test.releng.mdc1.mozilla.com
       - macmini-r8-186.test.releng.mdc1.mozilla.com
@@ -203,6 +205,7 @@ groups:
       - macmini-r8-229.test.releng.mdc1.mozilla.com
       - macmini-r8-230.test.releng.mdc1.mozilla.com
       - macmini-r8-231.test.releng.mdc1.mozilla.com
+      - macmini-r8-232.test.releng.mdc1.mozilla.com
       - macmini-r8-233.test.releng.mdc1.mozilla.com
       - macmini-r8-234.test.releng.mdc1.mozilla.com
       - macmini-r8-235.test.releng.mdc1.mozilla.com

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -24,6 +24,5 @@ class roles_profiles::roles::mozillavpn_b_1_osx {
     include ::roles_profiles::profiles::worker
     #include ::fw::roles::osx_taskcluster_worker_loaner
     #include ::macos_utils::uninstall_homebrew
-    include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
 }

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
@@ -24,6 +24,5 @@ class roles_profiles::roles::mozillavpn_b_3_osx {
     include ::roles_profiles::profiles::worker
     #include ::fw::roles::osx_taskcluster_worker_loaner
     #include ::macos_utils::uninstall_homebrew
-    include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
 }


### PR DESCRIPTION
Fixed a few previously defective R8s and removed pip.conf from VPN pools

https://mozilla-hub.atlassian.net/browse/RELOPS-941
https://mozilla-hub.atlassian.net/browse/RELOPS-943