### PR TITLE
[RELOPS-1805] deploy taskcluster 88.0.5 to all windows workers

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -54,7 +54,7 @@ windows:
     package_source: "https://github.com/taskcluster/generic-worker/releases/download"
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
-    version: "86.0.2"
+    version: "88.0.5"
     generic-worker:
       name:
         amd64: "generic-worker-multiuser-windows-amd64"


### PR DESCRIPTION
Includes fix for azure:

Worker Runner/Generic Worker (Azure): polls the metadata service for events the worker should gracefully terminate on every second (down from 15s). This frequency is recommended by Microsoft [here](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#polling-frequency) and will hopefully reduce tasks resolving as claim-expired.