### PR TITLE
RELOPS-2321 - collect all xperf profiling data then publish ETL file

### DIFF
--- a/modules/win_hw_profiling/files/xperf_kernel_stop.ps1
+++ b/modules/win_hw_profiling/files/xperf_kernel_stop.ps1
@@ -40,6 +40,7 @@ if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Path $outDir -Forc
 
 $log         = Join-Path $outDir 'xperf_kernel_stop.log'
 $combinedEtl = Join-Path $outDir 'combined.etl'
+$partialEtl  = Join-Path $outDir 'combined.etl.tmp'
 
 $xperf = Find-Xperf
 if (-not $xperf) {
@@ -50,10 +51,12 @@ if (-not $xperf) {
 WriteUserLog $log 'INFO' ("stop :: outDir={0}" -f $outDir)
 WriteUserLog $log 'INFO' ("stop :: combinedEtl={0}" -f $combinedEtl)
 
+if (Test-Path $partialEtl) { Remove-Item -Force $partialEtl }
+
 $args = @(
   '-stop', 'NT Kernel Logger',
   '-stop', 'usersession',
-  '-d',    $combinedEtl
+  '-d',    $partialEtl
 )
 
 WriteUserLog $log 'INFO' ("stop :: invoking xperf: {0} {1}" -f $xperf, ($args -join ' '))
@@ -68,5 +71,6 @@ if ($rc -ne 0) {
   exit $rc
 }
 
+Move-Item -Force $partialEtl $combinedEtl
 WriteUserLog $log 'INFO' "stop :: SUCCESS"
 exit 0


### PR DESCRIPTION
Addresses: 
https://gist.github.com/mstange/ad5e30140588f3db0d1b4b08bc33e1a2
https://bugzilla.mozilla.org/show_bug.cgi?id=2028315 (The Chrome base MSI was updated in our source location and will be picked up on this deployment). 

Related try push:
https://treeherder.mozilla.org/jobs?repo=try&author=mcornmesser%40mozilla.com&selectedTaskRun=aTQ25Yn2Sh6GShy6TgRoqw.0