### PR TITLE
macOS role/manifest cleanup

### DIFF
--- a/data/roles/applicationservices_1_b_osx_1015.yaml
+++ b/data/roles/applicationservices_1_b_osx_1015.yaml
@@ -27,7 +27,6 @@ generic_worker:
   bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"
 
 packages_classes:
-  #- google_chrome
   - mercurial
   - nodejs
   - python2
@@ -44,7 +43,6 @@ packages_classes:
   - zstandard
 
 # Package class parameters
-# packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/applicationservices_3_b_osx_1015.yaml
+++ b/data/roles/applicationservices_3_b_osx_1015.yaml
@@ -27,7 +27,6 @@ generic_worker:
   bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"
 
 packages_classes:
-  #- google_chrome
   - mercurial
   - nodejs
   - python2
@@ -44,7 +43,6 @@ packages_classes:
   - zstandard
 
 # Package class parameters
-# packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_1_b_osx_1015.yaml
+++ b/data/roles/gecko_1_b_osx_1015.yaml
@@ -19,8 +19,8 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - python3
   - mercurial
+  - python3
   - python3_zstandard
   - xcode_cmd_line_tools
   - zstandard

--- a/data/roles/gecko_1_b_osx_1015_staging.yaml
+++ b/data/roles/gecko_1_b_osx_1015_staging.yaml
@@ -19,8 +19,8 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - python3
   - mercurial
+  - python3
   - python3_zstandard
   - xcode_cmd_line_tools
   - zstandard

--- a/data/roles/gecko_1_b_osx_arm64.yaml
+++ b/data/roles/gecko_1_b_osx_arm64.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-    #  - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
@@ -41,7 +38,6 @@ packages_classes:
   - xcode_cmd_line_tools
 
 # Package class parameters
-#packages::google_chrome::version: v80.0.3987.106
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_3_b_osx_1015.yaml
+++ b/data/roles/gecko_3_b_osx_1015.yaml
@@ -19,8 +19,8 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - python3
   - mercurial
+  - python3
   - python3_zstandard
   - xcode_cmd_line_tools
   - zstandard

--- a/data/roles/gecko_3_b_osx_arm64.yaml
+++ b/data/roles/gecko_3_b_osx_arm64.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-    #  - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,14 +28,12 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
   - wget
   - zstandard
   - telegraf
-  # - virt_audio_s3
 
 # Package class parameters
 packages::google_chrome::version: v80.0.3987.106
@@ -51,7 +47,6 @@ packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::zstandard::version: 1.3.8
 packages::telegraf::version: 1.19.0
-# packages::virt_audio_s3::version: 0.5.0
 
 # Talos class parameters
 talos::user: cltbld

--- a/data/roles/gecko_t_osx_1015_r8.yaml
+++ b/data/roles/gecko_t_osx_1015_r8.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1015_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1015_r8_staging.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1100_m1.yaml
+++ b/data/roles/gecko_t_osx_1100_m1.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-    #  - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
@@ -41,7 +38,6 @@ packages_classes:
   - xcode_cmd_line_tools
 
 # Package class parameters
-packages::google_chrome::version: v80.0.3987.106
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1100_m1_loaner.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_loaner.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-    #  - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
@@ -41,7 +38,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v80.0.3987.106
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1100_m1_staging.yaml
+++ b/data/roles/gecko_t_osx_1100_m1_staging.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-    #  - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -41,7 +39,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v80.0.3987.106
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1100_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1100_r8_latest.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1200_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1200_r8_latest.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  #- google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-#packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1300_m2_vms.yaml
+++ b/data/roles/gecko_t_osx_1300_m2_vms.yaml
@@ -21,7 +21,6 @@ worker:
 
 packages_classes:
   - google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +29,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
@@ -41,7 +39,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102_arm64
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1300_r8.yaml
+++ b/data/roles/gecko_t_osx_1300_r8.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1300_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1300_r8_latest.yaml
@@ -19,7 +19,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  #- google_chrome
   - mercurial
   - nodejs
   - python2
@@ -37,7 +36,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-# packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1400_m2.yaml
+++ b/data/roles/gecko_t_osx_1400_m2.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 21600
 
 packages_classes:
-  #- google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - safari_preview
   - scres
   - tooltool
@@ -42,7 +39,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-#packages::google_chrome::version: v115.0.5790.102_arm64
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1400_m2_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_m2_staging.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 3600
 
 packages_classes:
-  #- google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - safari_preview
   - scres
   - tooltool
@@ -42,7 +39,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-#packages::google_chrome::version: v115.0.5790.102_arm64
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1400_m2_vms_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_m2_vms_staging.yaml
@@ -20,8 +20,6 @@ worker:
   idle_timeout_secs: 21600
 
 packages_classes:
-  #- google_chrome
-    #  - java_developer_package_for_osx
   - mercurial
   - nodejs
   - python2
@@ -30,7 +28,6 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_zstandard
-#  - rosetta_2
   - scres
   - tooltool
   - virtualenv
@@ -41,7 +38,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-#packages::google_chrome::version: v115.0.5790.102_arm64
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1400_r8_latest.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_latest.yaml
@@ -20,7 +20,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  # - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -39,7 +38,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-# packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/gecko_t_osx_1400_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_staging.yaml
@@ -20,7 +20,6 @@ worker:
   idle_timeout_secs: 21600 # 6 hours
 
 packages_classes:
-  # - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -39,7 +38,6 @@ packages_classes:
   - virt_audio_s3
 
 # Package class parameters
-# packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/mozilla_b_3_osx.yaml
+++ b/data/roles/mozilla_b_3_osx.yaml
@@ -36,7 +36,6 @@ packages_classes:
   - telegraf
 
 # Package class parameters
-packages::google_chrome::version: v80.0.3987.106
 packages::mercurial::version: 6.4.5
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/mozillavpn_b_1_osx.yaml
+++ b/data/roles/mozillavpn_b_1_osx.yaml
@@ -27,7 +27,6 @@ generic_worker:
   bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -44,7 +43,6 @@ packages_classes:
   - zstandard
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/data/roles/mozillavpn_b_3_osx.yaml
+++ b/data/roles/mozillavpn_b_3_osx.yaml
@@ -27,7 +27,6 @@ generic_worker:
   bugzilla_api_key: "%{lookup('vault_secrets::generic_worker.data.bugzilla_api_key')}"
 
 packages_classes:
-  - google_chrome
   - mercurial
   - nodejs
   - python2
@@ -44,7 +43,6 @@ packages_classes:
   - zstandard
 
 # Package class parameters
-packages::google_chrome::version: v115.0.5790.102
 packages::mercurial::version: 5.5.2
 packages::nodejs::version: 12.11.1
 packages::python2::version: 2.7.18

--- a/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::applicationservices_1_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
   include roles_profiles::profiles::macos_people_remover

--- a/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_1_b_osx_1015.pp
@@ -3,28 +3,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::applicationservices_1_b_osx_1015 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    #include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    #include ::roles_profiles::profiles::suppress_dialog_boxes
-    #include ::roles_profiles::profiles::power_management
-    #include ::roles_profiles::profiles::screensaver
-    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    #include ::roles_profiles::profiles::software_updates
-    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    # include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::relops_users
-    #include ::roles_profiles::profiles::homebrew
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
-    #include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::gui
+  include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::applicationservices_3_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
   include roles_profiles::profiles::macos_people_remover

--- a/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/applicationservices_3_b_osx_1015.pp
@@ -3,28 +3,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::applicationservices_3_b_osx_1015 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    #include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    #include ::roles_profiles::profiles::suppress_dialog_boxes
-    #include ::roles_profiles::profiles::power_management
-    #include ::roles_profiles::profiles::screensaver
-    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    #include ::roles_profiles::profiles::software_updates
-    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    # include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::relops_users
-    #include ::roles_profiles::profiles::homebrew
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
-    #include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::gui
+  include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_1_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015.pp
@@ -3,16 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_1_b_osx_1015 {
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::network
-  include roles_profiles::profiles::vnc
-  include roles_profiles::profiles::sudo
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::worker
-  include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_1_b_osx_1015_staging {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_1015_staging.pp
@@ -3,16 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_1_b_osx_1015_staging {
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::network
-  include roles_profiles::profiles::vnc
-  include roles_profiles::profiles::sudo
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::worker
-  include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64.pp
@@ -2,28 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class roles_profiles::roles::gecko_1_b_osx_arm64{
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    #include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    #include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    #include ::roles_profiles::profiles::macos_tcc_perms
+class roles_profiles::roles::gecko_1_b_osx_arm64 {
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_1_b_osx_arm64 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
@@ -3,16 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_3_b_osx_1015 {
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::network
-  include roles_profiles::profiles::vnc
-  include roles_profiles::profiles::sudo
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::worker
-  include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_3_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_3_b_osx_arm64 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64.pp
@@ -3,27 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_3_b_osx_arm64 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    # include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    #include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    #include ::roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
@@ -4,6 +4,7 @@
 
 class roles_profiles::roles::gecko_3_t_osx_1014 {
   include fw::roles::osx_taskcluster_worker
+  include macos_utils::disable_bluetooth_setup
   include macos_utils::uninstall_homebrew
   include roles_profiles::profiles::disable_services
   include roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker

--- a/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
@@ -3,24 +3,22 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_3_t_osx_1014 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    include ::roles_profiles::profiles::suppress_dialog_boxes
-    include ::roles_profiles::profiles::power_management
-    include ::roles_profiles::profiles::screensaver
-    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    include ::roles_profiles::profiles::software_updates
-    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker
-    include ::fw::roles::osx_taskcluster_worker
-
-    include ::macos_utils::uninstall_homebrew
+  include fw::roles::osx_taskcluster_worker
+  include macos_utils::uninstall_homebrew
+  include roles_profiles::profiles::disable_services
+  include roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker
+  include roles_profiles::profiles::gui
+  include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::power_management
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::screensaver
+  include roles_profiles::profiles::software_updates
+  include roles_profiles::profiles::suppress_dialog_boxes
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
@@ -3,30 +3,22 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1015_r8 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::safariupdate
-    include ::roles_profiles::profiles::safaridriver
-    include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::safariupdate
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
@@ -3,31 +3,23 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1015_r8_staging {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::safaridriver
-    include ::roles_profiles::profiles::safariupdate
-    include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
-    include ::roles_profiles::profiles::macos_directory_cleaner
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_directory_cleaner
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::safariupdate
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -3,28 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
-    #include ::roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
@@ -3,24 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1_loaner {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::worker
     include ::roles_profiles::profiles::macos_people_remover
+    include ::roles_profiles::profiles::motd
+    include ::roles_profiles::profiles::network
+    include ::roles_profiles::profiles::ntp
+    include ::roles_profiles::profiles::packages_installed
+    include ::roles_profiles::profiles::relops_users
+    include ::roles_profiles::profiles::sudo
+    include ::roles_profiles::profiles::timezone
+    include ::roles_profiles::profiles::users
+    include ::roles_profiles::profiles::vnc
+    include ::roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1_loaner {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_loaner.pp
@@ -3,16 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1_loaner {
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::network
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::sudo
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::vnc
-    include ::roles_profiles::profiles::worker
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -3,28 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
-    #include ::roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_r8_latest.pp
@@ -3,30 +3,21 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1100_r8_latest {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    # include ::roles_profiles::profiles::safariupdate
-    include ::roles_profiles::profiles::safaridriver
-    include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1200_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1200_r8_latest.pp
@@ -3,30 +3,21 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1200_r8_latest {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    # include ::roles_profiles::profiles::safariupdate
-    include ::roles_profiles::profiles::safaridriver
-    include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8.pp
@@ -3,33 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1300_r8 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    # include ::roles_profiles::profiles::safariupdate
-    # Manually enabled for this pool
-    # include ::roles_profiles::profiles::safaridriver
-    include macos_utils::disable_bluetooth_setup
-    # include ::roles_profiles::profiles::pipconf
-    # Disabling for this pool as it will probably be temporary
-    include ::roles_profiles::profiles::macos_people_remover
-    # This needs to re-worked if this pool is more permanent
-    #include ::roles_profiles::profiles::macos_tcc_perms
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::gecko_t_osx_1300_r8 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::metrics
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1300_r8_latest.pp
@@ -3,30 +3,21 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1300_r8_latest {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    # include ::roles_profiles::profiles::safariupdate
-    include ::roles_profiles::profiles::safaridriver
-    include macos_utils::disable_bluetooth_setup
-    # include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::metrics
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::gecko_t_osx_1400_m2 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network
   include roles_profiles::profiles::ntp

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
@@ -3,27 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2_staging {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_xcodes_installer

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
@@ -3,27 +3,20 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2_staging {
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-  include roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-  include roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::cltbld_user
-  include roles_profiles::profiles::packages_installed
-  include roles_profiles::profiles::talos
-  include roles_profiles::profiles::worker
-  include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
-  include roles_profiles::profiles::safaridriver
   include roles_profiles::profiles::macos_xcodes_installer
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::gecko_t_osx_1400_m2_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::macos_xcodes_installer
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
@@ -3,19 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2_vms_staging {
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::network
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::safaridriver
-    include ::roles_profiles::profiles::sudo
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::vnc
-    include ::roles_profiles::profiles::worker
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2_vms_staging {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::gecko_t_osx_1400_m2_vms_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network
   include roles_profiles::profiles::ntp

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
@@ -3,27 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_m2_vms_staging {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::pipconf
     include ::roles_profiles::profiles::macos_people_remover
+    include ::roles_profiles::profiles::motd
+    include ::roles_profiles::profiles::network
+    include ::roles_profiles::profiles::ntp
+    include ::roles_profiles::profiles::packages_installed
+    include ::roles_profiles::profiles::pipconf
+    include ::roles_profiles::profiles::relops_users
     include ::roles_profiles::profiles::safaridriver
+    include ::roles_profiles::profiles::sudo
+    include ::roles_profiles::profiles::talos
+    include ::roles_profiles::profiles::timezone
+    include ::roles_profiles::profiles::users
+    include ::roles_profiles::profiles::vnc
+    include ::roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_r8_latest {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
@@ -14,7 +14,6 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_latest {
   include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::safaridriver
-  include roles_profiles::profiles::safariupdate
   include roles_profiles::profiles::sudo
   include roles_profiles::profiles::talos
   include roles_profiles::profiles::timezone

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_latest.pp
@@ -3,31 +3,21 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_r8_latest {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    # include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::safaridriver
-    include ::roles_profiles::profiles::safariupdate
-    #include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::safariupdate
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -14,7 +14,6 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
   include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::safaridriver
-  include roles_profiles::profiles::safariupdate
   include roles_profiles::profiles::sudo
   include roles_profiles::profiles::talos
   include roles_profiles::profiles::timezone

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -3,31 +3,21 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-#    include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-#    include ::roles_profiles::profiles::suppress_dialog_boxes
-#    include ::roles_profiles::profiles::power_management
-#    include ::roles_profiles::profiles::screensaver
-#    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-#    include ::roles_profiles::profiles::software_updates
-#    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    # include ::roles_profiles::profiles::metrics
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::safaridriver
-    include ::roles_profiles::profiles::safariupdate
-    #include macos_utils::disable_bluetooth_setup
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_tcc_perms
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::safaridriver
+  include roles_profiles::profiles::safariupdate
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozilla_b_1_osx {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
@@ -3,17 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozilla_b_1_osx {
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::network
-  include roles_profiles::profiles::vnc
-  include roles_profiles::profiles::sudo
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::packages_installed
-  include roles_profiles::profiles::talos
-  include roles_profiles::profiles::worker
-  include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
@@ -3,17 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozilla_b_3_osx {
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    include ::roles_profiles::profiles::vnc
-    include ::roles_profiles::profiles::sudo
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::talos
-    include ::roles_profiles::profiles::worker
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::talos
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozilla_b_3_osx {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -3,16 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozillavpn_b_1_osx {
-    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::macos_people_remover
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::network
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::sudo
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::users
-    include ::roles_profiles::profiles::vnc
-    include ::roles_profiles::profiles::worker
+  include roles_profiles::profiles::gui
+  include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozillavpn_b_1_osx {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
   include roles_profiles::profiles::macos_people_remover

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -3,26 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozillavpn_b_1_osx {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    #include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    #include ::roles_profiles::profiles::suppress_dialog_boxes
-    #include ::roles_profiles::profiles::power_management
-    #include ::roles_profiles::profiles::screensaver
     include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    #include ::roles_profiles::profiles::software_updates
     include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    #include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::relops_users
-    #include ::roles_profiles::profiles::homebrew
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
     include ::roles_profiles::profiles::macos_people_remover
+    include ::roles_profiles::profiles::motd
+    include ::roles_profiles::profiles::network
+    include ::roles_profiles::profiles::ntp
+    include ::roles_profiles::profiles::relops_users
+    include ::roles_profiles::profiles::sudo
+    include ::roles_profiles::profiles::timezone
+    include ::roles_profiles::profiles::users
+    include ::roles_profiles::profiles::vnc
+    include ::roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozillavpn_b_3_osx {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
   include roles_profiles::profiles::macos_people_remover

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
@@ -3,26 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::mozillavpn_b_3_osx {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    #include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    #include ::roles_profiles::profiles::suppress_dialog_boxes
-    #include ::roles_profiles::profiles::power_management
-    #include ::roles_profiles::profiles::screensaver
-    include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    #include ::roles_profiles::profiles::software_updates
-    include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    #include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::relops_users
-    #include ::roles_profiles::profiles::homebrew
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
-    include ::roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::gui
+  include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::nss_1_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_1_b_osx_1015.pp
@@ -3,27 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::nss_1_b_osx_1015 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    # include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    # include ::roles_profiles::profiles::suppress_dialog_boxes
-    # include ::roles_profiles::profiles::power_management
-    # include ::roles_profiles::profiles::screensaver
-    # include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    # include ::roles_profiles::profiles::software_updates
-    # include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    #include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }

--- a/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::nss_3_b_osx_1015 {
+  include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::motd
   include roles_profiles::profiles::network

--- a/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
+++ b/modules/roles_profiles/manifests/roles/nss_3_b_osx_1015.pp
@@ -3,27 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class roles_profiles::roles::nss_3_b_osx_1015 {
-
-    include ::roles_profiles::profiles::timezone
-    include ::roles_profiles::profiles::ntp
-    include ::roles_profiles::profiles::network
-    # include ::roles_profiles::profiles::disable_services
-    include ::roles_profiles::profiles::vnc
-    # include ::roles_profiles::profiles::suppress_dialog_boxes
-    # include ::roles_profiles::profiles::power_management
-    # include ::roles_profiles::profiles::screensaver
-    # include ::roles_profiles::profiles::gui
-    include ::roles_profiles::profiles::sudo
-    # include ::roles_profiles::profiles::software_updates
-    # include ::roles_profiles::profiles::hardware
-    include ::roles_profiles::profiles::motd
-    include ::roles_profiles::profiles::users
-    #include ::roles_profiles::profiles::cltbld_user
-    include ::roles_profiles::profiles::packages_installed
-    include ::roles_profiles::profiles::relops_users
-    include ::roles_profiles::profiles::worker
-    #include ::fw::roles::osx_taskcluster_worker_loaner
-    #include ::macos_utils::uninstall_homebrew
-    include ::roles_profiles::profiles::pipconf
-    include ::roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
 }


### PR DESCRIPTION
- removed references to google chrome in data/roles* as we deploy Chrome updates via mdm
- removed commented out references to applications we no longer deploy in data/roles*
- alphabetized package classes in data/roles* for readability
- removed commented out in role profiles. these haven't been used in +1 years so I'm comfortable removing the entries
- alphabetized role profiles for readability