### PR TITLE
[RELOPS-986] Added generic worker process checker

### DIFF
--- a/modules/macos_gw_checker/files/gw_checker.sh
+++ b/modules/macos_gw_checker/files/gw_checker.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if the semaphore file exists
+if [ ! -f /var/tmp/semaphore/run-buildbot ]; then
+    echo "Semaphore file /var/tmp/semaphore/run-buildbot does not exist. Exiting script."
+    exit 1
+fi
+
 # Check if /bin/bash, /usr/local/bin/worker-runner.sh, and /opt/worker/worker-runner-config.yaml are running
 check_processes() {
     if ! pgrep -x "bash" > /dev/null; then

--- a/modules/macos_gw_checker/files/gw_checker.sh
+++ b/modules/macos_gw_checker/files/gw_checker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check if /bin/bash, /usr/local/bin/worker-runner.sh, and /opt/worker/worker-runner-config.yaml are running
+check_processes() {
+    if ! pgrep -x "bash" > /dev/null; then
+        return 1
+    fi
+
+    if ! pgrep -f "/usr/local/bin/worker-runner.sh" > /dev/null; then
+        return 1
+    fi
+
+    if ! pgrep -f "/opt/worker/worker-runner-config.yaml" > /dev/null; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Main script
+if ! check_processes; then
+    echo "One or more required processes are not running. Rebooting the machine..."
+    sudo reboot
+else
+    echo "All required processes are running."
+fi

--- a/modules/macos_gw_checker/manifests/init.pp
+++ b/modules/macos_gw_checker/manifests/init.pp
@@ -1,0 +1,24 @@
+# gw_checker/manifests/init.pp
+
+class macos_gw_checker (
+  Boolean $enabled = true,
+)
+{
+
+  # Ensure the gw_checker.sh script is present and executable
+  file { '/usr/local/bin/gw_checker.sh':
+    ensure => file,
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'wheel',
+    source => 'puppet:///modules/macos_gw_checker/gw_checker.sh',
+  }
+
+  # Ensure the cron job is present in root's crontab
+  cron { 'gw_checker':
+    ensure  => present,
+    command => '/usr/local/bin/gw_checker.sh',
+    user    => 'root',
+    minute  => '*/30',
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/macos_gw_checker.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_gw_checker.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_gw_checker {
+  class { 'macos_gw_checker':
+    enabled    => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1015_r8 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::metrics

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::gecko_t_osx_1015_r8_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_directory_cleaner
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_sbom
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1100_m1 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1.pp
@@ -5,7 +5,6 @@
 class roles_profiles::roles::gecko_t_osx_1100_m1 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
-  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1100_m1_staging.pp
@@ -5,7 +5,6 @@
 class roles_profiles::roles::gecko_t_osx_1100_m1_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
-  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1400_m2 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_staging.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1400_m2_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::macos_xcodes_installer

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_m2_vms_staging.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1400_m2_vms_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::motd


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RELOPS-986

macOS workers (especially performance workers for some reason) routinely stop taking tasks after 24-48 hours. This module lands a script that gets run every 30 minutes to see if the Generic Worker process is running and if it's not, reboots the host. Rebooting the host always "fixes" the issue.

This solution was manually tested prior to Mozweek and was successful.

The Taskcluster team suggests we switch to multiuser generic worker in hope of resolving this issue. While that might still be a priority, since it is a much larger lift, this PR is the short term solution.