### PR TITLE
RELOPS-2349: Windows 11 25H2 1.0.2 image troubleshooting

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -57,7 +57,7 @@ windows:
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
     download_url: "https://github.com/taskcluster/taskcluster/releases/download"
-    version: "99.2.0"
+    version: "96.2.3"
     hw_version: "96.2.2"
 
     generic-worker:

--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -57,7 +57,7 @@ windows:
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
     download_url: "https://github.com/taskcluster/taskcluster/releases/download"
-    version: "96.2.3"
+    version: "99.2.0"
     hw_version: "96.2.2"
 
     generic-worker:


### PR DESCRIPTION
## Summary
Working branch for [RELOPS-2349](https://mozilla-hub.atlassian.net/browse/RELOPS-2349) / [bug 2035917](https://bugzilla.mozilla.org/show_bug.cgi?id=2035917): troubleshooting permanent test failures observed on the Windows 11 25H2 1.0.2 worker image after the `generic-worker` 96.2.3 to 99.2.0 bump.

OS-side patching is being handled separately. The puppet-side change will be added here once the root cause is identified.

## Affected tests (from bug 2035917)
- GTest: `ExpirationTracker.main`
- web-platform-tests: `service-workers/service-worker/controlled-iframe-postMessage.https.html`
- web-platform-tests: `service-workers/service-worker/controller-on-reload.https.htm`
- web-platform-tests: `preload/preload-referrer-policy-subresource-header.tentative.html`
- xpcshell: `toolkit/modules/tests/xpcshell/test_DeferredTask.js`

## Test plan
- [ ] CI pre-commit and r10k workflows pass
- [ ] Kitchen Windows workflow passes
- [ ] Affected GTest, wpt, and xpcshell jobs recover on the rebuilt image