### PR TITLE
Remove non working cleanup

### DIFF
--- a/modules/worker_runner/templates/worker-runner.sh.erb
+++ b/modules/worker_runner/templates/worker-runner.sh.erb
@@ -22,7 +22,7 @@ rm <%= @data_dir %>/tasks-resolved-count.txt
 rm -rf /opt/worker/tasks/task_*
 
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1927416
-find /private/var/folders/ -depth -path '*/C/org.mozilla.*' -type d -exec rm -rf {} +
+# find /private/var/folders/ -depth -path '*/C/org.mozilla.*' -type d -exec rm -rf {} +
 
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1967525
 if [ -x  /usr/local/bin/lsdb.py ]; then


### PR DESCRIPTION
this silently fails because it's getting executed as the `cltbld` user (non-admin)

Ex:
```
[relops@macmini-r8-109.test.releng.mdc1.mozilla.com ~]$ sudo tail -f /opt/worker/logs/stderr.log
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n0000000000000/0/com.apple.icloud.searchpartyd/KeyMaps: Permission denied
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n0000000000000/0/com.apple.pluginkit: Permission denied
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n0000000000000/T: Permission denied
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n0000000000000/C: Permission denied
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n000011w00008g/T: Permission denied
find: /private/var/folders//zz/zyxvpxvq6csfxvn_n000011w00008g/C: Permission denied
find: /private/var/folders//y0/wsh0tw5j03g6mrwcv49_13g4000017/T: Permission denied
find: /private/var/folders//y0/wsh0tw5j03g6mrwcv49_13g4000017/C: Permission denied
find: /private/var/folders//4h/4ykfpjy14rd1v_rhxrlwwj8c00000x/T: Permission denied
find: /private/var/folders//4h/4ykfpjy14rd1v_rhxrlwwj8c00000x/C: Permission denied
rm: /opt/worker/tasks-resolved-count.txt: No such file or directory
```

and causes the mac workers to take longer to startup. I gave Joel a heads up and he said if it was a priority to fix he'd let us know. commenting out for now