### PR TITLE
RELOPS-2317 - bump taskcluster cloud worker version to 99.2.0

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -57,7 +57,7 @@ windows:
     relops_az: "https://roninpuppetassets.blob.core.windows.net/binaries/taskcluster"
     relops_s3: "https://s3-us-west-2.amazonaws.com/ronin-puppet-package-repo/Windows/taskcluster"
     download_url: "https://github.com/taskcluster/taskcluster/releases/download"
-    version: "96.2.3"
+    version: "99.2.0"
     hw_version: "96.2.2"
 
     generic-worker:


### PR DESCRIPTION
## Summary
- Bump cloud `taskcluster.version` in `data/os/Windows.yaml` from `96.2.3` to `99.2.0` for Generic Worker deployment to win11-64-24h2 tester pools.
- `hw_version` left unchanged.

Ref: [RELOPS-2317](https://mozilla-hub.atlassian.net/browse/RELOPS-2317)

## Test plan
- [ ] Pre-commit hooks pass
- [ ] Validate on alpha pool (win11-64-24h2-alpha) before promoting to prod tester pools