### PR TITLE
101824_linux_dir_cleaner_tweaks

### DIFF
--- a/modules/linux_directory_cleaner/manifests/init.pp
+++ b/modules/linux_directory_cleaner/manifests/init.pp
@@ -54,6 +54,7 @@ EOF
     $systemd_service_content = @("EOF")
 [Unit]
 Description=Clean directory at startup
+Before=run-puppet.service
 
 [Service]
 ExecStart=/usr/local/bin/clean_at_startup.sh
@@ -81,7 +82,7 @@ EOF
 
     # Enable the service to run at startup
     service { 'clean_at_startup':
-      ensure  => 'running',
+      # ensure  => 'running',
       enable  => true,
       require => Exec['systemd-reload'],
     }

--- a/modules/linux_directory_cleaner/manifests/init.pp
+++ b/modules/linux_directory_cleaner/manifests/init.pp
@@ -82,6 +82,7 @@ EOF
 
     # Enable the service to run at startup
     service { 'clean_at_startup':
+      # don't ensure running, we want it to run once at startup
       # ensure  => 'running',
       enable  => true,
       require => Exec['systemd-reload'],


### PR DESCRIPTION
Tested on ms001.

Followup to https://github.com/mozilla-platform-ops/ronin_puppet/pull/758.

- directory cleaner runs before puppet
- puppet doesn't run directory cleaner during a puppet run

```
# journalctl -u clean_at_startup -u run-puppet  -f -n 2000
-- Reboot --
Oct 18 18:07:15 t-linux64-ms-001 systemd[1]: Started Clean directory at startup.
Oct 18 18:07:15 t-linux64-ms-001 clean_at_startup.sh[733]: Cleaned directory '/home/cltbld/downloads'. Removed 4 files and 2 directories.
Oct 18 18:07:45 t-linux64-ms-001 systemd[1]: Starting masterless puppet run...
Oct 18 18:07:45 t-linux64-ms-001 run-puppet.sh[1467]: Loading settings from /etc/puppet/ronin_settings...
...
(also no start of directory cleaner during convergence)
```