### PR TITLE
safaridriver: only write has-run semaphore on actual success

### DIFF
--- a/modules/macos_safaridriver/files/safari-enable-remote-automation.sh
+++ b/modules/macos_safaridriver/files/safari-enable-remote-automation.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -uo pipefail
 
 # Ensure the logged-in user is 'cltbld'
 current_user=$(id -u -n)
@@ -7,7 +8,12 @@ if [ "$current_user" != "cltbld" ]; then
   exit 1
 fi
 
-# Function to enable remote automation for Safari
+# Track per-app failures so puppet's `unless => test -f <semaphore>` can keep retrying
+# on subsequent runs until the work actually succeeds.
+overall_rc=0
+
+# Function to enable remote automation for Safari.
+# Returns 0 on success (semaphore written), non-zero on failure (semaphore NOT written).
 enable_remote_automation() {
   local semaphore_file="$1"
   local semaphore_version="1"
@@ -15,49 +21,52 @@ enable_remote_automation() {
   local develop_menu_text="$3"
   local allow_remote_automation_text="$4"
 
-  mkdir -p "$(dirname "$semaphore_file")"
-  touch "$semaphore_file"
-
-  if [[ "$(cat "$semaphore_file")" == "$semaphore_version" ]]; then
-    echo "$0: file indicates this version of the script has already run. exiting..."
-    exit 0
-  else
-    echo "$0: running..."
+  if [[ -f "$semaphore_file" ]] && [[ "$(cat "$semaphore_file")" == "$semaphore_version" ]]; then
+    echo "$0: $semaphore_file indicates ${safari_app} has already been configured. skipping..."
+    return 0
   fi
 
-  if csrutil status | grep -q 'disabled'; then
-    osascript -e "
-      tell application \"System Events\"
-        tell application \"$safari_app\" to activate
-        delay 15
-        tell process \"$safari_app\"
-          set frontmost to true
+  echo "$0: configuring ${safari_app}..."
+
+  if ! csrutil status | grep -q 'disabled'; then
+    echo "Unable to add permissions for ${safari_app}: System Integrity Protection is enabled."
+    return 1
+  fi
+
+  if ! osascript -e "
+    tell application \"System Events\"
+      tell application \"$safari_app\" to activate
+      delay 15
+      tell process \"$safari_app\"
+        set frontmost to true
+        delay 5
+        click menu item \"Settings…\" of menu 1 of menu bar item \"$safari_app\" of menu bar 1
+        delay 5
+        click button \"Advanced\" of toolbar 1 of window 1
+        delay 5
+        tell checkbox \"Show features for web developers\" of group 1 of group 1 of window 1
+          if value is 0 then click it
           delay 5
-          click menu item \"Settings…\" of menu 1 of menu bar item \"$safari_app\" of menu bar 1
+        end tell
+        delay 5
+        click button \"$develop_menu_text\" of toolbar 1 of window 1
+        delay 5
+        tell checkbox \"$allow_remote_automation_text\" of group 1 of group 1 of window 1
+          if value is 0 then click it
           delay 5
-          click button \"Advanced\" of toolbar 1 of window 1
-          delay 5
-          tell checkbox \"Show features for web developers\" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-          end tell
-          delay 5
-          click button \"$develop_menu_text\" of toolbar 1 of window 1
-          delay 5
-          tell checkbox \"$allow_remote_automation_text\" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-          end tell
         end tell
       end tell
+    end tell
 
-      tell application \"$safari_app\" to quit"
-  else
-    echo "Unable to add permissions! System Integrity Protection is enabled."
-    exit 1
+    tell application \"$safari_app\" to quit"; then
+    echo "osascript failed for ${safari_app}; semaphore not written, will retry on next puppet run."
+    return 1
   fi
 
+  # Only write the semaphore on confirmed success so puppet's `unless => test -f` retries on failure.
+  mkdir -p "$(dirname "$semaphore_file")"
   echo "$semaphore_version" > "$semaphore_file"
+  echo "$0: ${safari_app} configured; semaphore at $semaphore_file"
 }
 
 # Function to get the macOS version
@@ -73,7 +82,7 @@ case "$macos_major_version" in
   "10")
     if [ "$macos_minor_version" -eq 15 ]; then
       semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
-      enable_remote_automation "$semaphore_file" "Safari" "Develop" "Allow Remote Automation"
+      enable_remote_automation "$semaphore_file" "Safari" "Develop" "Allow Remote Automation" || overall_rc=$?
     else
       echo "Unsupported macOS version: $macos_full_version"
       exit 1
@@ -81,11 +90,11 @@ case "$macos_major_version" in
     ;;
   "11"|"12")
     semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
-    enable_remote_automation "$semaphore_file" "Safari" "Develop" "Allow Remote Automation"
+    enable_remote_automation "$semaphore_file" "Safari" "Develop" "Allow Remote Automation" || overall_rc=$?
     ;;
   "13")
     semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
-    enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation"
+    enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation" || overall_rc=$?
     ;;
   "14")
     safari_version=$(/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" /Applications/Safari.app/Contents/Info.plist)
@@ -93,23 +102,23 @@ case "$macos_major_version" in
 
     if [ "$safari_major_version" == "16" ] || [ "$safari_major_version" == "17" ] || [ "$safari_major_version" == "18" ]; then
       semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
-      enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation"
+      enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation" || overall_rc=$?
     fi
 
     if [ -d "/Applications/Safari Technology Preview.app" ]; then
       semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-tech-preview-enable-remote-automation-has-run"
-      enable_remote_automation "$semaphore_file" "Safari Technology Preview" "Developer" "Allow remote automation"
+      enable_remote_automation "$semaphore_file" "Safari Technology Preview" "Developer" "Allow remote automation" || overall_rc=$?
     else
       echo "Safari Technology Preview is not installed."
     fi
     ;;
   "15")
     semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
-    enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation"
+    enable_remote_automation "$semaphore_file" "Safari" "Developer" "Allow remote automation" || overall_rc=$?
 
     if [ -d "/Applications/Safari Technology Preview.app" ]; then
       semaphore_file="/Users/$current_user/Library/Preferences/semaphore/safari-tech-preview-enable-remote-automation-has-run"
-      enable_remote_automation "$semaphore_file" "Safari Technology Preview" "Developer" "Allow remote automation"
+      enable_remote_automation "$semaphore_file" "Safari Technology Preview" "Developer" "Allow remote automation" || overall_rc=$?
     else
       echo "Safari Technology Preview is not installed."
     fi
@@ -119,3 +128,5 @@ case "$macos_major_version" in
     exit 1
     ;;
 esac
+
+exit "$overall_rc"


### PR DESCRIPTION
## Summary

Fixes #1207.

The script `modules/macos_safaridriver/files/safari-enable-remote-automation.sh` currently writes the `safari-(tech-preview-)enable-remote-automation-has-run` semaphore unconditionally, even when the underlying osascript "click the checkbox" sequence failed (most commonly because cltbld's TCC.db doesn't exist yet on first bootstrap). Puppet's `unless => /bin/test -f <semaphore>` then sees the file on the next apply and skips the resource — the worker is permanently broken with no retry path.

This PR:

- Removes the pre-emptive `touch` of the semaphore file at script startup
- Refactors `enable_remote_automation` to return non-zero on failure
- Only writes the semaphore on confirmed osascript success
- Aggregates per-app return codes so the script exits non-zero if Safari and/or Safari Tech Preview failed (puppet will surface this as a visible error)

With this change, puppet's existing `unless` guard does the right thing: the semaphore is created only when configuration actually succeeded, so a failed run is retried on the next puppet apply.

## Test plan

- [ ] Manually run on a fresh worker where cltbld TCC.db hasn't been created yet — confirm semaphore is NOT written, script exits non-zero
- [ ] Manually run on a fresh worker after cltbld has auto-logged in — confirm semaphore IS written, script exits 0
- [ ] Re-run puppet after a successful semaphore write — confirm the exec is skipped via `unless`
- [ ] On a 15.x host with both Safari and STP installed, simulate a partial failure (e.g. quit one of the apps mid-osascript) and confirm only the failing app's semaphore is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)