### PR TITLE
Handle Python dependency issues on VPN builder jobs

### DIFF
--- a/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_1_osx.pp
@@ -10,7 +10,7 @@ class roles_profiles::roles::mozilla_b_1_osx {
   include roles_profiles::profiles::network
   include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
-  include roles_profiles::profiles::pipconf
+  #include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::sudo
   include roles_profiles::profiles::talos

--- a/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozilla_b_3_osx.pp
@@ -10,7 +10,7 @@ class roles_profiles::roles::mozilla_b_3_osx {
   include roles_profiles::profiles::network
   include roles_profiles::profiles::ntp
   include roles_profiles::profiles::packages_installed
-  include roles_profiles::profiles::pipconf
+  #include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::relops_users
   include roles_profiles::profiles::sudo
   include roles_profiles::profiles::talos


### PR DESCRIPTION
VPN builders are failing jobs when this change is applied.

We usually resolve these types of Puppet failures by uploading the necessary .whl files, but that may not be practical for all the dependencies used in this job.
In this case, the missing dependency was multidict, but fixing that may just uncover additional missing packages.

@aerickson — let me know what you think.

I think its also useful to note that while this config change was added to the builders in ronin_puppet some time ago, we have not yet to date applied the config (until now) to builders
