### PR TITLE
[RELOPS-773] New mac signer pool/deprecating Deploy Studio

### DIFF
--- a/data/roles/mac_v4_signing_ff_prod.yaml
+++ b/data/roles/mac_v4_signing_ff_prod.yaml
@@ -1,0 +1,13 @@
+---
+
+# Package class parameters
+packages::vault::version: 1.7.3
+
+# Override secrets with vault secrets
+
+papertrail:
+  host: "%{lookup('vault_secrets::papertrail.data.host')}"
+  port: "%{lookup('vault_secrets::papertrail.data.port')}"
+
+notarization:
+  password: "%{lookup('vault_secrets::notarization.data.password')}"

--- a/inventory.d/signing-v4.yaml
+++ b/inventory.d/signing-v4.yaml
@@ -1,0 +1,8 @@
+---
+name: mac-v4-signing
+groups:
+  - name: mac-v4-signing-ff-prod
+    targets:
+      - macmini-m2-54.test.releng.mdc1.mozilla.com
+    facts:
+      puppet_role: mac_v4_signing_ff_prod

--- a/modules/roles_profiles/manifests/roles/mac_v4_signing_ff_prod.pp
+++ b/modules/roles_profiles/manifests/roles/mac_v4_signing_ff_prod.pp
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::mac_v4_signing_ff_prod {
+
+    include ::roles_profiles::profiles::timezone
+    include ::roles_profiles::profiles::ntp
+    include ::roles_profiles::profiles::network
+    include ::roles_profiles::profiles::disable_services
+    include ::roles_profiles::profiles::vnc
+    include ::roles_profiles::profiles::suppress_dialog_boxes
+    include ::roles_profiles::profiles::power_management
+    include ::roles_profiles::profiles::screensaver
+    include ::roles_profiles::profiles::gui
+    include ::roles_profiles::profiles::sudo
+    include ::roles_profiles::profiles::software_updates
+    include ::roles_profiles::profiles::hardware
+    include ::roles_profiles::profiles::motd
+    include ::roles_profiles::profiles::users
+    include ::roles_profiles::profiles::relops_users
+    include ::roles_profiles::profiles::signing_users
+    include ::roles_profiles::profiles::remove_bootstrap_user
+    include ::roles_profiles::profiles::duo
+    include ::roles_profiles::profiles::vault_agent
+    include ::fw::roles::mac_signing
+    include ::roles_profiles::profiles::mac_v3_signing
+    include ::roles_profiles::profiles::macos_people_remover
+}


### PR DESCRIPTION
We're still in the early stages of [understanding](https://docs.google.com/document/d/1pgIK4TbeqJtRlt1UiE4C7o2e37I2DttUrxEcN72d5Pg/edit) how the mac signers are configured, but I think we are getting close. The purpose of this PR is to setup a new pool initially for testing, which will then convert to prod.

I *think* the code below will need to merge before the auto puppeting of the new signer host takes place

We can change the hostnames at a later time but the short term goal is to just see if we can get a signer provisioned on new hardware manually.

Please sanity check me @ahal @aerickson and/or @hneiva as I know the signers are sensitive. Thanks all