### PR TITLE
fix chrome spec tests

### DIFF
--- a/modules/linux_packages/manifests/google_chrome.pp
+++ b/modules/linux_packages/manifests/google_chrome.pp
@@ -2,44 +2,100 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class linux_packages::google_chrome {
-  include apt
+# This class installs Google Chrome on Ubuntu.
+class linux_packages::google_chrome () {
+  case $facts['os']['name'] {
+    'Ubuntu': {
+      case $facts['os']['release']['full'] {
+        '18.04': {
+          include apt
 
-  Exec['apt_update'] -> Package['google-chrome-stable']
+          Exec['apt_update'] -> Package['google-chrome-stable']
 
-  # setup chrome source
-  apt::source { 'google_repo':
-    location => '[arch=amd64] https://dl.google.com/linux/chrome/deb/',
-    release  => 'stable',
-    key      => {
-      id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
-      source => 'https://dl.google.com/linux/linux_signing_key.pub',
-    },
-    repos    => 'main',
-    include  => {
-      'src' => false,
-    },
-    notify   => Exec['apt_update'],
-  }
+          # setup chrome source
+          apt::source { 'google_repo':
+            location => '[arch=amd64] https://dl.google.com/linux/chrome/deb/',
+            release  => 'stable',
+            key      => {
+              id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+              source => 'https://dl.google.com/linux/linux_signing_key.pub',
+            },
+            repos    => 'main',
+            include  => {
+              'src' => false,
+            },
+            notify   => Exec['apt_update'],
+          }
 
-  # configure auto-update
-  schedule { 'update-chrome-schedule':
-    period => weekly,
-    repeat => 1,
-  }
-  exec { 'update-chrome-action':
-    schedule => 'update-chrome-schedule',
-    command  => '/usr/bin/apt-get update -o \
+          # configure auto-update
+          schedule { 'update-chrome-schedule':
+            period => weekly,
+            repeat => 1,
+          }
+          exec { 'update-chrome-action':
+            schedule => 'update-chrome-schedule',
+            command  => '/usr/bin/apt-get update -o \
             Dir::Etc::sourcelist="sources.list.d/google-chrome.list" \
             -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
-  }
+          }
 
-  # install chrome
-  package {
-    'google-chrome-stable':
-      # on 1804, latest no longer works missing packages (won't be created for deprecated release)
-      #  `google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable`
-      # need to upgrade to newer os version
-      ensure => present;
+          # install chrome
+          package {
+            'google-chrome-stable':
+              # on 1804, latest no longer works missing packages (won't be created for deprecated release)
+              #  `google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable`
+              # need to upgrade to newer os version
+              ensure => '127.0.6533.119-1';
+          }
+        }
+        '22.04','24.04': {
+          include apt
+
+          Exec['apt_update'] -> Package['google-chrome-stable']
+
+          # setup chrome source
+          apt::source { 'google_repo':
+            location => '[arch=amd64] https://dl.google.com/linux/chrome/deb/',
+            release  => 'stable',
+            key      => {
+              id     => '4CCA1EAF950CEE4AB83976DCA040830F7FAC5991',
+              source => 'https://dl.google.com/linux/linux_signing_key.pub',
+            },
+            repos    => 'main',
+            include  => {
+              'src' => false,
+            },
+            notify   => Exec['apt_update'],
+          }
+
+          # configure auto-update
+          schedule { 'update-chrome-schedule':
+            period => weekly,
+            repeat => 1,
+          }
+          exec { 'update-chrome-action':
+            schedule => 'update-chrome-schedule',
+            command  => '/usr/bin/apt-get update -o \
+            Dir::Etc::sourcelist="sources.list.d/google-chrome.list" \
+            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"',
+          }
+
+          # install chrome
+          package {
+            'google-chrome-stable':
+              # on 1804, latest no longer works missing packages (won't be created for deprecated release)
+              #  `google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable`
+              # need to upgrade to newer os version
+              ensure => 'latest';
+          }
+        }
+        default: {
+          fail("cannot install on ${facts['os']['release']['full']}")
+        }
+      }
+    }
+    default: {
+      fail("cannot install on ${facts['os']['name']}")
+    }
   }
 }

--- a/test/integration/linux-perf/inspec/google_chrome_spec.rb
+++ b/test/integration/linux-perf/inspec/google_chrome_spec.rb
@@ -1,6 +1,20 @@
 require_relative 'spec_helper'
 
-describe command('google-chrome-stable --version') do
-  its(:exit_status) { should eq 0 }
-  its(:stdout) { should match /Google Chrome/ }
+if os.family == 'debian' && os.release == '24.04'
+  describe command('google-chrome-stable --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /Google Chrome/ }
+  end
+end
+
+if os.family == 'debian' && os.release == '22.04'
+  describe command('google-chrome-stable --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /Google Chrome/ }
+  end
+end
+
+# 18.04 is busted, due to new package requirement that's not available
+if os.family == 'debian' && os.release == '18.04'
+  # pass
 end


### PR DESCRIPTION
On 18.04, install a specific version (vs 'present').

Add support for 24.04 and 22.04.