### PR TITLE
address puppet failure

### DIFF
--- a/modules/pf/files/pf.conf.sonoma
+++ b/modules/pf/files/pf.conf.sonoma
@@ -1,0 +1,29 @@
+#
+# Default PF configuration file.
+#
+# This file contains the main ruleset, which gets automatically loaded
+# at startup.  PF will not be automatically enabled, however.  Instead,
+# each component which utilizes PF is responsible for enabling and disabling
+# PF via -E and -X as documented in pfctl(8).  That will ensure that PF
+# is disabled only when the last enable reference is released.
+#
+# Care must be taken to ensure that the main ruleset does not get flushed,
+# as the nested anchors rely on the anchor point defined here. In addition,
+# to the anchors loaded by this file, some system services would dynamically
+# insert anchors into the main ruleset. These anchors will be added only when
+# the system service is used and would removed on termination of the service.
+#
+# See pf.conf(5) for syntax.
+#
+
+#
+# com.apple anchor point
+#
+scrub-anchor "com.apple/*"
+nat-anchor "com.apple/*"
+rdr-anchor "com.apple/*"
+dummynet-anchor "com.apple/*"
+anchor "com.apple/*"
+anchor "org.mozilla"
+load anchor "com.apple" from "/etc/pf.anchors/com.apple"
+load anchor "org.mozilla" from "/etc/pf.mozilla.anchors/main.conf"


### PR DESCRIPTION
Fixes

```
[root@macmini-m2-54.test.releng.mdc1.mozilla.com ronin_puppet]# /var/root/bootstrap_mojave.sh
Running puppet apply
Notice: Compiled catalog for macmini-m2-54.test.releng.mdc1.mozilla.com in environment production in 0.22 seconds
Notice: /Stage[main]/Macos_people_remover/Exec[execute people remover script]/returns: executed successfully
Error: /Stage[main]/Pf/File[/etc/pf.conf]: Could not evaluate: Could not retrieve information from environment production source(s) puppet:///modules/pf/pf.conf.sonoma
Notice: /Stage[main]/Pf/Exec[update_pf]: Dependency File[/etc/pf.conf] has failures: true
Warning: /Stage[main]/Pf/Exec[update_pf]: Skipping because of failed dependencies
Notice: Applied catalog in 0.74 seconds
Puppet run failed; re-trying after 10m
```