### PR TITLE
[RELOPS-1164] Deploy watchman (hg fsmonitor)

### DIFF
--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -1,0 +1,72 @@
+class macos_fsmonitor (
+  Boolean $enabled = true,
+) {
+  # Install the watchman package from S3
+  packages::macos_package_from_s3 { 'watchman.pkg':
+    private             => false,
+    os_version_specific => false,
+    type                => 'pkg',
+    require             => Exec['prepare_watchman_dir'],
+  }
+
+  # Step 1: Create the necessary directory
+  exec { 'prepare_watchman_dir':
+    command => 'sudo mkdir -p /usr/local/var/run/watchman',
+    creates => '/usr/local/var/run/watchman',
+    path    => ['/usr/bin', '/usr/local/bin'],
+  }
+
+  # Step 2: Adjust ownership of the directory
+  exec { 'chown_watchman_dir':
+    command => 'sudo chown -R cltbld:staff /usr/local/var/run/watchman',
+    require => Exec['prepare_watchman_dir'],
+    path    => ['/usr/bin', '/usr/local/bin'],
+  }
+
+  # Step 3: Codesign the `watchman` binary
+  exec { 'codesign_watchman':
+    command => 'sudo codesign --force --sign - /usr/local/bin/watchman',
+    onlyif  => '/bin/test -f /usr/local/bin/watchman',
+    require => Packages::Macos_package_from_s3['watchman.pkg'],
+    path    => ['/usr/bin', '/usr/local/bin', '/bin'],
+  }
+
+  # Step 4: Codesign the `watchmanctl` binary
+  exec { 'codesign_watchmanctl':
+    command => 'sudo codesign --force --sign - /usr/local/bin/watchmanctl',
+    onlyif  => '/bin/test -f /usr/local/bin/watchmanctl',
+    require => Packages::Macos_package_from_s3['watchman.pkg'],
+    path    => ['/usr/bin', '/usr/local/bin', '/bin'],
+  }
+
+  exec { 'install_pywatchman':
+    command => '/usr/local/bin/pip3.11 install pywatchman==2.0.0',
+    unless  => '/usr/local/bin/python3 -c "import pywatchman"',
+    path    => ['/usr/local/bin', '/usr/bin'],
+  }
+
+  # Step 5: Append fsmonitor config to existing .hgrc if enabled
+  if $enabled {
+    file_line { 'add_fsmonitor_extension':
+      path    => '/Users/cltbld/.hgrc',
+      line    => 'fsmonitor =',
+      match   => '^fsmonitor\s*=',
+      after   => '^sparse\s*=',
+      require => File['/Users/cltbld/.hgrc'],
+    }
+
+    file_line { 'add_fsmonitor_section':
+      path    => '/Users/cltbld/.hgrc',
+      line    => '[fsmonitor]',
+      match   => '^\[fsmonitor\]',
+      require => File_line['add_fsmonitor_extension'],
+    }
+
+    file_line { 'add_fsmonitor_mode':
+      path    => '/Users/cltbld/.hgrc',
+      line    => 'mode = paranoid',
+      match   => '^mode\s*=',
+      require => File_line['add_fsmonitor_section'],
+    }
+  }
+}

--- a/modules/macos_fsmonitor/manifests/init.pp
+++ b/modules/macos_fsmonitor/manifests/init.pp
@@ -39,13 +39,14 @@ class macos_fsmonitor (
     path    => ['/usr/bin', '/usr/local/bin', '/bin'],
   }
 
+  # Step 5: Install the pywatchman package using pip
   exec { 'install_pywatchman':
     command => '/usr/local/bin/pip3.11 install pywatchman==2.0.0',
     unless  => '/usr/local/bin/python3 -c "import pywatchman"',
     path    => ['/usr/local/bin', '/usr/bin'],
   }
 
-  # Step 5: Append fsmonitor config to existing .hgrc if enabled
+  # Step 6: Append fsmonitor config to existing .hgrc if enabled
   if $enabled {
     file_line { 'add_fsmonitor_extension':
       path    => '/Users/cltbld/.hgrc',

--- a/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_fsmonitor.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_fsmonitor {
+  class { 'macos_fsmonitor':
+    enabled => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8.pp
@@ -7,6 +7,7 @@ class roles_profiles::roles::gecko_t_osx_1400_r8 {
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_bin_signer
   include roles_profiles::profiles::macos_directory_cleaner
+  include roles_profiles::profiles::macos_fsmonitor
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_tcc_perms

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1400_r8_staging.pp
@@ -7,6 +7,7 @@ class roles_profiles::roles::gecko_t_osx_1400_r8_staging {
   include roles_profiles::profiles::cltbld_user
   include roles_profiles::profiles::macos_bin_signer
   include roles_profiles::profiles::macos_directory_cleaner
+  include roles_profiles::profiles::macos_fsmonitor
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_notification_disabler
   include roles_profiles::profiles::macos_people_remover


### PR DESCRIPTION
** Note: Andy [approved](https://github.com/mozilla-platform-ops/ronin_puppet/pull/784#pullrequestreview-2761259093) this last week pending the test failure resolved. It is being applied to production today. Cut a new PR due to git issues**

https://mozilla-hub.atlassian.net/browse/RELOPS-1164

https://github.com/facebook/watchman/releases/tag/v2023.05.01.00

`watchman.pkg` drops 
```
watchman 
watchmanctl
```

into `/usr/local/bin` and

```
libcrypto.1.1.dylib
libevent-2.1.7.dylib
libgflags.2.2.dylib
libglog.0.dylib
liblz4.1.dylib
libpcre2-8.0.dylib
libsodium.23.dylib
libssl.1.1.dylib
libz.1.dylib
libzstd.1.dylib
```

into `/usr/local/lib/`


These binaries should work for now but its worth noting that this the last binary release for macOS. Other install methods are available via `homebrew`, but that presents challenges (for one we dont install `homebrew`) and my initial testing via the `brew pkg` method were unsuccessful