### PR TITLE
Xcodes installer round 1

### DIFF
--- a/modules/macos_xcodes_installer/files/xcodes_installer.sh
+++ b/modules/macos_xcodes_installer/files/xcodes_installer.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 sudo curl -o /usr/local/bin/xcodes https://ronin-puppet-package-repo.s3.us-west-2.amazonaws.com/macos/public/common/xcodes;
+sudo chmod +x /usr/local/bin/xcodes;

--- a/modules/macos_xcodes_installer/files/xcodes_installer.sh
+++ b/modules/macos_xcodes_installer/files/xcodes_installer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo curl -o /usr/local/bin/xcodes https://ronin-puppet-package-repo.s3.us-west-2.amazonaws.com/macos/public/common/xcodes;

--- a/modules/macos_xcodes_installer/manifests/init.pp
+++ b/modules/macos_xcodes_installer/manifests/init.pp
@@ -1,0 +1,28 @@
+# @summary installs xcodes
+#
+#
+class macos_xcodes_installer (
+  Boolean $enabled = true,
+) {
+  if $enabled {
+    case $facts['os']['name'] {
+      'Darwin': {
+        $xcodes_installer_script = '/usr/local/bin/xcodes_installer.sh'
+
+        file { $xcodes_installer_script:
+          content => file('macos_xcodes_installer/xcodes_installer.sh'),
+          mode    => '0755',
+        }
+
+        exec { 'execute xcodes installer script':
+          command => $xcodes_installer_script,
+          require => File[$xcodes_installer_script],
+          user    => 'root',
+        }
+      }
+    default: {
+      fail("${facts['os']['release']} not supported")
+    }
+  }
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/macos_xcodes_installer.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_xcodes_installer.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_xcodes_installer {
+  class { 'macos_xcodes_installer':
+    enabled    => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
@@ -25,4 +25,5 @@ class roles_profiles::roles::gecko_t_osx_1400_m2_staging {
   include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::macos_xcodes_installer
 }


### PR DESCRIPTION
@aerickson Any clues as to why this is failing to converge?

```
Failed on macmini-m2-8.test.releng.mslv.mozilla.com:
  Apply failed to compile for macmini-m2-8.test.releng.mslv.mozilla.com: Could not find class ::roles_profiles::profiles::macos_xcodes_installer for macmini-m2-8.test.releng.mslv.mozilla.com (file: /Users/rcurran/git/ronin_xcodes/ronin_puppet/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp, line: 28, column: 3)
Failed on 1 target: macmini-m2-8.test.releng.mslv.mozilla.com
```

I modeled this after the `macos_people_remover` module which does work so I'm a little puzzled

I also tried naming the class `roles_profiles::profiles::macos_xcodes_installer` but that didn't help