### PR TITLE
Remove macmini-m4-126/127 from staging inventory: TC loaners

### DIFF
--- a/inventory.d/macmini-m4.yaml
+++ b/inventory.d/macmini-m4.yaml
@@ -8,8 +8,6 @@ groups:
       - macmini-m4-113.test.releng.mdc1.mozilla.com
       - macmini-m4-114.test.releng.mdc1.mozilla.com
       - macmini-m4-115.test.releng.mdc1.mozilla.com
-      - macmini-m4-126.test.releng.mdc1.mozilla.com
-      - macmini-m4-127.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: gecko_t_osx_1500_m4_staging
 


### PR DESCRIPTION
These machines are Taskcluster loaners and do not belong in the gecko-t-osx-1500-m4-staging group.