### PR TITLE
Update Mercurial/use Python3 per RELOPS-1005

### DIFF
--- a/data/roles/applicationservices_1_b_osx_1015.yaml
+++ b/data/roles/applicationservices_1_b_osx_1015.yaml
@@ -45,7 +45,7 @@ packages_classes:
 
 # Package class parameters
 # packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/applicationservices_3_b_osx_1015.yaml
+++ b/data/roles/applicationservices_3_b_osx_1015.yaml
@@ -45,7 +45,7 @@ packages_classes:
 
 # Package class parameters
 # packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_1_b_osx_arm64.yaml
+++ b/data/roles/gecko_1_b_osx_arm64.yaml
@@ -42,7 +42,7 @@ packages_classes:
 
 # Package class parameters
 #packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_3_b_osx_arm64.yaml
+++ b/data/roles/gecko_3_b_osx_arm64.yaml
@@ -37,11 +37,11 @@ packages_classes:
   - wget
   - zstandard
   - telegraf
-  - virt_audio_s3
+  # - virt_audio_s3
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1
@@ -51,7 +51,7 @@ packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::zstandard::version: 1.3.8
 packages::telegraf::version: 1.19.0
-packages::virt_audio_s3::version: 0.5.0
+# packages::virt_audio_s3::version: 0.5.0
 
 # Talos class parameters
 talos::user: cltbld

--- a/data/roles/gecko_t_osx_1100_m1.yaml
+++ b/data/roles/gecko_t_osx_1100_m1.yaml
@@ -42,7 +42,7 @@ packages_classes:
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -42,7 +42,7 @@ packages_classes:
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1100_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1100_r8_latest.yaml
@@ -38,7 +38,7 @@ packages_classes:
 
 # Package class parameters
 packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1200_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1200_r8_latest.yaml
@@ -38,7 +38,7 @@ packages_classes:
 
 # Package class parameters
 #packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1300_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1300_r8_latest.yaml
@@ -38,7 +38,7 @@ packages_classes:
 
 # Package class parameters
 # packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1400_m2.yaml
+++ b/data/roles/gecko_t_osx_1400_m2.yaml
@@ -43,7 +43,7 @@ packages_classes:
 
 # Package class parameters
 #packages::google_chrome::version: v115.0.5790.102_arm64
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1400_m2_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_m2_staging.yaml
@@ -43,7 +43,7 @@ packages_classes:
 
 # Package class parameters
 #packages::google_chrome::version: v115.0.5790.102_arm64
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/data/roles/gecko_t_osx_1400_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_latest.yaml
@@ -40,7 +40,7 @@ packages_classes:
 
 # Package class parameters
 # packages::google_chrome::version: v115.0.5790.102
-packages::mercurial::version: 5.5.2
+packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18
 packages::python2_zstandard::version: 0.11.1

--- a/modules/packages/manifests/mercurial.pp
+++ b/modules/packages/manifests/mercurial.pp
@@ -28,6 +28,8 @@ class packages::mercurial (
     ensure   => $version,
     name     => 'mercurial',
     provider => pip3,
+    # Sometimes it seems this below is needed for macOS > 10.15 (?)
+    #install_options => ['--use-pep517'],
     require  => Class['packages::python3', 'packages::xcode_cmd_line_tools'],
   }
 


### PR DESCRIPTION
Updated Mercurial from v5.5.2 to v6.4.5.

The previous version was using python2. This update uses python3