### PR TITLE
Change cltbld account provisioning

### DIFF
--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -62,7 +62,7 @@ class macos_safaridriver (
           exec { "${user_running_safari}_group_${group}":
             command => "/usr/sbin/dseditgroup -o edit -a ${user_running_safari} -t user ${group}",
             unless  => "/usr/bin/groups ${user_running_safari} | /usr/bin/grep -q -w ${group}",
-            require => User[$user_running_safari],
+            require => Exec['create_macos_user'],
           }
         }
         # 20 == OS X 11
@@ -117,7 +117,7 @@ class macos_safaridriver (
           exec { "${user_running_safari}_group_${group}":
             command => "/usr/sbin/dseditgroup -o edit -a ${user_running_safari} -t user ${group}",
             unless  => "/usr/bin/groups ${user_running_safari} | /usr/bin/grep -q -w ${group}",
-            #require => User[$user_running_safari],
+            require => Exec['create_macos_user'],
           }
         }
         # # 22 == OS X 13
@@ -173,7 +173,7 @@ class macos_safaridriver (
           exec { "${user_running_safari}_group_${group}":
             command => "/usr/sbin/dseditgroup -o edit -a ${user_running_safari} -t user ${group}",
             unless  => "/usr/bin/groups ${user_running_safari} | /usr/bin/grep -q -w ${group}",
-            #require => User[$user_running_safari],
+            require => Exec['create_macos_user'],
           }
         }
         # # 23 == OS X 14
@@ -253,7 +253,7 @@ class macos_safaridriver (
           exec { "${user_running_safari}_group_${group}":
             command => "/usr/sbin/dseditgroup -o edit -a ${user_running_safari} -t user ${group}",
             unless  => "/usr/bin/groups ${user_running_safari} | /usr/bin/grep -q -w ${group}",
-            #require => User[$user_running_safari],
+            require => Exec['create_macos_user'],
           }
         }
         default: {

--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -5,46 +5,19 @@
 class roles_profiles::profiles::cltbld_user {
   case $facts['os']['name'] {
     'Darwin': {
-      $account_username = 'cltbld'
-      $password     = lookup('cltbld_user.password')
-      # lookup('cltbld_user.unhashedpassword') does not work for some reason. Hard coding for now
-      $password_unhashed    = 'cltbld'
-      $salt         = lookup('cltbld_user.salt')
-      $iterations   = lookup('cltbld_user.iterations')
-      $kcpassword   = lookup('cltbld_user.kcpassword')
-      $password_hash = inline_template("<%= IO.popen(['openssl', 'passwd', '-6', '-salt', '${salt}', '-6', '-rounds', '${iterations}', '${password}']).read.chomp %>")
+      $account = lookup('cltbld_user.password')
 
       # Create the cltbld user
       case $facts['os']['release']['major'] {
-        '19': {
-          users::single_user { 'cltbld':
-            # Bug 1122875 - cltld needs to be in this group for debug tests
-            password   => $password,
-            salt       => $salt,
-            iterations => $iterations,
-          }
-          # Set user to autologin
-          class { 'macos_utils::autologin_user':
-            user       => 'cltbld',
-            kcpassword => $kcpassword,
-          }
-          macos_utils::clean_appstate { 'cltbld':
-            user  => 'cltbld',
-            group => 'staff',
-          }
-          file { '/Users/cltbld/Library/LaunchAgents':
-            ensure => directory,
-          }
-        }
-        '20','21','22', '23': {
+        '19','20','21','22', '23': {
           exec { 'create_macos_user':
             # UID needs to be > 501 for LaunchAgents to function
-            command => "/usr/sbin/sysadminctl -addUser ${account_username} -UID 555 -password '${password_hash}'",
+            command => "/usr/sbin/sysadminctl -addUser ${account} -UID 555 -password '${account}'",
             unless  => '/usr/bin/dscl . -read /Users/cltbld',
           }
           class { 'macos_utils::autologin_user':
-            user       => $account_username,
-            kcpassword => $password_unhashed,
+            user       => $account,
+            kcpassword => $account,
           }
           macos_utils::clean_appstate_13_plus { 'cltbld':
             user  => 'cltbld',
@@ -63,7 +36,7 @@ class roles_profiles::profiles::cltbld_user {
         exec { "cltbld_group_${group}":
           command => "/usr/bin/dscl . -append /Groups/${group} GroupMembership cltbld",
           unless  => "/usr/bin/groups cltbld | /usr/bin/grep -q -w ${group}",
-          #require => User['cltbld'],
+          require => Exec['create_macos_user'],
         }
       }
       # Ensure the AuthenticationAuthority hash is set.  Puppet does not set this when creating a user.  Needed for GUI/VNC access.
@@ -71,16 +44,16 @@ class roles_profiles::profiles::cltbld_user {
       exec { 'cltbld_auth_key':
         command => "/usr/bin/dscl . -create /Users/cltbld AuthenticationAuthority ${auth_key_hash}",
         unless  => "/usr/bin/dscl . -read /Users/cltbld AuthenticationAuthority| grep -q -w ${auth_key_hash}",
-        #require => User['cltbld'],
+        require => Exec['create_macos_user'],
       }
 
       # Enable DevToolsSecurity
       include macos_utils::enable_dev_tools_security
 
       mercurial::hgrc { '/Users/cltbld/.hgrc':
-        user  => 'cltbld',
-        group => 'staff',
-        # require => User['cltbld'],
+        user    => 'cltbld',
+        group   => 'staff',
+        require => Exec['create_macos_user'],
       }
 
       $sudo_commands = ['/sbin/reboot']


### PR DESCRIPTION
Historically we've been setting the password for the `cltbld` account using salt/iterations/hashing. The end result was a secure password but also one that was unknown to us in plaintext.

In an effort to shift to Generic Worker multiuser, we will need to hard code the credentials for `cltbld` in` /opt/worker/current-task-user.json` and `/opt/worker/next-task-user.json.`

This PR sets a plaintext password stored in Vault.

@aerickson I don't think this will break anything on your end, but can you check line 67 and just ensure there will be no conflict. I changed `cltbld_user.password` in Vault, but only in `roles/gecko_t_osx_1015_r8_staging/vault_secrets::cltbld_user
`

Thanks