### PR TITLE
fix build_and_install_git: remove cwd, cd in command instead

### DIFF
--- a/modules/packages/manifests/git.pp
+++ b/modules/packages/manifests/git.pp
@@ -27,8 +27,7 @@ class packages::git (
   }
 
   exec { 'build_and_install_git':
-    command => "/bin/sh -c '${src_dir}/configure --prefix=/usr/local --without-tcltk && make -j4 all && make install'",
-    cwd     => $src_dir,
+    command => "/bin/sh -c 'cd ${src_dir} && ${src_dir}/configure --prefix=/usr/local --without-tcltk && make -j4 all && make install'",
     path    => ['/usr/bin', '/usr/local/bin', '/bin', '/usr/sbin', '/sbin'],
     unless  => $git_version_check,
     require => Exec['extract_git_src'],


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced in #1125.

Puppet validates the `cwd` attribute **before** running the `unless` check on an exec resource. With `cwd => $src_dir`, any host where `/tmp/git-2.47.1` doesn't exist — including hosts where git is already installed and the exec would be skipped — fails catalog application with:

```
Error: /Stage[main]/Packages::Git/Exec[build_and_install_git]: Could not evaluate: Working directory /tmp/git-2.47.1 does not exist!
```

Fix: remove `cwd => $src_dir` and embed `cd ${src_dir} &&` at the start of the command.

## Test plan

- [ ] Puppet apply succeeds on a host where git 2.47.1 is already installed (exec skipped cleanly, no cwd error)
- [ ] Puppet apply builds and installs git on a fresh host

🤖 Generated with [Claude Code](https://claude.com/claude-code)