### PR TITLE
[RELOPS-1311] Automate/Install pyobjc on macOS 15

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -27,6 +27,7 @@ packages_classes:
   - python2_zstandard
   - python3
   - python3_psutil
+  - python3_pyobjc
   - python3_zstandard
   - scres
   - telegraf

--- a/modules/packages/manifests/python3_pyobjc.pp
+++ b/modules/packages/manifests/python3_pyobjc.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::python3_pyobjc (
+  String $version = '11.0',
+) {
+  require packages::python3
+  require macos_xcode_tools
+
+  exec { 'install_pyobjc':
+    command => "/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 install pyobjc==${version}",
+    unless  => "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -c 'import objc; print(objc.__version__)' | grep -q ${version}",
+    path    => ['/Library/Frameworks/Python.framework/Versions/3.11/bin', '/usr/local/bin', '/usr/bin'],
+    require => Class['packages::python3', 'macos_xcode_tools'],
+  }
+}


### PR DESCRIPTION
Uploaded 156 `*.whl` depedencies to https://pypi.pub.build.mozilla.org/pub/

https://mozilla-hub.atlassian.net/browse/RELOPS-1311