### PR TITLE
Add ordering requirement for directory_cleaner

### DIFF
--- a/modules/macos_directory_cleaner/manifests/init.pp
+++ b/modules/macos_directory_cleaner/manifests/init.pp
@@ -1,10 +1,13 @@
 class macos_directory_cleaner (
   Boolean $enabled = true,
 ) {
+  require roles_profiles::profiles::pipconf  # Ensures pipconf runs first
+
   # Install the directory_cleaner package using pip3
   exec { 'install_directory_cleaner':
     command => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 install directory_cleaner==0.2.0',
     unless  => '/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 show directory_cleaner | grep "Version: 0.2.0"',
+    require => Class['roles_profiles::profiles::pipconf'],  # Ensure pipconf runs first
   }
 
   # Create necessary directories if they do not exist


### PR DESCRIPTION
Need `pip.conf` to land before `directory_cleaner`