### PR TITLE
refactor: ⚰️Restore gamebar per relops-1276

### DIFF
--- a/modules/win_disable_services/files/appxpackages/uninstall.ps1
+++ b/modules/win_disable_services/files/appxpackages/uninstall.ps1
@@ -29,11 +29,6 @@ $apps = @{
         "URL"         = "https://apps.microsoft.com/detail/9NBLGGH4NNS1"
         "Description" = "Microsoft App Installer for Windows 10 makes sideloading Windows apps easy"
     }
-    "Microsoft.GamingApp"                    = @{
-        "VDIState"    = "Unchanged"
-        "URL"         = "https://www.microsoft.com/en-us/p/xbox/9mv0b5hzvk9z"
-        "Description" = "Xbox app"
-    }
     "Microsoft.GetHelp"                      = @{
         "VDIState"    = "Unchanged"
         "URL"         = "https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/customize-get-help-app"
@@ -183,16 +178,6 @@ $apps = @{
         "VDIState"    = "Unchanged"
         "URL"         = "https://docs.microsoft.com/en-us/gaming/xbox-live/features/general/tcui/live-tcui-overview"
         "Description" = "XBox Title Callable UI (TCUI) enables your game code to call pre-defined user interface displays"
-    }
-    "Microsoft.XboxGameOverlay"              = @{
-        "VDIState"    = "Unchanged"
-        "URL"         = "https://www.microsoft.com/en-us/p/xbox-game-bar/9nzkpstsnw4p"
-        "Description" = "Xbox Game Bar extensible overlay"
-    }
-    "Microsoft.XboxGamingOverlay"            = @{
-        "VDIState"    = "Unchanged"
-        "URL"         = "https://www.microsoft.com/en-us/p/xbox-game-bar/9nzkpstsnw4p"
-        "Description" = "Xbox Game Bar extensible overlay"
     }
     "Microsoft.XboxIdentityProvider"         = @{
         "VDIState"    = "Unchanged"


### PR DESCRIPTION
## Summary
- Updates Windows image to version 1.1.0 with ronin_puppet deployment `a026eab`
- **Taskcluster**: 96.1.0 → [96.3.1](https://taskcluster.github.io/changelog-viewer/#releaseFrom=v96.1.0&releaseTo=v96.3.1)
- Fix Windows 11 24H2 Microphone Prompt Consent in [RELOPS-2181](https://mozilla-hub.atlassian.net/browse/RELOPS-2181)

## ronin_puppet commits (ab4658e...a026eab)

### Image changes
| Commit | Description |
|--------|-------------|
| [a026eab](https://github.com/mozilla-platform-ops/ronin_puppet/commit/a026eabf) | [RELOPS-2180] Fix critical bugs, add exec guards, remove dead code for Windows Branch (#1037) |
| [d017938](https://github.com/mozilla-platform-ops/ronin_puppet/commit/d017938e) | update taskcluster on cloud workers to 96.3.1 |
| [e864878](https://github.com/mozilla-platform-ops/ronin_puppet/commit/e8648785) | [RELOPS-2181] Add AppPrivacy registry key to allow microphone access (#1040) |