### PR TITLE
devicepool hosts: place new v3 bitbar devicepool service unit

### DIFF
--- a/modules/bitbar_devicepool/manifests/devicepool.pp
+++ b/modules/bitbar_devicepool/manifests/devicepool.pp
@@ -55,4 +55,13 @@ class bitbar_devicepool::devicepool {
     ],
   }
 
+  # place systemd unit file for devicepool (v3 server)
+  file { '/etc/systemd/system/bitbar-v3.service':
+    ensure => file,
+    source => '/home/bitbar/mozilla-bitbar-devicepool/service/bitbar-v3.service',
+    notify => [
+      Class['bitbar_devicepool::systemd_reload'],
+    ],
+  }
+
 }

--- a/test/integration/bitbar/inspec/bitbar_devicepool_spec.rb
+++ b/test/integration/bitbar/inspec/bitbar_devicepool_spec.rb
@@ -25,6 +25,16 @@ describe 'service' do
     # code 3 is loaded, but not running
     its(:exit_status) { should eq 3 }
   end
+
+  # v3 server unit file
+  describe file('/etc/systemd/system/bitbar-v3.service') do
+    it { should be_file }
+  end
+
+  describe command('systemctl status bitbar-v3') do
+    # code 3 is loaded, but not running
+    its(:exit_status) { should eq 3 }
+  end
 end
 
 # 2204 doesn't have python(2)


### PR DESCRIPTION
Place the v3 bitbar devicepool systemd service unit (`bitbar-v3.service`) on devicepool hosts.

## Changes

- `modules/bitbar_devicepool/manifests/devicepool.pp`: add a `file` resource that places `/etc/systemd/system/bitbar-v3.service` from the cloned `mozilla-bitbar-devicepool` repo, notifying `bitbar_devicepool::systemd_reload`. Mirrors the existing `bitbar.service` unit placement.

## Tests

- `test/integration/bitbar/inspec/bitbar_devicepool_spec.rb`: assert the unit file is placed and that `systemctl status bitbar-v3` returns exit code 3 (loaded but not running). Mirrors the existing `bitbar.service` test. Runs in the `bitbar-ubuntu-2204` Docker kitchen suite.
