### PR TITLE
[RELOPS-1131] Add two mdc m2 workers to gecko-3-b-osx-arm64

### DIFF
--- a/data/roles/gecko_3_b_osx_arm64.yaml
+++ b/data/roles/gecko_3_b_osx_arm64.yaml
@@ -12,7 +12,7 @@ worker:
   taskcluster_version: 60.3.4
   provider_type: standalone
   worker_pool_id: releng-hardware/gecko-3-b-osx-arm64
-  worker_group: aws-ec2
+  worker_group: mdc1
   worker_id: "%{facts.networking.hostname}"
   client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
   access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/inventory.d/macmini-m2.yaml
+++ b/inventory.d/macmini-m2.yaml
@@ -29,6 +29,8 @@ groups:
     targets:
       - ec2-34-217-63-158.us-west-2.compute.amazonaws.com
       - ec2-35-94-45-176.us-west-2.compute.amazonaws.com
+      - macmini-m2-40.test.releng.mdc1.mozilla.com
+      - macmini-m2-41.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_3_b_osx_arm64
 


### PR DESCRIPTION
To replace the AWS workers