### PR TITLE
🛠 Fix error in cltbld provisioning that was slowing down Puppet runs

### DIFF
--- a/modules/roles_profiles/manifests/profiles/cltbld_user.pp
+++ b/modules/roles_profiles/manifests/profiles/cltbld_user.pp
@@ -11,7 +11,7 @@ class roles_profiles::profiles::cltbld_user {
       $salt         = lookup('cltbld_user.salt')
       $iterations   = lookup('cltbld_user.iterations')
       $kcpassword   = lookup('cltbld_user.kcpassword')
-      $password_hash = inline_template("<%= IO.popen(['openssl', 'passwd', '-6', '-salt', '${salt}', '-6', '-rounds', '${iterations}', '${password}']).read.chomp %>")
+      $password_hash = $password
 
       # Create the cltbld user
       case $facts['os']['release']['major'] {
@@ -37,8 +37,7 @@ class roles_profiles::profiles::cltbld_user {
         }
         '20','21','22', '23', '24': {
           exec { 'create_macos_user':
-            # UID needs to be > 501 for LaunchAgents to function
-            command => "/usr/sbin/sysadminctl -addUser ${account_username} -UID 555 -password '${password_hash}'",
+            command => "/usr/sbin/sysadminctl -addUser ${account_username} -UID 555 -password '${password}'",
             unless  => '/usr/bin/dscl . -read /Users/cltbld',
           }
           class { 'macos_utils::autologin_user':


### PR DESCRIPTION
While reconfiguring provisioning for the `cltbld` user, I previously introduced what seemed like a harmless error involving the use of unsupported options in the openssl passwd command on macOS.

Although this didn’t break functionality, it added significant overhead during each Puppet run. After removing the faulty logic, Puppet runtime dropped by 50% on average (from ~23s to ~11s across multiple runs).

Since we’re now running Puppet on every reboot, it’s a good time to address this and speed things up.