### PR TITLE
Wifi bug fix

### DIFF
--- a/modules/macos_utils/manifests/wifi_disabled.pp
+++ b/modules/macos_utils/manifests/wifi_disabled.pp
@@ -3,15 +3,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class macos_utils::wifi_disabled {
-    if $::operatingsystem == 'Darwin' {
-        if $::networking['en0'] {
-            exec {
-                'disable-wifi':
-                    command => '/usr/sbin/networksetup -setairportpower en1 off',
-                    unless  => "/usr/sbin/networksetup -getairportpower en1 | egrep 'Off'";
-            }
-        }
-    } else {
-        fail("${module_name} does not support ${::operatingsystem}")
+  if $facts['os']['name'] == 'Darwin' {
+    $wifi_interface = $::networking['interfaces']['en1'] ? {
+      undef   => 'en0',
+      default => 'en1',
     }
+
+    exec { 'disable-wifi':
+      command     => "/usr/sbin/networksetup -setairportpower ${wifi_interface} off",
+      unless      => "/usr/sbin/networksetup -getairportpower ${wifi_interface} | grep 'Off'",
+      refreshonly => false,
+    }
+  } else {
+    fail("${module_name} does not support ${facts['os']['name']}")
+  }
 }


### PR DESCRIPTION
macOS systems seem to have turned wifi back on (via possibly a software update/apple being annoying) and the existing puppet code didn't remediate the re-enablement.

Now it does