### PR TITLE
chrome set to installed vs latest

### DIFF
--- a/modules/linux_packages/manifests/google_chrome.pp
+++ b/modules/linux_packages/manifests/google_chrome.pp
@@ -3,40 +3,43 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_packages::google_chrome {
-    include apt
+  include apt
 
-    Exec['apt_update'] -> Package['google-chrome-stable']
+  Exec['apt_update'] -> Package['google-chrome-stable']
 
-    # setup chrome source
-    apt::source { 'google_repo':
-        location => '[arch=amd64] https://dl.google.com/linux/chrome/deb/',
-        release  => 'stable',
-        key      => {
-            id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
-            source => 'https://dl.google.com/linux/linux_signing_key.pub',
-        },
-        repos    => 'main',
-        include  => {
-            'src' => false
-        },
-        notify   => Exec['apt_update'],
-    }
+  # setup chrome source
+  apt::source { 'google_repo':
+    location => '[arch=amd64] https://dl.google.com/linux/chrome/deb/',
+    release  => 'stable',
+    key      => {
+      id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+      source => 'https://dl.google.com/linux/linux_signing_key.pub',
+    },
+    repos    => 'main',
+    include  => {
+      'src' => false,
+    },
+    notify   => Exec['apt_update'],
+  }
 
-    # configure auto-update
-    schedule { 'update-chrome-schedule':
-        period => weekly,
-        repeat => 1,
-    }
-    exec { 'update-chrome-action':
-        schedule => 'update-chrome-schedule',
-        command  => '/usr/bin/apt-get update -o \
+  # configure auto-update
+  schedule { 'update-chrome-schedule':
+    period => weekly,
+    repeat => 1,
+  }
+  exec { 'update-chrome-action':
+    schedule => 'update-chrome-schedule',
+    command  => '/usr/bin/apt-get update -o \
             Dir::Etc::sourcelist="sources.list.d/google-chrome.list" \
             -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
-    }
+  }
 
-    # install chrome
-    package {
-        'google-chrome-stable':
-            ensure => latest;
-    }
+  # install chrome
+  package {
+    'google-chrome-stable':
+      # on 1804, latest no longer works missing packages (won't be created for deprecated release)
+      #  `google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable`
+      # need to upgrade to newer os version
+      ensure => present;
+  }
 }


### PR DESCRIPTION
Moonshots are currently not working because of a convergence issue.

This is due to the latest version of chrome requiring a new package that's not available on 18.04.

> Error: /Stage[main]/Linux_packages::Google_chrome/Package[google-chrome-stable]/ensure: change from '127.0.6533.119-1' to '128.0.6613.84-1' failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install google-chrome-stable' returned 100: Reading package lists...
> 
>google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable