### PR TITLE
inventory: add macmini-m4-130 through 149 to gecko-t-osx-1500-m4

### DIFF
--- a/inventory.d/macmini-m4.yaml
+++ b/inventory.d/macmini-m4.yaml
@@ -64,6 +64,26 @@ groups:
       - macmini-m4-108.test.releng.mdc1.mozilla.com
       - macmini-m4-109.test.releng.mdc1.mozilla.com
       - macmini-m4-110.test.releng.mdc1.mozilla.com
+      - macmini-m4-130.test.releng.mdc1.mozilla.com
+      - macmini-m4-131.test.releng.mdc1.mozilla.com
+      - macmini-m4-132.test.releng.mdc1.mozilla.com
+      - macmini-m4-133.test.releng.mdc1.mozilla.com
+      - macmini-m4-134.test.releng.mdc1.mozilla.com
+      - macmini-m4-135.test.releng.mdc1.mozilla.com
+      - macmini-m4-136.test.releng.mdc1.mozilla.com
+      - macmini-m4-137.test.releng.mdc1.mozilla.com
+      - macmini-m4-138.test.releng.mdc1.mozilla.com
+      - macmini-m4-139.test.releng.mdc1.mozilla.com
+      - macmini-m4-140.test.releng.mdc1.mozilla.com
+      - macmini-m4-141.test.releng.mdc1.mozilla.com
+      - macmini-m4-142.test.releng.mdc1.mozilla.com
+      - macmini-m4-143.test.releng.mdc1.mozilla.com
+      - macmini-m4-144.test.releng.mdc1.mozilla.com
+      - macmini-m4-145.test.releng.mdc1.mozilla.com
+      - macmini-m4-146.test.releng.mdc1.mozilla.com
+      - macmini-m4-147.test.releng.mdc1.mozilla.com
+      - macmini-m4-148.test.releng.mdc1.mozilla.com
+      - macmini-m4-149.test.releng.mdc1.mozilla.com
       - macmini-m4-150.test.releng.mdc1.mozilla.com
       - macmini-m4-151.test.releng.mdc1.mozilla.com
       - macmini-m4-152.test.releng.mdc1.mozilla.com


### PR DESCRIPTION
## Summary
- Adds 20 freshly-provisioned M4 mac minis (`macmini-m4-130` through `macmini-m4-149`) to the `gecko-t-osx-1500-m4` Bolt inventory group.
- These hosts were bootstrapped today onto the `gecko_t_osx_1500_m4` role (vault.yaml, puppet_role, initial puppet apply, run-buildbot semaphore).
- A subset are currently re-running puppet post a SimpleMDM-driven 15.3 upgrade; that's orthogonal to the inventory entry.

## Test plan
- [ ] `bundle exec bolt inventory show --inventoryfile inventory.yaml --targets gecko-t-osx-1500-m4` lists the new hosts
- [ ] Confirm each host responds to a Bolt no-op (e.g. `bolt command run 'uptime' -t <new host>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)