### PR TITLE
Roll out local puppet runs on gecko-t-osx-1015-r8-staging/gecko-t-osx-1015-r8

### DIFF
--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::gecko_t_osx_1015_r8 {
   include roles_profiles::profiles::macos_directory_cleaner
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::macos_xcode_tools
   include roles_profiles::profiles::metrics

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1015_r8_staging.pp
@@ -8,6 +8,7 @@ class roles_profiles::roles::gecko_t_osx_1015_r8_staging {
   include roles_profiles::profiles::macos_directory_cleaner
   include roles_profiles::profiles::macos_gw_checker
   include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
   include roles_profiles::profiles::macos_sbom
   include roles_profiles::profiles::macos_tcc_perms
   include roles_profiles::profiles::macos_xcode_tools


### PR DESCRIPTION
Also resolves an issue where 1015 workers would fail landing mercurial. Tested change against all staging pools