### PR TITLE
RELOPS-2353: Stabilize Ubuntu Kitchen apt bootstrap

### DIFF
--- a/.kitchen_configs/Dockerfile.ubuntu.erb
+++ b/.kitchen_configs/Dockerfile.ubuntu.erb
@@ -1,0 +1,78 @@
+<%
+require "shellwords"
+
+username = @username || "kitchen"
+homedir = username == "root" ? "/root" : "/home/#{username}"
+public_key = Shellwords.escape(File.read(@public_key).strip)
+provision_commands = Array(@provision_command)
+%>
+FROM <%= @image %>
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV container=docker
+
+<% if @disable_upstart %>
+RUN [ ! -f "/sbin/initctl" ] || dpkg-divert --local --rename --add /sbin/initctl \
+    && ln -sf /bin/true /sbin/initctl
+<% end %>
+
+RUN set -eux; \
+    rm -f /etc/apt/apt.conf.d/docker-clean; \
+    printf '%s\n' \
+      'Acquire::Retries "6";' \
+      'Acquire::http::Pipeline-Depth "0";' \
+      'Acquire::http::No-Cache "true";' \
+      'Acquire::http::Timeout "30";' \
+      > /etc/apt/apt.conf.d/80-retries; \
+    apt_sources="$(mktemp -d)"; \
+    cp -a /etc/apt/sources.list "${apt_sources}/sources.list" 2>/dev/null || true; \
+    cp -a /etc/apt/sources.list.d "${apt_sources}/sources.list.d" 2>/dev/null || true; \
+    mirrors="http://azure.archive.ubuntu.com/ubuntu/ http://archive.ubuntu.com/ubuntu/ http://us.archive.ubuntu.com/ubuntu/"; \
+    if /usr/lib/apt/apt-helper download-file http://mirrors.ubuntu.com/mirrors.txt /tmp/ubuntu-mirrors.txt; then \
+      mirrors="${mirrors} $(grep -vE '^[[:space:]]*$' /tmp/ubuntu-mirrors.txt | tr '\n' ' ')"; \
+    fi; \
+    installed=0; \
+    for mirror in ${mirrors}; do \
+      mirror="${mirror%/}"; \
+      if [ -f "${apt_sources}/sources.list" ]; then cp "${apt_sources}/sources.list" /etc/apt/sources.list; fi; \
+      rm -rf /etc/apt/sources.list.d; \
+      if [ -d "${apt_sources}/sources.list.d" ]; then cp -a "${apt_sources}/sources.list.d" /etc/apt/sources.list.d; else mkdir -p /etc/apt/sources.list.d; fi; \
+      find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i \
+        -e "s|http://archive.ubuntu.com/ubuntu/|${mirror}/|g" \
+        -e "s|http://archive.ubuntu.com/ubuntu|${mirror}|g" \
+        -e "s|http://security.ubuntu.com/ubuntu/|${mirror}/|g" \
+        -e "s|http://security.ubuntu.com/ubuntu|${mirror}|g" \
+        -e "s|http://us.archive.ubuntu.com/ubuntu/|${mirror}/|g" \
+        -e "s|http://us.archive.ubuntu.com/ubuntu|${mirror}|g" \
+        {} +; \
+      rm -rf /var/lib/apt/lists/*; \
+      if apt-get -o Acquire::Retries=6 update -y \
+          && apt-get -o Acquire::Retries=6 install -y sudo openssh-server curl ca-certificates lsb-release dbus systemd; then \
+        installed=1; \
+        break; \
+      fi; \
+      echo "APT bootstrap failed using ${mirror}; trying the next Ubuntu mirror" >&2; \
+    done; \
+    [ "${installed}" = "1" ]; \
+    rm -rf /var/lib/apt/lists/* /tmp/ubuntu-mirrors.txt "${apt_sources}"
+
+RUN if ! getent passwd <%= username %>; then \
+      useradd -d <%= homedir %> -m -s /bin/bash -p '*' <%= username %>; \
+    fi
+RUN mkdir -p /etc/sudoers.d
+RUN chmod 0750 /etc/sudoers.d
+RUN echo "<%= username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/<%= username %>
+RUN echo "Defaults !requiretty" >> /etc/sudoers.d/<%= username %>
+RUN mkdir -p <%= homedir %>/.ssh
+RUN chown -R <%= username %> <%= homedir %>/.ssh
+RUN chmod 0700 <%= homedir %>/.ssh
+RUN touch <%= homedir %>/.ssh/authorized_keys
+RUN chown <%= username %> <%= homedir %>/.ssh/authorized_keys
+RUN chmod 0600 <%= homedir %>/.ssh/authorized_keys
+RUN mkdir -p /run/sshd
+
+<% provision_commands.each do |cmd| %>
+RUN <%= cmd %>
+<% end %>
+
+RUN echo <%= public_key %> >> <%= homedir %>/.ssh/authorized_keys

--- a/.kitchen_configs/kitchen.docker.yml
+++ b/.kitchen_configs/kitchen.docker.yml
@@ -13,21 +13,11 @@ driver:
   #
   # on m1 macs, nothing even starts on amd64 now...
   # docker_platform: linux/arm64
+  dockerfile: .kitchen_configs/Dockerfile.ubuntu.erb
   run_command: /bin/systemd
   cap_add:
     - SYS_ADMIN
   mount: type=bind,source=/tmp/docker/var/cache/apt,destination=/var/cache/apt
-  provision_command:
-    - rm -f /etc/apt/apt.conf.d/docker-clean
-    # apt: retries/timeouts (single-line, sh-safe)
-    - sh -c 'printf "%s\n" "Acquire::Retries \"6\";" "Acquire::http::Pipeline-Depth \"0\";" "Acquire::http::No-Cache \"true\";" "Acquire::http::Timeout \"30\";" > /etc/apt/apt.conf.d/80-retries'
-    # Fetch mirrors, exclude archive.ubuntu.com, pick first one, and update sources.list
-    - sh -c 'MIRROR=$(curl -fsSL http://mirrors.ubuntu.com/mirrors.txt | grep -vE "(archive\.ubuntu\.com|us\.archive\.ubuntu\.com)" | head -n1); MIRROR=${MIRROR:-http://mirror.math.princeton.edu/pub/ubuntu/}; MIRROR=${MIRROR%/}; sed -i "s|http://archive.ubuntu.com/ubuntu|${MIRROR}|g" /etc/apt/sources.list'
-    # clean lists, then update with retries
-    - rm -rf /var/lib/apt/lists/*
-    - apt-get -o Acquire::Retries=6 update -y
-    # your original intent, but calmer for CI
-    - DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=6 install -y --no-install-recommends dbus
 
 provisioner:
   name: puppet_apply


### PR DESCRIPTION
## Summary
- replace kitchen-docker's autogenerated Ubuntu bootstrap Dockerfile with a repo-owned ERB template
- configure apt retries/timeouts before the first apt update and install bootstrap packages in the same layer
- prefer `azure.archive.ubuntu.com` on GitHub-hosted runners, rewrite archive/security sources together, and fall back through the Ubuntu mirror list
- install Kitchen's expected bootstrap/runtime packages, including `systemd` and `ca-certificates`, before `run_command: /bin/systemd`
- keep bootstrap apt package behavior aligned with kitchen-docker's default `apt-get install -y` behavior so recommended runtime packages like `systemd-timesyncd` are present on noble
- remove the later `provision_command` apt bootstrap that ran too late to fix Kitchen create failures

## Jira
- https://mozilla-hub.atlassian.net/browse/RELOPS-2353

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".kitchen_configs/kitchen.docker.yml")'`
- `git diff --check`
- rendered `.kitchen_configs/Dockerfile.ubuntu.erb` with kitchen-docker's default `ERB.new` mode
- Docker builds from the rendered template passed for `ubuntu:18.04`, `ubuntu:22.04`, and `ubuntu:24.04` on `linux/amd64`
- verified the rendered test images contain `/bin/systemd`, `/usr/sbin/sshd`, `/usr/bin/curl`, `/etc/ssl/certs/ca-certificates.crt`, and the expected distro codename for bionic, jammy, and noble
- verified `curl -fsSL` can fetch the configured `puppet_omnibus_url` from each rendered test image
- verified the rendered noble image includes `systemd-timesyncd`; local `systemctl start systemd-timesyncd` returns success under `/bin/systemd`
- GitHub Linux checks passed on commit `1842545f` in run https://github.com/mozilla-platform-ops/ronin_puppet/actions/runs/25340982416
