### PR TITLE
Add relops-dashboard SSH key to relops authorized_keys

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -407,6 +407,7 @@ all_users:
   # from relops_common_keys_2020-09-08.yml
   relops:
     - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILB0k0dwdH7h8j+zRPprLFeTgRwkgI6mcjQCeEoaqOY2 Relops ed25519 Key
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILBjZq7vEV+ZO7wceEnH3n1qurWlMyUazmYuVfERi2QO relops-dashboard@macmini-m4-117
 
 
 # Class parameter defaults: most data lookups should take place in profiles


### PR DESCRIPTION
Adds the ed25519 key generated on macmini-m4-117 for the RelOps Fleet Dashboard service, so it can SSH as relops to clear branch overrides (remove /opt/puppet_environments/ronin_settings) via the dashboard UI.