### PR TITLE
New taskcluster release v84.0.2

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -54,7 +54,7 @@ windows:
     package_source: "https://github.com/taskcluster/generic-worker/releases/download"
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
-    version: "83.5.7"
+    version: "84.0.2"
     generic-worker:
       name:
         amd64: "generic-worker-multiuser-windows-amd64"

--- a/data/roles/win10642009hwalpha.yaml
+++ b/data/roles/win10642009hwalpha.yaml
@@ -14,7 +14,7 @@ win-worker:
   # Logging level options debug, verbose, or restricted.
   log:
     level: "verbose"
+
   ## Use to overwrite values in the Windows yaml file.
   ## Replace windows. with win-worker.variant.
-
   variant:

--- a/data/roles/win116424h2hwrelops1213.yaml
+++ b/data/roles/win116424h2hwrelops1213.yaml
@@ -16,6 +16,6 @@ win-worker:
   log:
     level: "restricted"
 
+  ## Use to overwrite values in the Windows yaml file.
+  ## Replace windows. with win-worker.variant.
   variant:
-    #taskcluster:
-      #version: '81.0.3'


### PR DESCRIPTION
Updating taskcluster worker components to latest release [v84.0.2](https://github.com/taskcluster/taskcluster/releases/tag/v84.0.2).