### PR TITLE
[RELOPS-1164] Deploy watchman (hg fsmonitor)

### DIFF
--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -218,6 +218,8 @@ groups:
 
   - name: mozillavpn-b-1-osx
     targets:
+    # New Mac15 VPN worker
+      - macmini-r8-102.test.releng.mdc1.mozilla.com
       - macmini-r8-179.test.releng.mdc1.mozilla.com
       - macmini-r8-182.test.releng.mdc1.mozilla.com
       - macmini-r8-183.test.releng.mdc1.mozilla.com
@@ -248,10 +250,11 @@ groups:
   - name: gecko-t-osx-1400-r8-staging
     targets:
       - macmini-r8-109.test.releng.mdc1.mozilla.com
-      - macmini-r8-114.test.releng.mdc1.mozilla.com
       - macmini-r8-154.test.releng.mdc1.mozilla.com
       - macmini-r8-156.test.releng.mdc1.mozilla.com
       - macmini-r8-246.test.releng.mdc1.mozilla.com
+      - macmini-r8-361.test.releng.mdc1.mozilla.com
+      - macmini-r8-375.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1400_r8_staging
 

--- a/inventory.d/macmini-r8.yaml
+++ b/inventory.d/macmini-r8.yaml
@@ -247,7 +247,6 @@ groups:
 
   - name: gecko-t-osx-1400-r8-staging
     targets:
-      - macmini-r8-102.test.releng.mdc1.mozilla.com
       - macmini-r8-109.test.releng.mdc1.mozilla.com
       - macmini-r8-114.test.releng.mdc1.mozilla.com
       - macmini-r8-154.test.releng.mdc1.mozilla.com

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -39,6 +39,12 @@ class macos_fsmonitor (
     path    => ['/usr/bin', '/usr/local/bin', '/bin'],
   }
 
+  exec { 'install_pywatchman':
+    command => '/usr/local/bin/pip3.11 install pywatchman==2.0.0',
+    unless  => '/usr/local/bin/python3 -c "import pywatchman"',
+    path    => ['/usr/local/bin', '/usr/bin'],
+  }
+
   # Step 5: Append fsmonitor config to existing .hgrc if enabled
   if $enabled {
     file_line { 'add_fsmonitor_extension':

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -1,7 +1,6 @@
 class macos_fsmonitor (
   Boolean $enabled = true,
 ) {
-
   # Install the watchman package from S3
   packages::macos_package_from_s3 { 'watchman.pkg':
     private             => false,

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -1,0 +1,41 @@
+class macos_fsmonitor (
+  Boolean $enabled = true,
+) {
+  # Install the watchman package from S3
+  packages::macos_package_from_s3 { 'watchman.pkg':
+    private             => false,
+    os_version_specific => false,
+    type                => 'pkg',
+    require             => Exec['prepare_watchman_dir'], # Ensure the directory is created before the package is used.
+  }
+
+  # Step 1: Create the necessary directory
+  exec { 'prepare_watchman_dir':
+    command => 'sudo mkdir -p /usr/local/var/run/watchman',
+    creates => '/usr/local/var/run/watchman', # Ensures this is idempotent.
+    path    => ['/usr/bin', '/usr/local/bin'], # Ensure `mkdir` is found in the PATH.
+  }
+
+  # Step 2: Adjust ownership of the directory
+  exec { 'chown_watchman_dir':
+    command => 'sudo chown -R relops:staff /usr/local/var/run/watchman',
+    require => Exec['prepare_watchman_dir'], # Run only after the directory is created.
+    path    => ['/usr/bin', '/usr/local/bin'],
+  }
+
+  # Step 3: Codesign the `watchman` binary
+  exec { 'codesign_watchman':
+    command => 'sudo codesign --force --sign - /usr/local/bin/watchman',
+    onlyif  => '/bin/test -f /usr/local/bin/watchman', # Specify full path to 'test'.
+    require => Packages::Macos_package_from_s3['watchman.pkg'],
+    path    => ['/usr/bin', '/usr/local/bin', '/bin'],
+  }
+
+  # Step 4: Codesign the `watchmanctl` binary
+  exec { 'codesign_watchmanctl':
+    command => 'sudo codesign --force --sign - /usr/local/bin/watchmanctl',
+    onlyif  => '/bin/test -f /usr/local/bin/watchmanctl', # Specify full path to 'test'.
+    require => Packages::Macos_package_from_s3['watchman.pkg'],
+    path    => ['/usr/bin', '/usr/local/bin', '/bin'],
+  }
+}

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -39,26 +39,41 @@ class macos_fsmonitor (
     path    => ['/usr/bin', '/usr/local/bin', '/bin'],
   }
 
-  # Step 5: Append configuration to `.hgrc` for cltbld
-  file_line { 'enable_fsmonitor_plugin':
-    path    => '/Users/cltbld/.hgrc',
-    line    => '[extensions]\nfsmonitor =',
-    match   => '^\[extensions\]',
-    require => Exec['codesign_watchman'], # Ensure this runs after Watchman setup.
-  }
-
-  file_line { 'configure_fsmonitor_mode':
-    path    => '/Users/cltbld/.hgrc',
-    line    => '[fsmonitor]\nmode = paranoid',
-    match   => '^\[fsmonitor\]',
+  # Step 5: Manage `.hgrc` file for cltbld
+  file { '/Users/cltbld/.hgrc':
+    ensure  => file,
+    owner   => 'cltbld',
+    group   => 'staff',
+    mode    => '0644',
+    content => epp('macos_fsmonitor/hgrc.epp'), # Use a template for consistent content.
     require => Exec['codesign_watchman'],
   }
 
-  # Ensure correct ownership and permissions of .hgrc
-  file { '/Users/cltbld/.hgrc':
-    ensure => file,
-    owner  => 'cltbld',
-    group  => 'staff',
-    mode   => '0644',
-  }
+  # Embedded Puppet Template (hgrc.epp)
+  # This template will look like this:
+  #
+  # <%# macos_fsmonitor/hgrc.epp %>
+  # [diff]
+  # git=True
+  # showfunc=True
+  # ignoreblanklines=True
+  #
+  # [ui]
+  # username = Mozilla Release Engineering <release@mozilla.com>
+  # traceback = True
+  #
+  # [extensions]
+  # share=
+  # rebase=
+  # mq=
+  # purge=
+  # robustcheckout=/usr/local/lib/hgext/robustcheckout.py
+  # sparse=
+  # fsmonitor =
+  #
+  # [fsmonitor]
+  # mode = paranoid
+  #
+  # [web]
+  # cacerts = /etc/mercurial/cacert.pem
 }

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -1,32 +1,33 @@
 class macos_fsmonitor (
   Boolean $enabled = true,
 ) {
+
   # Install the watchman package from S3
   packages::macos_package_from_s3 { 'watchman.pkg':
     private             => false,
     os_version_specific => false,
     type                => 'pkg',
-    require             => Exec['prepare_watchman_dir'], # Ensure the directory is created before the package is used.
+    require             => Exec['prepare_watchman_dir'],
   }
 
   # Step 1: Create the necessary directory
   exec { 'prepare_watchman_dir':
     command => 'sudo mkdir -p /usr/local/var/run/watchman',
-    creates => '/usr/local/var/run/watchman', # Ensures this is idempotent.
-    path    => ['/usr/bin', '/usr/local/bin'], # Ensure `mkdir` is found in the PATH.
+    creates => '/usr/local/var/run/watchman',
+    path    => ['/usr/bin', '/usr/local/bin'],
   }
 
   # Step 2: Adjust ownership of the directory
   exec { 'chown_watchman_dir':
     command => 'sudo chown -R cltbld:staff /usr/local/var/run/watchman',
-    require => Exec['prepare_watchman_dir'], # Run only after the directory is created.
+    require => Exec['prepare_watchman_dir'],
     path    => ['/usr/bin', '/usr/local/bin'],
   }
 
   # Step 3: Codesign the `watchman` binary
   exec { 'codesign_watchman':
     command => 'sudo codesign --force --sign - /usr/local/bin/watchman',
-    onlyif  => '/bin/test -f /usr/local/bin/watchman', # Specify full path to 'test'.
+    onlyif  => '/bin/test -f /usr/local/bin/watchman',
     require => Packages::Macos_package_from_s3['watchman.pkg'],
     path    => ['/usr/bin', '/usr/local/bin', '/bin'],
   }
@@ -34,46 +35,33 @@ class macos_fsmonitor (
   # Step 4: Codesign the `watchmanctl` binary
   exec { 'codesign_watchmanctl':
     command => 'sudo codesign --force --sign - /usr/local/bin/watchmanctl',
-    onlyif  => '/bin/test -f /usr/local/bin/watchmanctl', # Specify full path to 'test'.
+    onlyif  => '/bin/test -f /usr/local/bin/watchmanctl',
     require => Packages::Macos_package_from_s3['watchman.pkg'],
     path    => ['/usr/bin', '/usr/local/bin', '/bin'],
   }
 
-  # Step 5: Manage `.hgrc` file for cltbld
-  file { '/Users/cltbld/.hgrc':
-    ensure  => file,
-    owner   => 'cltbld',
-    group   => 'staff',
-    mode    => '0644',
-    content => epp('macos_fsmonitor/hgrc.epp'), # Use a template for consistent content.
-    require => Exec['codesign_watchman'],
-  }
+  # Step 5: Append fsmonitor config to existing .hgrc if enabled
+  if $enabled {
+    file_line { 'add_fsmonitor_extension':
+      path    => '/Users/cltbld/.hgrc',
+      line    => 'fsmonitor =',
+      match   => '^fsmonitor\s*=',
+      after   => '^sparse\s*=',
+      require => File['/Users/cltbld/.hgrc'],
+    }
 
-  # Embedded Puppet Template (hgrc.epp)
-  # This template will look like this:
-  #
-  # <%# macos_fsmonitor/hgrc.epp %>
-  # [diff]
-  # git=True
-  # showfunc=True
-  # ignoreblanklines=True
-  #
-  # [ui]
-  # username = Mozilla Release Engineering <release@mozilla.com>
-  # traceback = True
-  #
-  # [extensions]
-  # share=
-  # rebase=
-  # mq=
-  # purge=
-  # robustcheckout=/usr/local/lib/hgext/robustcheckout.py
-  # sparse=
-  # fsmonitor =
-  #
-  # [fsmonitor]
-  # mode = paranoid
-  #
-  # [web]
-  # cacerts = /etc/mercurial/cacert.pem
+    file_line { 'add_fsmonitor_section':
+      path    => '/Users/cltbld/.hgrc',
+      line    => '[fsmonitor]',
+      match   => '^\[fsmonitor\]',
+      require => File_line['add_fsmonitor_extension'],
+    }
+
+    file_line { 'add_fsmonitor_mode':
+      path    => '/Users/cltbld/.hgrc',
+      line    => 'mode = paranoid',
+      match   => '^mode\s*=',
+      require => File_line['add_fsmonitor_section'],
+    }
+  }
 }

--- a/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
@@ -4,6 +4,6 @@
 
 class roles_profiles::profiles::macos_fsmonitor {
   class { 'macos_fsmonitor':
-    enabled    => true,
+    enabled => true,
   }
 }

--- a/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_fsmonitor {
+  class { 'macos_fsmonitor':
+    enabled    => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -7,6 +7,7 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_bin_signer
   include roles_profiles::profiles::macos_directory_cleaner
+  include roles_profiles::profiles::macos_fsmonitor
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -16,7 +16,7 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
   include roles_profiles::profiles::network
   include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
-  include roles_profiles::profiles::pipconf
+  #include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::safaridriver
   include roles_profiles::profiles::sudo


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RELOPS-1164

https://github.com/facebook/watchman/releases/tag/v2023.05.01.00

`watchman.pkg` drops 
```
watchman 
watchmanctl
```

into `/usr/local/bin` and

```
libcrypto.1.1.dylib
libevent-2.1.7.dylib
libgflags.2.2.dylib
libglog.0.dylib
liblz4.1.dylib
libpcre2-8.0.dylib
libsodium.23.dylib
libssl.1.1.dylib
libz.1.dylib
libzstd.1.dylib
```

into `/usr/local/lib/`


These binaries should work for now but its worth noting that this the last binary release for macOS. Other install methods are available via `homebrew`, but that presents challenges (for one we dont install `homebrew`) and my initial testing via the `brew pkg` method were unsuccessful