### PR TITLE
[RELOPS-1554] linux integration tests: resolve rate-limiting issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,8 +201,9 @@ jobs:
           name: 0-60s sleep (rate-limit avoidance)
           shell: bash
           command: |
-            echo "Sleeping 0-60 seconds to avoid Ubuntu rate limiting..."
-            sleep $((RANDOM % 61))
+            sleep_duration=$((RANDOM % 61))
+            echo "Sleeping for $sleep_duration seconds..."
+            sleep $sleep_duration
       - run:
           command: bundle exec kitchen converge << parameters.kitchen_target >>
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,12 @@ jobs:
       - gem_cache
       - apt_cache_restore
       - run:
+          name: 0-60s sleep (rate-limit avoidance)
+          shell: bash
+          command: |
+            echo "Sleeping 0-60 seconds to avoid Ubuntu rate limiting..."
+            sleep $((RANDOM % 61))
+      - run:
           command: bundle exec kitchen converge << parameters.kitchen_target >>
           no_output_timeout: 30m
       - run: bundle exec kitchen verify << parameters.kitchen_target >>


### PR DESCRIPTION
Tests on master are broken again. They seem to be due to Ubuntu's servers rate-limiting requests.

Introduce a random sleep to avoid a thundering herd scenario.

See https://mozilla-hub.atlassian.net/browse/RELOPS-1554.