### PR TITLE
RELOPS-838 Add directory_cleaner module to cleanup GW

### DIFF
--- a/modules/macos_directory_cleaner/manifests/init.pp
+++ b/modules/macos_directory_cleaner/manifests/init.pp
@@ -1,0 +1,43 @@
+class macos_directory_cleaner (
+  Boolean $enabled = true,
+) {
+  # Install the directory_cleaner package using pip3
+  exec { 'install_directory_cleaner':
+    command => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 install directory_cleaner',
+    # require => Package['python3-pip'],
+    unless  => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 show directory_cleaner',
+  }
+
+  # Create necessary directories if they do not exist
+  file { '/opt/directory_cleaner':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'wheel',
+    mode   => '0755',
+  }
+
+  file { '/opt/directory_cleaner/configs':
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0755',
+    require => File['/opt/directory_cleaner'],
+  }
+
+  # Define the content of the file to be created
+  $config_content = @("EOF")
+    exclusion_patterns = [
+
+               ]
+EOF
+
+  # Create the configuration file with the specified content
+  file { '/opt/directory_cleaner/configs/config.toml':
+    ensure  => file,
+    content => $config_content,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'wheel',
+    require => File['/opt/directory_cleaner/configs'],
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/macos_directory_cleaner.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_directory_cleaner.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_directory_cleaner {
+  class { 'macos_directory_cleaner':
+    enabled    => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
@@ -29,4 +29,5 @@ class roles_profiles::roles::gecko_t_osx_1015_r8_staging {
     include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
     include ::roles_profiles::profiles::macos_tcc_perms
+    include ::roles_profiles::profiles::macos_directory_cleaner
 }

--- a/modules/worker_runner/templates/worker-runner.sh.erb
+++ b/modules/worker_runner/templates/worker-runner.sh.erb
@@ -66,6 +66,11 @@ else
     sleep 30
 fi
 
+echo "Cleaning /opt/worker/downloads/ and /opt/worker/cache/"
+
+directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/downloads
+directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/caches
+
 echo "REBOOT $(date)"
 /usr/bin/sudo /sbin/reboot
 # Sleep to prevent this script from terminating naturally, and launchd restarting


### PR DESCRIPTION
For the last few weeks we've seen `/opt/worker/downloads` and `/opt/worker/cache` on the r8s not getting cleaned up by generic worker, causing subsequent test failures due to insufficient amounts of space.

This runs the tool @aerickson created before the machine reboots between tasks.
