### PR TITLE
[RELOPS-1066] directory_cleaner implementation

### DIFF
--- a/modules/macos_directory_cleaner/files/clean_before_reboot.sh
+++ b/modules/macos_directory_cleaner/files/clean_before_reboot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Set environment variables explicitly
+export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/puppetlabs/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/munki
+export HOME=/Users/relops
+export SHELL=/bin/bash
+export LANG=en_US.UTF-8
+
+if command -v directory_cleaner &> /dev/null
+then
+    directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/downloads
+    directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/cache
+fi

--- a/modules/macos_directory_cleaner/files/org.mozilla.cleanbeforereboot.plist
+++ b/modules/macos_directory_cleaner/files/org.mozilla.cleanbeforereboot.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.mozilla.cleanbeforereboot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>su - root -c '/usr/local/bin/clean_before_reboot.sh'</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>LaunchOnlyOnce</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/org.mozilla.cleanbeforereboot.stdout</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/org.mozilla.cleanbeforereboot.stderr</string>
+
+    <key>InitGroups</key>
+    <true/>
+
+    <key>ExitTimeout</key>
+    <integer>300</integer>
+</dict>
+</plist>

--- a/modules/macos_directory_cleaner/manifests/init.pp
+++ b/modules/macos_directory_cleaner/manifests/init.pp
@@ -4,7 +4,6 @@ class macos_directory_cleaner (
   # Install the directory_cleaner package using pip3
   exec { 'install_directory_cleaner':
     command => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 install directory_cleaner',
-    # require => Package['python3-pip'],
     unless  => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 show directory_cleaner',
   }
 
@@ -39,5 +38,31 @@ EOF
     owner   => 'root',
     group   => 'wheel',
     require => File['/opt/directory_cleaner/configs'],
+  }
+
+  # Deploy the clean_before_reboot.sh script
+  file { '/usr/local/bin/clean_before_reboot.sh':
+    ensure => file,
+    source => 'puppet:///modules/macos_directory_cleaner/clean_before_reboot.sh',
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'wheel',
+  }
+
+  # Deploy the org.mozilla.cleanbeforereboot.plist file
+  file { '/Library/LaunchDaemons/org.mozilla.cleanbeforereboot.plist':
+    ensure  => file,
+    source  => 'puppet:///modules/macos_directory_cleaner/org.mozilla.cleanbeforereboot.plist',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'wheel',
+    require => File['/usr/local/bin/clean_before_reboot.sh'],
+  }
+
+  # Ensure the plist is loaded
+  exec { 'load_cleanbeforereboot_plist':
+    command     => '/bin/launchctl load /Library/LaunchDaemons/org.mozilla.cleanbeforereboot.plist',
+    refreshonly => true,
+    subscribe   => File['/Library/LaunchDaemons/org.mozilla.cleanbeforereboot.plist'],
   }
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
@@ -5,6 +5,7 @@
 class roles_profiles::roles::gecko_t_osx_1015_r8 {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::cltbld_user
+  include roles_profiles::profiles::macos_directory_cleaner
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/worker_runner/templates/worker-runner.sh.erb
+++ b/modules/worker_runner/templates/worker-runner.sh.erb
@@ -66,15 +66,6 @@ else
     sleep 30
 fi
 
-echo "Cleaning /opt/worker/downloads/ and /opt/worker/cache/"
-
-if command -v directory_cleaner &> /dev/null
-then
-    # Run the directory_cleaner commands
-    directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/downloads
-    directory_cleaner -c /opt/directory_cleaner/configs/config.toml /opt/worker/cache
-fi
-
 echo "REBOOT $(date)"
 /usr/bin/sudo /sbin/reboot
 # Sleep to prevent this script from terminating naturally, and launchd restarting


### PR DESCRIPTION
Sometimes cleanup does not happen in `/opt/worker/downloads` and `/opt/worker/cache/`, resulting in subsequent test [failures](https://treeherder.mozilla.org/intermittent-failures/bugdetails?bug=1774954&startday=2024-08-26&endday=2024-09-01&tree=all) due to a lack of disk space.

With this PR applied, when a reboot is triggered, `directory_cleaner` will run against those directories.