### PR TITLE
Add Signer support for macOS 14

### DIFF
--- a/modules/pf/manifests/init.pp
+++ b/modules/pf/manifests/init.pp
@@ -9,8 +9,11 @@ class pf {
         '10.14': {
             $osx_ver = 'mojave'
         }
+        '14': {
+            $osx_ver = 'sonoma'
+        }
         default: {
-            fail("OSX ${::macosx_productversion_major} is not supported")
+            fail("OSX ${facts['os']['macosx']['version']['major']} is not supported")
         }
     }
 


### PR DESCRIPTION
Related to https://mozilla-hub.atlassian.net/browse/RELOPS-773

At present, puppetization is failing due to the os version check