### PR TITLE
Install pyyaml on macOS M4 test workers

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4.yaml
+++ b/data/roles/gecko_t_osx_1500_m4.yaml
@@ -26,6 +26,7 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_pyobjc
+  - python3_yaml
   - python3_zstandard
   - safari_preview
   - scres

--- a/data/roles/gecko_t_osx_1500_m4_ipv6.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_ipv6.yaml
@@ -25,6 +25,7 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_pyobjc
+  - python3_yaml
   - python3_zstandard
   - safari_preview
   - scres

--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -26,6 +26,7 @@ packages_classes:
   - python3
   - python3_psutil
   - python3_pyobjc
+  - python3_yaml
   - python3_zstandard
   - safari_preview
   - scres

--- a/modules/packages/manifests/python3_yaml.pp
+++ b/modules/packages/manifests/python3_yaml.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::python3_yaml (
+  String $version = '6.0.2',
+) {
+  require packages::python3
+
+  exec { 'install_pyyaml':
+    command => "/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3 install pyyaml==${version}",
+    unless  => "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3 -c 'import yaml; print(yaml.__version__)' | grep -q ${version}",
+    path    => ['/Library/Frameworks/Python.framework/Versions/3.11/bin', '/usr/local/bin', '/usr/bin'],
+    timeout => 300,
+    require => Class['packages::python3'],
+  }
+}


### PR DESCRIPTION
## Summary

Adds `packages::python3_yaml` and includes it in the `packages_classes` for the three macOS M4 role variants (`gecko_t_osx_1500_m4`, `_staging`, `_ipv6`) so that `pyyaml` is available in the Python 3.11 framework env that mozharness invokes.

Fixes #1203.

## Why

mochitest `test-verify` on `gecko-t-osx-1500-m4` fails in the mozharness setup phase with:

```
File "/opt/worker/tasks/cltbld/mozharness/mozinfo/platforminfo.py", line 11
    import yaml
ModuleNotFoundError: No module named 'yaml'
FATAL - Aborting due to failure in post-action listener.
```

The yaml import is reached via `manifestparser/toml.py` during `find_tests_for_verification`. test-verify-wpt and other mochitest variants don't traverse this path, so they pass. Without this fix, `test-verify` (and likely `test-verify-gpu`) cannot run on M4, blocking their migration from `macosx1470-64-tests` to `macosx1500-aarch64-tests` (Bug 2034604).

Try push validating that test-verify-wpt is fine (and showing the test-verify failure on the same workers): https://treeherder.mozilla.org/jobs?repo=try&revision=787df10bbfeac1457f564a4898ec07a3563873d9

## Implementation

- `modules/packages/manifests/python3_yaml.pp` — new class, modeled on existing `packages::python3_pyobjc`. Uses the explicit `/Library/Frameworks/Python.framework/Versions/3.11/bin/pip3` path (matching the Python version the M4 roles pin via `packages::python3::version: 3.11.0`). Idempotent via `unless` clause that checks the installed yaml version.
- Adds `python3_yaml` to `packages_classes` in:
  - `data/roles/gecko_t_osx_1500_m4.yaml`
  - `data/roles/gecko_t_osx_1500_m4_staging.yaml`
  - `data/roles/gecko_t_osx_1500_m4_ipv6.yaml`

Not adding to the r8 (Intel) roles in this PR since test-verify already works there — left as-is to minimize scope. Worth a follow-up audit if the convention is to keep python package lists symmetric.

## Verification plan

After Puppet picks this up, schedule a try push that touches a mochitest manifest and confirm test-verify on macosx1500-aarch64 reaches actual test execution rather than failing in setup. Once confirmed, follow-up patch in the firefox repo will move `test-verify` (and `test-verify-gpu`) into `macosx1500-aarch64-tests`.