### PR TITLE
moonshot linux py311 and tc update plus 1804 hg upgrade

### DIFF
--- a/.kitchen_configs/kitchen.docker.yml
+++ b/.kitchen_configs/kitchen.docker.yml
@@ -51,7 +51,10 @@ provisioner:
   puppet_verbose: true
   # explodes if version specified, see https://github.com/petems/puppet-install-shell/issues/137
   # puppet_version: 7
-  puppet_omnibus_url: https://raw.githubusercontent.com/aerickson/puppet-install-shell/2204-jammy-support/install_puppet_7_agent.sh
+  # used to work, but now grumpy about gpg keys
+  # puppet_omnibus_url: https://raw.githubusercontent.com/aerickson/puppet-install-shell/2204-jammy-support/install_puppet_7_agent.sh
+  # fix for gpg keys (includes upstream fixes for 2204)
+  puppet_omnibus_url: https://raw.githubusercontent.com/aerickson/puppet-install-shell/puppet7-1804-fix/install_puppet_7_agent.sh
   puppet_debug: true
   require_chef_for_busser: true
   require_puppet_omnibus: true

--- a/modules/linux_mercurial/manifests/init.pp
+++ b/modules/linux_mercurial/manifests/init.pp
@@ -4,11 +4,13 @@
 
 class linux_mercurial {
   include shared
-  include linux_packages::mercurial
+  class { 'linux_packages::mercurial' :
+    pkg_ensure       => 'absent',
+  }
 
   $hgext_dir       = '/usr/local/lib/hgext'
   $hgrc            = '/etc/mercurial/hgrc.d/mozilla.rc'
-  $hgrc_parentdirs = ['/etc/mercurial']
+  $hgrc_parentdirs = ['/etc/mercurial', '/etc/mercurial/hgrc.d/']
 
   # setup ext dir
   file {

--- a/modules/linux_mercurial/manifests/init.pp
+++ b/modules/linux_mercurial/manifests/init.pp
@@ -4,6 +4,8 @@
 
 class linux_mercurial {
   include shared
+
+  # install mercurial (not via package)
   class { 'linux_packages::mercurial' :
     pkg_ensure       => 'absent',
   }
@@ -14,24 +16,24 @@ class linux_mercurial {
 
   # setup ext dir
   file {
-      default: * => $::shared::file_defaults;
+    default: * => $shared::file_defaults;
 
-      $hgext_dir:
-          ensure => directory,
-          mode   => '0755';
+    $hgext_dir:
+      ensure => directory,
+      mode   => '0755';
 
-      $hgrc_parentdirs:
-          ensure => directory,
-          mode   => '0755';
+    $hgrc_parentdirs:
+      ensure => directory,
+      mode   => '0755';
 
-      $hgrc:
-          ensure => file,
-          source => 'puppet:///modules/linux_mercurial/hgrc',
-          mode   => '0644';
+    $hgrc:
+      ensure => file,
+      source => 'puppet:///modules/linux_mercurial/hgrc',
+      mode   => '0644';
   }
 
   # robust checkout
   file { "${hgext_dir}/robustcheckout.py":
-      source => 'puppet:///modules/linux_mercurial/robustcheckout.py',
+    source => 'puppet:///modules/linux_mercurial/robustcheckout.py',
   }
 }

--- a/modules/linux_packages/manifests/mercurial.pp
+++ b/modules/linux_packages/manifests/mercurial.pp
@@ -2,21 +2,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class linux_packages::mercurial {
-  case $::operatingsystem {
+# handles installation of mercurial on linux (via pkg and pip)
+class linux_packages::mercurial ( Enum['present', 'absent'] $pkg_ensure = 'present') {
+  case $facts['os']['name'] {
     'Ubuntu': {
       include linux_packages::python2_mercurial
       include linux_packages::python3_mercurial
 
-      # the binary just calls the installed python module
+      # the binary just calls the installed python module,
+      # but it points at py2 on 1804
 
       package {
-          'mercurial':
-              ensure => present;
+        'mercurial':
+          ensure => $pkg_ensure;
       }
     }
     default: {
-      fail("Cannot install on ${::operatingsystem}")
+      fail("Cannot install on ${facts['os']['name']}")
     }
   }
 }

--- a/modules/linux_packages/manifests/psutil_py2.pp
+++ b/modules/linux_packages/manifests/psutil_py2.pp
@@ -5,10 +5,11 @@
 class linux_packages::psutil_py2 {
     require linux_packages::py2
 
-    package { 'psutil_py2':
-        ensure   => '5.7.0',
-        name     => 'psutil',
-        provider => pip,
-        require  => Class['linux_packages::py2'],
-    }
+    # not installing py2 any longer
+    # package { 'psutil_py2':
+    #     ensure   => '5.7.0',
+    #     name     => 'psutil',
+    #     provider => pip,
+    #     require  => Class['linux_packages::py2'],
+    # }
 }

--- a/modules/linux_packages/manifests/py2.pp
+++ b/modules/linux_packages/manifests/py2.pp
@@ -3,12 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_packages::py2 {
-
-    package { 'python':
-        ensure   => present,
-    }
-    package { 'python-pip':
-        ensure => present,
-    }
-
+  # we're not installing py2 anymore, so remove it
+  package { 'python':
+    ensure   => absent,
+  }
+  package { 'python-pip':
+    ensure => absent,
+  }
 }

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -125,15 +125,17 @@ class linux_packages::py3 {
           #   require  => Packages::Linux_package_from_s3_multi['install py_3118'],
           # }
 
+          # no more py2
+          #
           # /usr/bin/pip ends up pointing at py3 after py3.9 install, fix that.
           #   /usr/bin/pip -> /usr/bin/pip2 (from system, vs pip3)
-          alternative_entry { '/usr/bin/pip2':
-            ensure   => present,
-            altlink  => '/usr/bin/pip',
-            altname  => 'pip',
-            priority => 20,
-            require  => Exec['install py39'],
-          }
+          # alternative_entry { '/usr/bin/pip2':
+          #   ensure   => present,
+          #   altlink  => '/usr/bin/pip',
+          #   altname  => 'pip',
+          #   priority => 20,
+          #   require  => Exec['install py39'],
+          # }
 
           # note: pip3 (/usr/local/bin/pip3, from the 39 install?) automatically
           #   uses `python3` so this works fine (no alternative entry needed).

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -113,15 +113,17 @@ class linux_packages::py3 {
             priority => 20,
             require  => Exec['install py39'],
           }
+
+          ### this breaks 18.04 (apt update starts to fail). tests will have to call python3.11.
           # set py3.11 as a higher level override
-          alternative_entry { '/opt/python/3.11.8/bin/python3':
-            ensure   => present,
-            altlink  => '/usr/bin/python3',
-            altname  => 'python3',
-            priority => 30,
-            # require  => Class['packages::linux_package_from_s3_multi'],
-            require  => Packages::Linux_package_from_s3_multi['install py_3118'],
-          }
+          # alternative_entry { '/opt/python/3.11.8/bin/python3':
+          #   ensure   => present,
+          #   altlink  => '/usr/bin/python3',
+          #   altname  => 'python3',
+          #   priority => 30,
+          #   # require  => Class['packages::linux_package_from_s3_multi'],
+          #   require  => Packages::Linux_package_from_s3_multi['install py_3118'],
+          # }
 
           # /usr/bin/pip ends up pointing at py3 after py3.9 install, fix that.
           #   /usr/bin/pip -> /usr/bin/pip2 (from system, vs pip3)

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -87,9 +87,9 @@ class linux_packages::py3 {
           }
 
           # make python3.11 available on path
-          alternative_entry { 'ae /usr/bin/python3.11':
+          alternative_entry { '/opt/python/3.11.8/bin/python3.11':
             ensure   => present,
-            altlink  => '/opt/python/3.11.8/bin/python3.11',
+            altlink  => '/usr/bin/python3.11',
             altname  => 'python3.11',
             priority => 30,
             # require  => Class['packages::linux_package_from_s3_multi'],
@@ -114,7 +114,7 @@ class linux_packages::py3 {
             require  => Exec['install py39'],
           }
           # set py3.11 as a higher level override
-          alternative_entry { '/opt/python/3.11.8/bin/python3.11':
+          alternative_entry { '/opt/python/3.11.8/bin/python3':
             ensure   => present,
             altlink  => '/usr/bin/python3',
             altname  => 'python3',

--- a/modules/linux_packages/manifests/py3.pp
+++ b/modules/linux_packages/manifests/py3.pp
@@ -64,6 +64,20 @@ class linux_packages::py3 {
               && /usr/bin/python3 -c "import distutils"',
           }
 
+          # py 3.11, from https://github.com/rstudio/python-builds
+          #   - pysnakes ppa: no longer publishing bionic debs
+
+          $temp_dir = '/tmp/py3118'
+
+          $pkgs_and_chksums_hash = {
+          'python-3.11.8_1_amd64.deb' => 'f83e52a7e57ba7c7d3f783c9168b125e04e510c9c43212baa98eaa614470d611' }
+
+          packages::linux_package_from_s3_multi { 'install py_3118' :
+            packages_and_checksums => $pkgs_and_chksums_hash,
+            temp_dir               => $temp_dir,
+            os_version_specific    => false,
+          }
+
           # configure alternatives
           #
           # system default py3.6 (what's installed by default)
@@ -80,6 +94,14 @@ class linux_packages::py3 {
             altname  => 'python3',
             priority => 20,
             require  => Exec['install py39'],
+          }
+          # set py3.11 as a higher level override
+          alternative_entry { '/opt/python/3.11.8/bin/python3.11':
+            ensure   => present,
+            altlink  => '/usr/bin/python3',
+            altname  => 'python3',
+            priority => 30,
+            require  => Exec['install py_3118'],
           }
 
           # /usr/bin/pip ends up pointing at py3 after py3.9 install, fix that.

--- a/modules/linux_packages/manifests/python2_mercurial.pp
+++ b/modules/linux_packages/manifests/python2_mercurial.pp
@@ -3,13 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_packages::python2_mercurial {
-    require linux_packages::py2
+  # no more py2
+  #
 
-    # robustcheckout is super slow with 4.9+
-    # see https://bugzilla.mozilla.org/show_bug.cgi?id=1672816
-    package { 'python2-mercurial':
-        ensure   => '4.8.1',
-        name     => 'mercurial',
-        provider => pip,
-    }
+  # require linux_packages::py2
+
+  # robustcheckout is super slow with 4.9+
+  # see https://bugzilla.mozilla.org/show_bug.cgi?id=1672816
+  # package { 'python2-mercurial':
+  #     ensure   => '4.8.1',
+  #     name     => 'mercurial',
+  #     provider => pip,
+  # }
 }

--- a/modules/linux_packages/manifests/python2_zstandard.pp
+++ b/modules/linux_packages/manifests/python2_zstandard.pp
@@ -3,12 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_packages::python2_zstandard {
-    require linux_packages::py2
 
-    package { 'python2-zstandard':
-        ensure   => '0.11.1',
-        name     => 'zstandard',
-        provider => pip,
-        require  => Class['linux_packages::py2'],
-    }
+    # no more py2
+    #
+    #require linux_packages::py2
+    # package { 'python2-zstandard':
+    #     ensure   => '0.11.1',
+    #     name     => 'zstandard',
+    #     provider => pip,
+    #     require  => Class['linux_packages::py2'],
+    # }
 }

--- a/modules/linux_packages/manifests/python3_mercurial.pp
+++ b/modules/linux_packages/manifests/python3_mercurial.pp
@@ -5,10 +5,10 @@
 class linux_packages::python3_mercurial {
     require linux_packages::py3
 
-    # mercurial below 5 is not compatible with py3
-    # package { 'python3-mercurial':
-    #     ensure   => '4.7.1',
-    #     name     => 'mercurial',
-    #     provider => pip3,
-    # }
+    # '6.7.4' is latest, but robustcheckout needs 6.4 or less
+    package { 'python3-mercurial':
+        ensure   => '6.4.5',
+        name     => 'mercurial',
+        provider => pip3,
+    }
 }

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -3,15 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class packages::python2_zstandard (
-    String $version = '0.11.1',
+  String $version = '0.11.1',
 ) {
-    # not installing py2 any longer
-    #
-    # require packages::python2
-    # package { 'python2-zstandard':
-    #     ensure   => $version,
-    #     name     => 'zstandard',
-    #     provider => pip,
-    #     require  => Class['packages::python2'],
-    # }
+  require packages::python2
+
+  package { 'python2-zstandard':
+    ensure   => $version,
+    name     => 'zstandard',
+    provider => pip,
+    require  => Class['packages::python2'],
+  }
 }

--- a/modules/packages/manifests/python2_zstandard.pp
+++ b/modules/packages/manifests/python2_zstandard.pp
@@ -5,12 +5,13 @@
 class packages::python2_zstandard (
     String $version = '0.11.1',
 ) {
-    require packages::python2
-
-    package { 'python2-zstandard':
-        ensure   => $version,
-        name     => 'zstandard',
-        provider => pip,
-        require  => Class['packages::python2'],
-    }
+    # not installing py2 any longer
+    #
+    # require packages::python2
+    # package { 'python2-zstandard':
+    #     ensure   => $version,
+    #     name     => 'zstandard',
+    #     provider => pip,
+    #     require  => Class['packages::python2'],
+    # }
 }

--- a/modules/puppet/templates/puppet-ubuntu-run-puppet.sh.erb
+++ b/modules/puppet/templates/puppet-ubuntu-run-puppet.sh.erb
@@ -7,6 +7,13 @@ PUPPET_ENV="${PUPPET_ENV:-<%= @puppet_env -%>}"
 PUPPET_REPO="${PUPPET_REPO:-<%= @puppet_repo -%>}"
 PUPPET_BRANCH="${PUPPET_BRANCH:-<%= @puppet_branch -%>}"
 PUPPET_MAIL="${PUPPET_MAIL:-<%= @puppet_notify_email %>}"
+
+# Override defaults with values from /etc/puppet/ronin_settings if the file exists
+if [ -f "/etc/puppet/ronin_settings" ]; then
+    echo "Loading settings from /etc/puppet/ronin_settings..."
+    source /etc/puppet/ronin_settings
+fi
+
 WORKING_DIR="/etc/puppet/environments/${PUPPET_ENV}/code"
 ROLE_FILE='/etc/puppet_role'
 PUPPET_BIN='/opt/puppetlabs/bin/puppet'

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_talos_generic_worker.pp
@@ -8,7 +8,7 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
     $worker_type  = 'gecko-t-linux-talos-1804'
     $worker_group = regsubst($facts['networking']['fqdn'], '.*\.releng\.(.+)\.mozilla\..*', '\1')
 
-    case $::operatingsystem {
+    case $facts['os']['name'] {
         'Ubuntu': {
             require roles_profiles::profiles::cltbld_user
 
@@ -66,14 +66,14 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
                 quarantine_client_id      => $quarantine_client_id,
                 quarantine_access_token   => $quarantine_access_token,
                 bugzilla_api_key          => $bugzilla_api_key,
-                generic_worker_version    => 'v44.23.2',
-                generic_worker_sha256     => '4b65b06281848749500063a53190d0222372fe7252ef77f935081bfbfa915ebe',
-                taskcluster_proxy_version => 'v44.23.2',
-                taskcluster_proxy_sha256  => 'af0559355a607ecc933e0109b12c187c2d7679a4b9b0044ad1c43b122000e3c5',
-                livelog_version           => 'v44.23.2',
-                livelog_sha256            => '0adbad0397aa608f4b826bff0dc504d2f9f4efba6474ec4c0d8f8ee22cf2ee90',
-                start_worker_version      => 'v44.23.2',
-                start_worker_sha256       => '05b00bbca08477d79613025ee877b8f0a925ab3c6063ef62316c9017ccce5881',
+                generic_worker_version    => 'v61.0.0',
+                generic_worker_sha256     => '9aed38c86c1c0417725a677318857266e51bd28e69b2e27586edd72e658af3f0',
+                taskcluster_proxy_version => 'v61.0.0',
+                taskcluster_proxy_sha256  => '639b3333cfefaf4d2e449c2962c20912e4449c3ffb9ab6d899c237d87e46712c',
+                livelog_version           => 'v61.0.0',
+                livelog_sha256            => '0513c85b3ad2f289961992ec166ee1e890ad033a1b485c29c69653049c369e23',
+                start_worker_version      => 'v61.0.0',
+                start_worker_sha256       => 'ddf74465e77e2a97a12c87a15dcd9599952127cb38b2e7040bc3177802b1151e',
                 quarantine_worker_version => 'v1.0.0',
                 quarantine_worker_sha256  => '42ea9e9df5dce6370750cf5141a400c07f781d3e28953a5f6d5066d4967a144c',
                 user                      => 'cltbld',
@@ -84,7 +84,7 @@ class roles_profiles::profiles::gecko_t_linux_talos_generic_worker {
 
         }
         default: {
-            fail("${::operatingsystem} not supported")
+            fail("${facts['os']['name']} not supported")
         }
     }
 }

--- a/test/integration/linux-perf/inspec/mercurial_spec.rb
+++ b/test/integration/linux-perf/inspec/mercurial_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'spec_helper'
 
-describe package('mercurial'), :if => os[:family] == 'ubuntu' do
-  it { should be_installed }
-end
+# describe package('mercurial'), :if => os[:family] == 'ubuntu' do
+#   it { should be_installed }
+# end
 
 describe file('/etc/mercurial/hgrc.d/mozilla.rc') do
   it { should exist }
@@ -16,15 +16,19 @@ end
 
 # pips
 
-# TODO: check versions
+# not installing py2 any longer
+# describe command('pip list | grep mercurial') do
+#   its(:exit_status) { should eq 0 }
+#   its(:stdout) { should match /mercurial/ }
+# end
 
-describe command('pip list | grep mercurial') do
+describe command('pip3 list | grep mercurial') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match /mercurial/ }
 end
 
-# disabled until we're on mercurial 5/py3 compatible version
-# describe command('pip3 list | grep mercurial') do
-#   its(:exit_status) { should eq 0 }
-#   its(:stdout) { should match /mercurial/ }
-# end
+# check version
+describe command('hg --version') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match /version 6.4.5/ }
+end

--- a/test/integration/linux-perf/inspec/psutil_spec.rb
+++ b/test/integration/linux-perf/inspec/psutil_spec.rb
@@ -1,9 +1,11 @@
 require_relative 'spec_helper'
 
-describe command('pip list | grep psutil') do
-  its(:exit_status) { should eq 0 }
-  its(:stdout) { should match /psutil/ }
-end
+# no more py2
+#
+# describe command('pip list | grep psutil') do
+#   its(:exit_status) { should eq 0 }
+#   its(:stdout) { should match /psutil/ }
+# end
 
 describe command('pip3 list | grep psutil') do
   its(:exit_status) { should eq 0 }

--- a/test/integration/linux-perf/inspec/python_spec.rb
+++ b/test/integration/linux-perf/inspec/python_spec.rb
@@ -39,7 +39,7 @@ describe command('python -m pip check') do
   its(:exit_status) { should eq 0 }
 end
 
-# system provided 3.6
+# default python3 (was system provided 3.6 initially)
 describe command('python3 -m pip check') do
   its(:exit_status) { should eq 0 }
 end
@@ -48,8 +48,8 @@ describe command('python3.9 -m pip check') do
   its(:exit_status) { should eq 0 }
 end
 
-# ensure /usr/bin/python3 is py3.9
+# ensure /usr/bin/python3 is py3.11
 describe command('/usr/bin/python3 --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match /Python 3.9/ }
+  its(:stdout) { should match /Python 3.11/ }
 end

--- a/test/integration/linux-perf/inspec/python_spec.rb
+++ b/test/integration/linux-perf/inspec/python_spec.rb
@@ -34,10 +34,12 @@ end
 
 # ensure pip check returns 0 for all pythons
 
+# no more py2
+#
 # system provided
-describe command('python -m pip check') do
-  its(:exit_status) { should eq 0 }
-end
+# describe command('python -m pip check') do
+#   its(:exit_status) { should eq 0 }
+# end
 
 # default python3 (was system provided 3.6 initially)
 describe command('python3 -m pip check') do

--- a/test/integration/linux-perf/inspec/python_spec.rb
+++ b/test/integration/linux-perf/inspec/python_spec.rb
@@ -51,5 +51,5 @@ end
 # ensure /usr/bin/python3 is py3.11
 describe command('/usr/bin/python3 --version') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match /Python 3.11/ }
+  its(:stdout) { should match /Python 3.9/ }
 end

--- a/test/integration/linux-perf/inspec/testresources_spec.rb
+++ b/test/integration/linux-perf/inspec/testresources_spec.rb
@@ -1,8 +1,10 @@
 require_relative 'spec_helper'
 
-describe package('python-testresources'), :if => os[:family] == 'ubuntu' do
-  it { should be_installed }
-end
+# no more py2
+#
+# describe package('python-testresources'), :if => os[:family] == 'ubuntu' do
+#   it { should be_installed }
+# end
 
 describe package('python3-testresources'), :if => os[:family] == 'ubuntu' do
   it { should be_installed }

--- a/test/integration/linux-perf/inspec/zstandard_spec.rb
+++ b/test/integration/linux-perf/inspec/zstandard_spec.rb
@@ -1,9 +1,11 @@
 require_relative 'spec_helper'
 
-describe bash('pip list | grep zstandard') do
-  its('exit_status') { should eq 0 }
-  its('stdout') { should match /zstandard/ }
-end
+# no more py2
+#
+# describe bash('pip list | grep zstandard') do
+#   its('exit_status') { should eq 0 }
+#   its('stdout') { should match /zstandard/ }
+# end
 
 describe bash('pip3 list | grep zstandard') do
   its('exit_status') { should eq 0 }


### PR DESCRIPTION
- **talos moonshot: use v61 of tc components**
- **kitchen docker: puppet-agent install fix**
- **install py3.11 and set as default**
- **py3 test tweaks**
- **wip**
- **alternatives fixing**
- **disable alternative making python3 call python3.11**
- **fix test**
- **place 1804_hg_upgrade changes on top of moonshot_linux_py311_and_tc_update**
- **re-enable mac py2zstandard, disable linux py2zstandard**
- **run-puppet file can load settings from a non-vc path**
