### PR TITLE
RELOPS-913: Skip cltbld provisioning for builders

### DIFF
--- a/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::applicationservices_1_b_osx_1015 {
     include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    # include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     #include ::roles_profiles::profiles::homebrew
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::applicationservices_3_b_osx_1015 {
     include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    # include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     #include ::roles_profiles::profiles::homebrew
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::gecko_1_b_osx_1015 {
     # include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::worker
     #include ::fw::roles::osx_taskcluster_worker_loaner

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::gecko_1_b_osx_1015_staging {
     #include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::worker
     #include ::fw::roles::osx_taskcluster_worker_loaner

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::gecko_3_b_osx_1015 {
     # include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    # include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::worker
     #include ::fw::roles::osx_taskcluster_worker_loaner

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
@@ -19,7 +19,7 @@ class roles_profiles::roles::gecko_3_b_osx_arm64 {
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
     include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
+    # include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::talos
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::mozillavpn_b_1_osx {
     include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     #include ::roles_profiles::profiles::homebrew
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::mozillavpn_b_3_osx {
     include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::relops_users
     #include ::roles_profiles::profiles::homebrew
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::nss_1_b_osx_1015 {
     # include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::worker

--- a/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
@@ -18,7 +18,7 @@ class roles_profiles::roles::nss_3_b_osx_1015 {
     # include ::roles_profiles::profiles::hardware
     include ::roles_profiles::profiles::motd
     include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::cltbld_user
+    #include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::packages_installed
     include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::worker


### PR DESCRIPTION
macOS builders run multiuser gw and do not need the cltbld account provisioned

provisioning the account creates an issue where we need to manually disable auto login for cltbld for multiuser gw to function as expected.