### PR TITLE
2404 linux: install pulseaudio-utils

### DIFF
--- a/modules/linux_packages/manifests/pulseaudio.pp
+++ b/modules/linux_packages/manifests/pulseaudio.pp
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class linux_packages::pulseaudio {
-  # Ensure the 'ulseaudio-utils' package is installed which provides pactl
+  # Ensure the 'pulseaudio-utils' package is installed which provides pactl
   package { 'pulseaudio-utils':
     ensure   => installed,
     name     => 'pulseaudio-utils',

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker.pp
@@ -28,6 +28,7 @@ class roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker {
       require linux_packages::python3_zstandard
       require linux_packages::tooltool
       require linux_packages::zstd
+      require linux_packages::pulseaudio
 
       # moved from base to avoid ordering issues with py2/3
       require linux_mercurial

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
@@ -28,6 +28,7 @@ class roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker_wayland 
       require linux_packages::python3_zstandard
       require linux_packages::tooltool
       require linux_packages::zstd
+      require linux_packages::pulseaudio
 
       # moved from base to avoid ordering issues with py2/3
       require linux_mercurial

--- a/test/integration/linux-perf/inspec/pactl_spec.rb
+++ b/test/integration/linux-perf/inspec/pactl_spec.rb
@@ -1,11 +1,9 @@
 require_relative 'spec_helper'
 
-if os.family == 'debian' && (os.release.start_with?('18.04') or os.release.start_with?('22.04'))
+if os.family == 'debian' && (os.release.start_with?('18.04') or os.release.start_with?('22.04') or os.release.start_with?('24.04'))
   describe package('pulseaudio-utils') do
     it { should be_installed }
   end
-elsif os.family == 'debian' && os.release.start_with?('24.04')
-  # on 24.04, pulseaudio has been replaced with pipewire
 else
   # shouldn't be here
   # for other OS families or versions, show error


### PR DESCRIPTION
pipewire has replaced pulseaudio on 2404, but we have tests that want to use pactl.
not sure if they'll work with pactl fronting pipewire, but give it a try.

Discovered via https://phabricator.services.mozilla.com/D289027.