### PR TITLE
Add gecko_{1,3}_b_osx_arm64_vms Puppet roles for VM-based builders

### DIFF
--- a/data/roles/gecko_1_b_osx_arm64_vms.yaml
+++ b/data/roles/gecko_1_b_osx_arm64_vms.yaml
@@ -1,0 +1,67 @@
+---
+ntp_server: time.apple.org
+
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+worker:
+  taskcluster_version: 95.0.3
+  provider_type: standalone
+  worker_pool_id: releng-hardware/gecko-1-b-osx-arm64-vms
+  worker_group: mdc1
+  worker_id: "%{facts.networking.hostname}"
+  client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+  access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+  generic_worker_engine: multiuser
+  idle_timeout_secs: 3600
+
+packages_classes:
+  - mercurial
+  - nodejs
+  - python3
+  - python3_psutil
+  - python3_zstandard
+  - scres
+  - tooltool
+  - virtualenv
+  - wget
+  - zstandard
+  - telegraf
+  - virt_audio_s3
+
+# Package class parameters
+packages::mercurial::version: 6.4.5
+packages::nodejs::version: 12.11.1
+packages::python3::version: 3.11.0
+packages::python3_zstandard::version: 0.22.0
+packages::virtualenv::version: 16.4.3
+packages::wget::version: 1.20.3_1
+packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
+packages::virt_audio_s3::version: 0.5.0
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+# Talos class parameters
+talos::user: cltbld
+
+puppet_run_strategy: never
+
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/data/roles/gecko_3_b_osx_arm64_vms.yaml
+++ b/data/roles/gecko_3_b_osx_arm64_vms.yaml
@@ -1,0 +1,66 @@
+---
+ntp_server: time.apple.org
+
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+worker:
+  taskcluster_version: 95.0.3
+  provider_type: standalone
+  worker_pool_id: releng-hardware/gecko-3-b-osx-arm64-vms
+  worker_group: mdc1
+  worker_id: "%{facts.networking.hostname}"
+  client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+  access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+  generic_worker_engine: multiuser
+  idle_timeout_secs: 3600
+
+packages_classes:
+  - mercurial
+  - nodejs
+  - python3
+  - python3_psutil
+  - python3_zstandard
+  - scres
+  - tooltool
+  - virtualenv
+  - wget
+  - zstandard
+  - telegraf
+
+# Package class parameters
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: 6.4.5
+packages::nodejs::version: 12.11.1
+packages::python3::version: 3.11.0
+packages::python3_zstandard::version: 0.22.0
+packages::virtualenv::version: 16.4.3
+packages::wget::version: 1.20.3_1
+packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+# Talos class parameters
+talos::user: cltbld
+
+puppet_run_strategy: never
+
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms.pp
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::gecko_1_b_osx_arm64_vms {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::macos_xcode_tools
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
+}

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms.pp
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::gecko_3_b_osx_arm64_vms {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::macos_xcode_tools
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
+}


### PR DESCRIPTION
## Summary

Adds Puppet roles and Hiera data for macOS 15.3 Tart VM builder workers on Apple Silicon (M4), targeting the \`releng-hardware/gecko-{1,3}-b-osx-arm64-vms\` Taskcluster pools.

**New files:**
- \`modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms.pp\`
- \`modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms.pp\`
- \`data/roles/gecko_1_b_osx_arm64_vms.yaml\`
- \`data/roles/gecko_3_b_osx_arm64_vms.yaml\`

**Design notes:**
- The \`-vms\` suffix follows the \`gecko-t-osx-1500-m-vms\` tester convention, keeping VM workers distinct from any future bare-metal \`gecko-{1,3}-b-osx-arm64\` workers
- \`taskcluster_version: 95.0.3\` (bumped from the bare-metal role's stale \`60.3.4\` to match the proven m_vms tester)
- \`puppet_agent.package_version: 7.28.0\` (pinned to match what the image build installs)
- \`generic_worker_engine: multiuser\`

## Test plan

- [x] Pre-commit hooks pass (puppet-lint, yaml check)
- [ ] Image build pipeline in mozilla-platform-ops/macos-vms#19 completes using this branch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)