### PR TITLE
fix cli tools checker

### DIFF
--- a/modules/macos_xcode_tools/manifests/init.pp
+++ b/modules/macos_xcode_tools/manifests/init.pp
@@ -1,7 +1,7 @@
 class macos_xcode_tools (
   Boolean $enabled = true,
 ) {
-  $xcode_select_path = '/Library/Developer/CommandLineTools'
+  $xcode_select_path = '/Library/Developer/CommandLineTools/Library'
 
   exec { 'install_xcode_tools':
     command => "xcode-select -p &> /dev/null; touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress; PROD=\$(softwareupdate -l | grep \"\\*.*Command Line\" | tail -n 1 | sed 's/^[^C]* //'); softwareupdate -i \"\$PROD\" --verbose;",


### PR DESCRIPTION
on mac 14 this is failing to run because `/Library/Developer/CommandLineTools/usr` exists, despite the command line tools not being installed