### PR TITLE
Add gecko_1_b_osx_arm64_vms and gecko_3_b_osx_arm64_vms roles

### DIFF
--- a/data/roles/gecko_1_b_osx_arm64_vms.yaml
+++ b/data/roles/gecko_1_b_osx_arm64_vms.yaml
@@ -30,7 +30,6 @@ packages_classes:
   - wget
   - zstandard
   - telegraf
-  - virt_audio_s3
 
 # Package class parameters
 packages::mercurial::version: 6.4.5
@@ -41,7 +40,6 @@ packages::virtualenv::version: 16.4.3
 packages::wget::version: 1.20.3_1
 packages::zstandard::version: 1.3.8
 packages::telegraf::version: 1.19.0
-packages::virt_audio_s3::version: 0.5.0
 
 # Puppet agent
 puppet_agent:

--- a/data/roles/gecko_1_b_osx_arm64_vms.yaml
+++ b/data/roles/gecko_1_b_osx_arm64_vms.yaml
@@ -1,0 +1,67 @@
+---
+ntp_server: time.apple.org
+
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+worker:
+  taskcluster_version: 95.0.3
+  provider_type: standalone
+  worker_pool_id: releng-hardware/gecko-1-b-osx-arm64-vms
+  worker_group: mdc1
+  worker_id: "%{facts.networking.hostname}"
+  client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+  access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+  generic_worker_engine: multiuser
+  idle_timeout_secs: 3600
+
+packages_classes:
+  - mercurial
+  - nodejs
+  - python3
+  - python3_psutil
+  - python3_zstandard
+  - scres
+  - tooltool
+  - virtualenv
+  - wget
+  - zstandard
+  - telegraf
+  - virt_audio_s3
+
+# Package class parameters
+packages::mercurial::version: 6.4.5
+packages::nodejs::version: 12.11.1
+packages::python3::version: 3.11.0
+packages::python3_zstandard::version: 0.22.0
+packages::virtualenv::version: 16.4.3
+packages::wget::version: 1.20.3_1
+packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
+packages::virt_audio_s3::version: 0.5.0
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+# Talos class parameters
+talos::user: cltbld
+
+puppet_run_strategy: never
+
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/data/roles/gecko_1_b_osx_arm64_vms_host.yaml
+++ b/data/roles/gecko_1_b_osx_arm64_vms_host.yaml
@@ -1,0 +1,20 @@
+---
+ntp_server: time.apple.org
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+puppet_run_strategy: cron
+
+# Tart VM host configuration: runs gecko-1b builder VMs
+tart:
+  version: '2.30.0'
+  registry_host: '10.49.56.83'
+  registry_port: 5000
+  oci_image: 'sequoia-gecko1b-vms'
+  oci_tag: 'prod-latest'
+  vm_name_prefix: 'gecko1b-vm'
+  worker_count: 2
+  insecure: true
+  user: 'admin'

--- a/data/roles/gecko_3_b_osx_arm64_vms.yaml
+++ b/data/roles/gecko_3_b_osx_arm64_vms.yaml
@@ -1,0 +1,66 @@
+---
+ntp_server: time.apple.org
+
+worker_metadata:
+  workerId: "%{lookup('gw.worker_id')}"
+  workerGroup: "%{lookup('gw.worker_group')}"
+  workerType: "%{lookup('gw.worker_type')}"
+  provisionerId: "%{lookup('gw.provisioner_id')}"
+
+worker:
+  taskcluster_version: 95.0.3
+  provider_type: standalone
+  worker_pool_id: releng-hardware/gecko-3-b-osx-arm64-vms
+  worker_group: mdc1
+  worker_id: "%{facts.networking.hostname}"
+  client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+  access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
+  generic_worker_engine: multiuser
+  idle_timeout_secs: 3600
+
+packages_classes:
+  - mercurial
+  - nodejs
+  - python3
+  - python3_psutil
+  - python3_zstandard
+  - scres
+  - tooltool
+  - virtualenv
+  - wget
+  - zstandard
+  - telegraf
+
+# Package class parameters
+packages::google_chrome::version: v80.0.3987.106
+packages::mercurial::version: 6.4.5
+packages::nodejs::version: 12.11.1
+packages::python3::version: 3.11.0
+packages::python3_zstandard::version: 0.22.0
+packages::virtualenv::version: 16.4.3
+packages::wget::version: 1.20.3_1
+packages::zstandard::version: 1.3.8
+packages::telegraf::version: 1.19.0
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+# Talos class parameters
+talos::user: cltbld
+
+puppet_run_strategy: never
+
+telegraf:
+    user: "%{lookup('vault_secrets::telegraf.data.user')}"
+    password: "%{lookup('vault_secrets::telegraf.data.password')}"
+
+cltbld_user:
+    password: "%{lookup('vault_secrets::cltbld_user.data.password')}"
+    salt: "%{lookup('vault_secrets::cltbld_user.data.salt')}"
+    iterations: "%{lookup('vault_secrets::cltbld_user.data.iterations')}"
+    kcpassword: "%{lookup('vault_secrets::cltbld_user.data.kcpassword')}"
+
+generic_worker_secrets:
+    taskcluster_client_id: "%{lookup('vault_secrets::generic_worker.data.taskcluster_client_id')}"
+    taskcluster_access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"

--- a/data/roles/gecko_3_b_osx_arm64_vms_host.yaml
+++ b/data/roles/gecko_3_b_osx_arm64_vms_host.yaml
@@ -1,0 +1,20 @@
+---
+ntp_server: time.apple.org
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+puppet_run_strategy: cron
+
+# Tart VM host configuration: runs gecko-3b builder VMs
+tart:
+  version: '2.30.0'
+  registry_host: '10.49.56.83'
+  registry_port: 5000
+  oci_image: 'sequoia-gecko3b-vms'
+  oci_tag: 'prod-latest'
+  vm_name_prefix: 'gecko3b-vm'
+  worker_count: 2
+  insecure: true
+  user: 'admin'

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -1,0 +1,110 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Installs Tart, pulls an OCI VM image, clones N worker VMs, and manages
+# per-VM LaunchAgents so they start and stay running as the configured user.
+class roles_profiles::profiles::tart {
+  $version        = lookup('tart.version',        String,  'first', '2.30.0')
+  $registry_host  = lookup('tart.registry_host',  String,  'first', '10.49.56.83')
+  $registry_port  = lookup('tart.registry_port',  Integer, 'first', 5000)
+  $oci_image      = lookup('tart.oci_image',      String,  'first', 'sequoia-gecko1b-vms')
+  $oci_tag        = lookup('tart.oci_tag',        String,  'first', 'prod-latest')
+  $vm_name_prefix = lookup('tart.vm_name_prefix', String,  'first', 'gecko1b-vm')
+  $worker_count   = lookup('tart.worker_count',   Integer, 'first', 2)
+  $insecure       = lookup('tart.insecure',       Boolean, 'first', true)
+  $user           = lookup('tart.user',           String,  'first', 'admin')
+
+  $install_dir   = '/Applications'
+  $bin_path      = '/usr/local/bin/tart'
+  $tart_url      = "https://github.com/cirruslabs/tart/releases/download/${version}/tart.tar.gz"
+  $insecure_flag = $insecure ? { true => '--insecure', false => '' }
+
+  exec { 'create_usr_local_bin':
+    command => 'mkdir -p /usr/local/bin',
+    path    => ['/usr/bin', '/bin'],
+    unless  => 'test -d /usr/local/bin',
+  }
+
+  exec { 'install_tart':
+    command => "/bin/bash -c 'set -e && tmp=\$(mktemp -d) && cd \"\$tmp\" && curl -L -o tart.tar.gz ${tart_url} && tar -xzf tart.tar.gz && rm -rf ${install_dir}/Tart.app && mv Tart.app ${install_dir}/Tart.app && (xattr -dr com.apple.quarantine ${install_dir}/Tart.app || true) && mkdir -p /usr/local/bin && ln -sf ${install_dir}/Tart.app/Contents/MacOS/tart ${bin_path} && cd / && rm -rf \"\$tmp\"'",
+    path    => ['/usr/bin', '/bin', '/usr/local/bin'],
+    unless  => "test -x ${bin_path}",
+    timeout => 600,
+    require => Exec['create_usr_local_bin'],
+  }
+
+  file { '/usr/local/bin/tart-pull-image.sh':
+    ensure  => file,
+    mode    => '0755',
+    content => epp('roles_profiles/tart/tart-pull-image.sh.epp', {
+      registry_host  => $registry_host,
+      registry_port  => $registry_port,
+      oci_image      => $oci_image,
+      oci_tag        => $oci_tag,
+      vm_name_prefix => $vm_name_prefix,
+      worker_count   => $worker_count,
+      insecure_flag  => $insecure_flag,
+      bin_path       => $bin_path,
+    }),
+    require => Exec['install_tart'],
+  }
+
+  file { '/usr/local/bin/tart-update-vms.sh':
+    ensure  => file,
+    mode    => '0755',
+    content => epp('roles_profiles/tart/tart-update-vms.sh.epp', {
+      registry_host  => $registry_host,
+      registry_port  => $registry_port,
+      oci_image      => $oci_image,
+      oci_tag        => $oci_tag,
+      vm_name_prefix => $vm_name_prefix,
+      worker_count   => $worker_count,
+      insecure_flag  => $insecure_flag,
+      bin_path       => $bin_path,
+      user           => $user,
+    }),
+    require => Exec['install_tart'],
+  }
+
+  file { "/Users/${user}/Library/LaunchAgents":
+    ensure => directory,
+    owner  => $user,
+    group  => 'staff',
+    mode   => '0755',
+  }
+
+  exec { 'pull_initial_image':
+    command => "su - ${user} -c '/usr/local/bin/tart-pull-image.sh'",
+    path    => ['/usr/bin', '/bin', '/usr/local/bin'],
+    require => [File['/usr/local/bin/tart-pull-image.sh']],
+    timeout => 1800,
+    unless  => "su - ${user} -c '${bin_path} list' | awk '{print \$1}' | grep -Fx '${vm_name_prefix}-1'",
+  }
+
+  Integer[1, $worker_count].each |$i| {
+    $vm_name = "${vm_name_prefix}-${i}"
+
+    file { "/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist":
+      ensure  => file,
+      content => epp('roles_profiles/tart/com.mozilla.tartworker.plist.epp', {
+        worker_id => $i,
+        vm_name   => $vm_name,
+        bin_path  => $bin_path,
+        user      => $user,
+      }),
+      owner   => $user,
+      group   => 'staff',
+      mode    => '0644',
+      require => [Exec['pull_initial_image'], File["/Users/${user}/Library/LaunchAgents"]],
+      notify  => Exec["load_tartworker_${i}"],
+    }
+
+    exec { "load_tartworker_${i}":
+      command     => "su - ${user} -c 'launchctl unload /Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist 2>/dev/null || true; launchctl load /Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist'",
+      path        => ['/bin', '/usr/bin'],
+      refreshonly => true,
+      require     => File["/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist"],
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms.pp
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::gecko_1_b_osx_arm64_vms {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::macos_xcode_tools
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
+}

--- a/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms_host.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_1_b_osx_arm64_vms_host.pp
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Physical macOS host that runs gecko-1b builder VMs via Tart.
+# Pulls sequoia-gecko1b-vms from the local OCI registry and manages
+# worker VM lifecycle via per-VM LaunchAgents.
+class roles_profiles::roles::gecko_1_b_osx_arm64_vms_host {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::tart
+}

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms.pp
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::roles::gecko_3_b_osx_arm64_vms {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_people_remover
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::macos_xcode_tools
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::packages_installed
+  include roles_profiles::profiles::pipconf
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::worker
+}

--- a/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms_host.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_b_osx_arm64_vms_host.pp
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Physical macOS host that runs gecko-3b builder VMs via Tart.
+# Pulls sequoia-gecko3b-vms from the local OCI registry and manages
+# worker VM lifecycle via per-VM LaunchAgents.
+class roles_profiles::roles::gecko_3_b_osx_arm64_vms_host {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::tart
+}

--- a/modules/roles_profiles/templates/tart/com.mozilla.tartworker.plist.epp
+++ b/modules/roles_profiles/templates/tart/com.mozilla.tartworker.plist.epp
@@ -1,0 +1,30 @@
+<%- | Integer $worker_id,
+      String  $vm_name,
+      String  $bin_path,
+      String  $user,
+| -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.tartworker-<%= $worker_id %></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $bin_path %></string>
+        <string>run</string>
+        <string>--no-graphics</string>
+        <string><%= $vm_name %></string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/<%= $user %></string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/<%= $user %>/Library/Logs/tartworker-<%= $worker_id %>.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/<%= $user %>/Library/Logs/tartworker-<%= $worker_id %>.err</string>
+</dict>
+</plist>

--- a/modules/roles_profiles/templates/tart/tart-pull-image.sh.epp
+++ b/modules/roles_profiles/templates/tart/tart-pull-image.sh.epp
@@ -1,0 +1,39 @@
+<%- | String  $registry_host,
+      Integer $registry_port,
+      String  $oci_image,
+      String  $oci_tag,
+      String  $vm_name_prefix,
+      Integer $worker_count,
+      String  $insecure_flag,
+      String  $bin_path,
+| -%>
+#!/bin/bash
+set -euo pipefail
+
+REGISTRY="<%= $registry_host %>:<%= $registry_port %>"
+IMAGE="<%= $oci_image %>:<%= $oci_tag %>"
+WORKER_COUNT=<%= $worker_count %>
+BIN_PATH="<%= $bin_path %>"
+VM_NAME_PREFIX="<%= $vm_name_prefix %>"
+INSECURE_FLAG="<%= $insecure_flag %>"
+
+echo "Pulling latest VM image from OCI registry..."
+"${BIN_PATH}" pull ${INSECURE_FLAG} "${REGISTRY}/${IMAGE}"
+
+echo "Setting up worker VMs..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  VM_NAME="${VM_NAME_PREFIX}-${i}"
+
+  if "${BIN_PATH}" list | awk '{print $1}' | grep -Fx "${VM_NAME}" > /dev/null 2>&1; then
+    echo "${VM_NAME} already exists, skipping clone"
+    continue
+  fi
+
+  echo "Cloning ${VM_NAME}..."
+  "${BIN_PATH}" clone "${REGISTRY}/${IMAGE}" "${VM_NAME}"
+
+  echo "Randomizing MAC and serial for ${VM_NAME}..."
+  "${BIN_PATH}" set "${VM_NAME}" --random-mac --random-serial
+done
+
+echo "VM setup complete"

--- a/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
+++ b/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
@@ -1,0 +1,59 @@
+<%- | String  $registry_host,
+      Integer $registry_port,
+      String  $oci_image,
+      String  $oci_tag,
+      String  $vm_name_prefix,
+      Integer $worker_count,
+      String  $insecure_flag,
+      String  $bin_path,
+      String  $user,
+| -%>
+#!/bin/bash
+# Manual VM update script: stops workers, pulls fresh image, reclones, restarts.
+set -euo pipefail
+
+REGISTRY="<%= $registry_host %>:<%= $registry_port %>"
+IMAGE="<%= $oci_image %>:<%= $oci_tag %>"
+WORKER_COUNT=<%= $worker_count %>
+BIN_PATH="<%= $bin_path %>"
+VM_NAME_PREFIX="<%= $vm_name_prefix %>"
+INSECURE_FLAG="<%= $insecure_flag %>"
+USER="<%= $user %>"
+PLIST_DIR="/Users/${USER}/Library/LaunchAgents"
+
+echo "Stopping Tart worker LaunchAgents..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  launchctl unload "${PLIST_DIR}/com.mozilla.tartworker-${i}.plist" 2>/dev/null || true
+done
+
+echo "Waiting 30s for VMs to shut down gracefully..."
+sleep 30
+
+echo "Force-stopping any remaining VMs..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  VM_NAME="${VM_NAME_PREFIX}-${i}"
+  "${BIN_PATH}" stop "${VM_NAME}" 2>/dev/null || true
+done
+
+echo "Deleting old VMs..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  VM_NAME="${VM_NAME_PREFIX}-${i}"
+  "${BIN_PATH}" delete "${VM_NAME}" 2>/dev/null || true
+done
+
+echo "Pulling latest image..."
+"${BIN_PATH}" pull ${INSECURE_FLAG} "${REGISTRY}/${IMAGE}"
+
+echo "Cloning fresh VMs..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  VM_NAME="${VM_NAME_PREFIX}-${i}"
+  "${BIN_PATH}" clone "${REGISTRY}/${IMAGE}" "${VM_NAME}"
+  "${BIN_PATH}" set "${VM_NAME}" --random-mac --random-serial
+done
+
+echo "Reloading LaunchAgents..."
+for i in $(seq 1 ${WORKER_COUNT}); do
+  launchctl load "${PLIST_DIR}/com.mozilla.tartworker-${i}.plist"
+done
+
+echo "Update complete. VMs are restarting."


### PR DESCRIPTION
## Summary
- Adds `gecko_1_b_osx_arm64_vms` and `gecko_3_b_osx_arm64_vms` Puppet roles for ARM64 macOS builder VM images
- `-vms` suffix pools are a staging/test tier before swap-and-replace of the existing production pools
- Role includes are identical to the existing `gecko_{1,3}_b_osx_arm64` roles; Hiera data points to new `releng-hardware/gecko-{1,3}-b-osx-arm64-vms` worker pool IDs
- `taskcluster_version` bumped to 95.0.3

## Test plan
- [ ] Build triggered via `macos-vms` PR #19 using `PUPPET_BRANCH: gecko-arm64-vms-roles`
- [ ] Verify Puppet phase 1 + 2 complete successfully in the builder image pipeline
- [ ] Merge after image build is confirmed working

🤖 Generated with [Claude Code](https://claude.ai/claude-code)