### PR TITLE
[RELOPS-1440] Add Safari Tech Preview 15 support for macOS 15

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4.yaml
+++ b/data/roles/gecko_t_osx_1500_m4.yaml
@@ -29,6 +29,7 @@ packages_classes:
   - python3_psutil
   - python3_pyobjc
   - python3_zstandard
+  - safari_preview
   - scres
   - telegraf
   - tooltool

--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -29,6 +29,7 @@ packages_classes:
   - python3_psutil
   - python3_pyobjc
   - python3_zstandard
+  - safari_preview
   - scres
   - telegraf
   - tooltool

--- a/modules/macos_safaridriver/files/safari-enable-remote-automation.sh
+++ b/modules/macos_safaridriver/files/safari-enable-remote-automation.sh
@@ -106,7 +106,14 @@ case "$macos_major_version" in
   "15")
     semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
     enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation"
-    ;; # <- **Missing `;;` was added here**
+
+    if [ -d "/Applications/Safari Technology Preview.app" ]; then
+      semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-tech-preview-enable-remote-automation-has-run"
+      enable_remote_automation "$semaphore_file" "Safari Technology Preview" "Developer" "Allow remote automation"
+    else
+      echo "Safari Technology Preview is not installed."
+    fi
+    ;;
   *)
     echo "Unsupported macOS version: $macos_full_version"
     exit 1

--- a/modules/packages/manifests/safari_preview.pp
+++ b/modules/packages/manifests/safari_preview.pp
@@ -20,6 +20,14 @@ class packages::safari_preview {
         type                => 'pkg',
       }
     }
+    # 23 == OS X 14
+    '24':  {
+      packages::macos_package_from_s3 { 'SafariTechnologyPreview15.pkg':
+        private             => false,
+        os_version_specific => false,
+        type                => 'pkg',
+      }
+    }
     default: {
       # Handle default case here if needed
     }


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RELOPS-1440

Rolled out to `gecko-t-osx-1500-m4-staging` and `gecko-t-osx-1500-m4`