### PR TITLE
Add gecko-1b VMs host role to macmini-m4-117 and fix OCI tag

### DIFF
--- a/data/roles/gecko_1_b_osx_arm64_vms_host.yaml
+++ b/data/roles/gecko_1_b_osx_arm64_vms_host.yaml
@@ -13,7 +13,7 @@ tart:
   registry_host: '10.49.56.83'
   registry_port: 5000
   oci_image: 'sequoia-gecko1b-vms'
-  oci_tag: 'prod-latest'
+  oci_tag: 'gecko1b-prod-latest'
   vm_name_prefix: 'gecko1b-vm'
   worker_count: 2
   insecure: true

--- a/inventory.d/macmini-m4.yaml
+++ b/inventory.d/macmini-m4.yaml
@@ -146,3 +146,9 @@ groups:
       - macmini-m4-173.test.releng.mdc1.mozilla.com
     facts:
       puppet_role: enterprise_3_b_osx_arm64
+
+  - name: gecko-1-b-osx-arm64-vms-host
+    targets:
+      - macmini-m4-117.test.releng.mdc1.mozilla.com
+    facts:
+      puppet_role: gecko_1_b_osx_arm64_vms_host


### PR DESCRIPTION
## Summary

- Add `macmini-m4-117` to bolt inventory as `gecko_1_b_osx_arm64_vms_host` to run 2x gecko-1b builder VMs
- Fix `oci_tag` in `gecko_1_b_osx_arm64_vms_host.yaml`: `prod-latest` → `gecko1b-prod-latest` (the actual tag used by the builder OCI registry at 10.49.56.83:5000)

## Test plan

- [x] Bolt apply succeeded on macmini-m4-117
- [x] Both gecko1b-vm-1 (mac-1eeefe) and gecko1b-vm-2 (mac-cffe05) started and registered with Taskcluster pool `releng-hardware/gecko-1-b-osx-arm64-vms`
- [x] Try push in progress targeting the pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)