### PR TITLE
Pin taskcluster version to 96.2.3

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -57,7 +57,7 @@ windows:
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
     download_url: "https://github.com/taskcluster/taskcluster/releases/download"
-    version: "99.2.0"
+    version: "96.2.3"
     hw_version: "96.2.2"
 
     generic-worker:


### PR DESCRIPTION
## Summary
- Pin the Windows generic-worker `version` in `data/os/Windows.yaml` from `99.2.0` to `96.2.3`.

## Test plan
- [ ] CI pre-commit and r10k workflows pass
- [ ] Kitchen Windows workflow passes