### PR TITLE
ci: trigger kitchen workflows when PR is marked ready for review

### DIFF
--- a/.github/workflows/kitchen-linux.yml
+++ b/.github/workflows/kitchen-linux.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/kitchen-macos.yml
+++ b/.github/workflows/kitchen-macos.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/kitchen-windows.yml
+++ b/.github/workflows/kitchen-windows.yml
@@ -6,6 +6,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   windows:


### PR DESCRIPTION
Kitchen workflows (Linux, macOS, Windows) skip jobs when a PR is in draft
state. Previously, converting a draft PR to ready-for-review did not
re-trigger CI because the workflows only listened to the default
pull_request activity types (opened, synchronize, reopened).

Add `ready_for_review` to the types list for all three kitchen workflows so
CI runs automatically when a draft is promoted.