### PR TITLE
Update Azure VM Agent from 2.7.41491.1057 to 2.7.41491.1216

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -109,8 +109,8 @@ windows:
     version: '464'
   azure:
     vm_agent:
-      version: '2.7.41491.1057_2205251057.fre'
-      display_name: "Windows Azure VM Agent - 2.7.41491.1057"
+      version: '2.7.41491.1216_2604021216.fre'
+      display_name: "Windows Azure VM Agent - 2.7.41491.1216"
   bios:
     NUC13:
       bios_src: 'https://roninpuppetassets.blob.core.windows.net/hardware/NUC13/BIOS_exports'

--- a/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
+++ b/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
@@ -7,7 +7,12 @@ class roles_profiles::profiles::azure_vm_agent {
     'Windows': {
       $agent_version = lookup('windows.azure.vm_agent.version')
       $package       = lookup('windows.azure.vm_agent.display_name')
-      $msi           = "WindowsAzureVmAgent.${agent_version}.msi"
+
+      $arch = $facts['custom_win_os_arch'] ? {
+        'aarch64' => 'arm64',
+        default   => 'amd64',
+      }
+      $msi = "WindowsAzureVmAgent.${arch}_${agent_version}.msi"
 
       class { 'win_packages::azure_vm_agent':
         package => $package,

--- a/test/integration/win11a6424h2azurebuilder/serverspec/azure_vm_agent_spec.rb
+++ b/test/integration/win11a6424h2azurebuilder/serverspec/azure_vm_agent_spec.rb
@@ -1,0 +1,8 @@
+require_relative 'spec_helper'
+
+expected_version = expected_hiera_value('azure', 'vm_agent', 'version').split('_').first
+
+describe software_property_command("$_.DisplayName -like 'Windows Azure VM Agent*'", 'DisplayVersion') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^#{Regexp.escape(expected_version)}\s*$/) }
+end

--- a/test/integration/win11a6424h2azurebuilder/serverspec/spec_helper.rb
+++ b/test/integration/win11a6424h2azurebuilder/serverspec/spec_helper.rb
@@ -1,0 +1,86 @@
+require 'base64'
+require 'serverspec'
+require 'winrm'
+require 'yaml'
+
+ROOT_DIR = File.expand_path('../../../..', __dir__).freeze
+ROLE_NAME = File.basename(File.expand_path('..', __dir__)).freeze
+ROLE_DATA = YAML.load_file(File.join(ROOT_DIR, 'data', 'roles', "#{ROLE_NAME}.yaml")).freeze
+WINDOWS_DATA = YAML.load_file(File.join(ROOT_DIR, 'data', 'os', 'Windows.yaml')).fetch('windows').freeze
+ROLE_HIERA = ROLE_DATA.fetch('win-worker').freeze
+VARIANT_DATA = ROLE_HIERA.fetch('variant', {}).freeze
+WORKER_FUNCTION = ROLE_HIERA.fetch('function').freeze
+
+conn = WinRM::Connection.new(
+  endpoint: "http://#{ENV.fetch('KITCHEN_HOSTNAME')}:5985/wsman",
+  user: ENV.fetch('KITCHEN_USERNAME'),
+  password: ENV.fetch('KITCHEN_PASSWORD'),
+  transport: :plaintext,
+  basic_auth_only: true,
+  operation_timeout: 1800,
+  receive_timeout: 1810
+)
+
+Specinfra.configuration.winrm = conn
+set :backend, :winrm
+set :os, :family => 'windows'
+
+def deep_fetch(hash, *keys)
+  keys.reduce(hash) do |memo, key|
+    memo.is_a?(Hash) ? memo[key] : nil
+  end
+end
+
+def expected_hiera_value(*keys)
+  deep_fetch(VARIANT_DATA, *keys) || deep_fetch(ROLE_HIERA, *keys) || deep_fetch(WINDOWS_DATA, *keys)
+end
+
+def powershell_command(script)
+  encoded = Base64.strict_encode64(script.encode('UTF-16LE'))
+  command("powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand #{encoded}")
+end
+
+def registry_value_command(path, property)
+  powershell_command(<<~POWERSHELL)
+    $value = Get-ItemPropertyValue -Path '#{path}' -Name '#{property}' -ErrorAction Stop
+    $value
+  POWERSHELL
+end
+
+def registry_key_exists_command(path)
+  powershell_command(<<~POWERSHELL)
+    if (Test-Path '#{path}') {
+      'present'
+    }
+    else {
+      exit 1
+    }
+  POWERSHELL
+end
+
+def service_property_command(name, property)
+  powershell_command(<<~POWERSHELL)
+    $service = Get-CimInstance Win32_Service -Filter "Name='#{name}'" -ErrorAction Stop
+    $service.#{property}
+  POWERSHELL
+end
+
+def scheduled_task_command(name, script)
+  powershell_command(<<~POWERSHELL)
+    $task = Get-ScheduledTask -TaskName '#{name}' -ErrorAction Stop | Select-Object -First 1
+    #{script}
+  POWERSHELL
+end
+
+def machine_env_command(name)
+  powershell_command("[Environment]::GetEnvironmentVariable('#{name}', 'Machine')")
+end
+
+def software_property_command(display_name_filter, property)
+  powershell_command(<<~POWERSHELL)
+    $items = Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*', 'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*' -ErrorAction SilentlyContinue
+    $match = $items | Where-Object { #{display_name_filter} } | Select-Object -First 1
+    if ($null -eq $match) { exit 1 }
+    $match.#{property}
+  POWERSHELL
+end

--- a/test/integration/win11a6424h2azuretester/serverspec/azure_vm_agent_spec.rb
+++ b/test/integration/win11a6424h2azuretester/serverspec/azure_vm_agent_spec.rb
@@ -1,0 +1,8 @@
+require_relative 'spec_helper'
+
+expected_version = expected_hiera_value('azure', 'vm_agent', 'version').split('_').first
+
+describe software_property_command("$_.DisplayName -like 'Windows Azure VM Agent*'", 'DisplayVersion') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^#{Regexp.escape(expected_version)}\s*$/) }
+end

--- a/test/integration/win11a6424h2azuretester/serverspec/spec_helper.rb
+++ b/test/integration/win11a6424h2azuretester/serverspec/spec_helper.rb
@@ -1,0 +1,86 @@
+require 'base64'
+require 'serverspec'
+require 'winrm'
+require 'yaml'
+
+ROOT_DIR = File.expand_path('../../../..', __dir__).freeze
+ROLE_NAME = File.basename(File.expand_path('..', __dir__)).freeze
+ROLE_DATA = YAML.load_file(File.join(ROOT_DIR, 'data', 'roles', "#{ROLE_NAME}.yaml")).freeze
+WINDOWS_DATA = YAML.load_file(File.join(ROOT_DIR, 'data', 'os', 'Windows.yaml')).fetch('windows').freeze
+ROLE_HIERA = ROLE_DATA.fetch('win-worker').freeze
+VARIANT_DATA = ROLE_HIERA.fetch('variant', {}).freeze
+WORKER_FUNCTION = ROLE_HIERA.fetch('function').freeze
+
+conn = WinRM::Connection.new(
+  endpoint: "http://#{ENV.fetch('KITCHEN_HOSTNAME')}:5985/wsman",
+  user: ENV.fetch('KITCHEN_USERNAME'),
+  password: ENV.fetch('KITCHEN_PASSWORD'),
+  transport: :plaintext,
+  basic_auth_only: true,
+  operation_timeout: 1800,
+  receive_timeout: 1810
+)
+
+Specinfra.configuration.winrm = conn
+set :backend, :winrm
+set :os, :family => 'windows'
+
+def deep_fetch(hash, *keys)
+  keys.reduce(hash) do |memo, key|
+    memo.is_a?(Hash) ? memo[key] : nil
+  end
+end
+
+def expected_hiera_value(*keys)
+  deep_fetch(VARIANT_DATA, *keys) || deep_fetch(ROLE_HIERA, *keys) || deep_fetch(WINDOWS_DATA, *keys)
+end
+
+def powershell_command(script)
+  encoded = Base64.strict_encode64(script.encode('UTF-16LE'))
+  command("powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand #{encoded}")
+end
+
+def registry_value_command(path, property)
+  powershell_command(<<~POWERSHELL)
+    $value = Get-ItemPropertyValue -Path '#{path}' -Name '#{property}' -ErrorAction Stop
+    $value
+  POWERSHELL
+end
+
+def registry_key_exists_command(path)
+  powershell_command(<<~POWERSHELL)
+    if (Test-Path '#{path}') {
+      'present'
+    }
+    else {
+      exit 1
+    }
+  POWERSHELL
+end
+
+def service_property_command(name, property)
+  powershell_command(<<~POWERSHELL)
+    $service = Get-CimInstance Win32_Service -Filter "Name='#{name}'" -ErrorAction Stop
+    $service.#{property}
+  POWERSHELL
+end
+
+def scheduled_task_command(name, script)
+  powershell_command(<<~POWERSHELL)
+    $task = Get-ScheduledTask -TaskName '#{name}' -ErrorAction Stop | Select-Object -First 1
+    #{script}
+  POWERSHELL
+end
+
+def machine_env_command(name)
+  powershell_command("[Environment]::GetEnvironmentVariable('#{name}', 'Machine')")
+end
+
+def software_property_command(display_name_filter, property)
+  powershell_command(<<~POWERSHELL)
+    $items = Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*', 'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*' -ErrorAction SilentlyContinue
+    $match = $items | Where-Object { #{display_name_filter} } | Select-Object -First 1
+    if ($null -eq $match) { exit 1 }
+    $match.#{property}
+  POWERSHELL
+end


### PR DESCRIPTION
## Summary

- Updates the baked Azure VM Agent from 2.7.41491.1057 (May 2022) to 2.7.41491.1216 (April 2026)
- Adds architecture-aware MSI selection since the new release ships separate amd64 and arm64 installers
- Both MSIs uploaded to `roninpuppetassets` blob storage and verified accessible

## Context

The old agent is a contributing factor in intermittent `OSProvisioningTimedOut` failures on `gecko-t/win11-64-25h2` workers during Azure first-boot. 4 failed deployments were observed on 25h2 vs 0 on 24h2 over 2026-04-14/15. The 4-year-old agent may have a compatibility issue with the Windows 25H2 kernel (build 26200).

## Changes

- `data/os/Windows.yaml` — version bump
- `modules/roles_profiles/manifests/profiles/azure_vm_agent.pp` — select MSI by `custom_win_os_arch` (`amd64` or `arm64`)

## Test plan

- Existing `azure_vm_agent_spec.rb` tests are data-driven from Hiera and need no changes (verified identical across all 6 suites)
- Build an alpha 25h2 image with this commit to validate the new agent installs and first-boot succeeds
- Monitor for `OSProvisioningTimedOut` rate on the alpha pool over 24-48h

RELOPS-2328