### PR TITLE
tcc: gate cltbld-TCC.db-dependent resources on a custom fact

### DIFF
--- a/modules/macos_run_puppet/files/run-puppet.sh
+++ b/modules/macos_run_puppet/files/run-puppet.sh
@@ -142,12 +142,6 @@ run_puppet() {
     retval=$?
     PUPPET_RUN_DURATION=$SECONDS
 
-    if grep -q "unable to open database \"/Users/cltbld/Library/Application Support/com.apple.TCC/TCC.db" "$TMP_LOG"; then
-        echo "Detected TCC.db issue. A reboot is required."
-        sudo shutdown -r now
-        exit 0
-    fi
-
     if grep -q "^Error:" "$TMP_LOG"; then
         retval=1
     fi
@@ -284,5 +278,16 @@ done
 # Clean Up & Finish
 rm -rf "$TMP_PUPPET_DIR"
 echo "System Installed: $(date)" >> /etc/issue
+
+# If cltbld's user TCC.db doesn't exist yet, autologin hasn't fired. The
+# cltbld_tcc_db_present fact gated off TCC-writing resources in this apply
+# pass, so they haven't run. Reboot so cltbld autologs in and the next
+# puppet apply (via either the bootstrap LaunchDaemon or the regular
+# at-boot LaunchDaemon, see #1206) picks them up.
+if [ ! -f "/Users/cltbld/Library/Application Support/com.apple.TCC/TCC.db" ]; then
+    echo "cltbld TCC.db not present after successful puppet apply; rebooting so autologin can fire and TCC resources can apply on the next pass."
+    sudo shutdown -r now
+    exit 0
+fi
 
 exit 0

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -31,8 +31,10 @@ class macos_safaridriver (
             mode    => '0755',
           }
 
-          # TCC.db doesn't exist yet in ci, so skip running the script
-          if $facts['running_in_test_kitchen'] != 'true' {
+          # cltbld's user TCC.db only exists after cltbld first logs in.
+          # Skip these resources on first bootstrap; the next puppet apply
+          # (post-cltbld-autologin reboot) will pick them up.
+          if $facts['running_in_test_kitchen'] != 'true' and $facts['cltbld_tcc_db_present'] {
             exec { 'execute perms script':
               command     => $perm_script,
               subscribe   => File[$perm_script],
@@ -43,7 +45,7 @@ class macos_safaridriver (
           }
 
           # needs to be logged in as the user, doesn't work in CI (haven't rebooted yet)
-          if $facts['running_in_test_kitchen'] != 'true' {
+          if $facts['running_in_test_kitchen'] != 'true' and $facts['cltbld_tcc_db_present'] {
             # needs to run as cltbld via launchctl or won't work
             exec { 'execute enable remote automation script':
               command => "/bin/launchctl asuser ${user_uid} sudo -u ${user_running_safari} ${enable_script}",

--- a/modules/macos_tcc_perms/lib/facter/cltbld_tcc_db_present.rb
+++ b/modules/macos_tcc_perms/lib/facter/cltbld_tcc_db_present.rb
@@ -1,0 +1,16 @@
+# Custom fact: cltbld_tcc_db_present
+#
+# True when /Users/cltbld/Library/Application Support/com.apple.TCC/TCC.db
+# exists. The user TCC.db is only created after cltbld has logged in via a
+# console session, so on a freshly-bootstrapped worker (autologin set up by
+# puppet but cltbld hasn't actually logged in yet) the file is absent.
+#
+# Used by macos_tcc_perms and macos_safaridriver to gate resources that
+# write to cltbld's TCC.db, replacing the older log-grep reboot trigger
+# in run-puppet.sh that relied on Apple's error string remaining stable.
+Facter.add('cltbld_tcc_db_present') do
+  confine kernel: 'Darwin'
+  setcode do
+    File.exist?('/Users/cltbld/Library/Application Support/com.apple.TCC/TCC.db')
+  end
+end

--- a/modules/macos_tcc_perms/manifests/init.pp
+++ b/modules/macos_tcc_perms/manifests/init.pp
@@ -14,8 +14,11 @@ class macos_tcc_perms (
           mode    => '0755',
         }
 
-        # in CI, this tcc.db file doesn't exist yet, so skip running the script
-        if $facts['running_in_test_kitchen'] != 'true' {
+        # cltbld's user TCC.db only exists after cltbld first logs in.
+        # On fresh bootstrap (autologin set up but cltbld hasn't logged in
+        # yet) we skip this resource — a reboot triggers autologin and the
+        # next puppet apply will pick it up.
+        if $facts['running_in_test_kitchen'] != 'true' and $facts['cltbld_tcc_db_present'] {
           exec { 'execute tcc perms script':
             command => $tcc_script,
             require => File[$tcc_script],


### PR DESCRIPTION
## Summary

Fixes #1208.

Replaces the log-grep reboot trigger in `run-puppet.sh` with a proactive fact-based gate.

The bootstrap script currently does this:

\`\`\`bash
if grep -q "unable to open database \\"/Users/cltbld/.../TCC.db" "\$TMP_LOG"; then
    echo "Detected TCC.db issue. A reboot is required."
    sudo shutdown -r now
    exit 0
fi
\`\`\`

That string is Apple-controlled (we'd silently lose the trigger if Apple rewords or localizes it), reboots mid-apply (so downstream resources never run in this pass), and can't distinguish "cltbld TCC.db not ready yet" from "cltbld TCC.db permanently broken" — same string, very different remediation.

## Changes

- **New custom fact** \`cltbld_tcc_db_present\` in \`modules/macos_tcc_perms/lib/facter/\`. Boolean — true iff \`/Users/cltbld/Library/Application Support/com.apple.TCC/TCC.db\` exists.
- **\`macos_tcc_perms\`**: gates the \`execute tcc perms script\` exec on \`\$facts['cltbld_tcc_db_present']\`.
- **\`macos_safaridriver\`**: gates \`execute perms script\` and \`execute enable remote automation script\` on the same fact (both write to or depend on cltbld's TCC.db).
- **\`run-puppet.sh\`**: removes the log-grep block. Adds a post-success check — if cltbld TCC.db is still missing after a clean apply, the script reboots once so autologin can fire; the next apply (via bootstrap LaunchDaemon #1206 or the regular at-boot mechanism) will see the fact flip to true and apply the resources cleanly.

## Behavior on a fresh host

1. First apply: autologin set up, TCC resources skipped (no errors)
2. Post-success check sees TCC.db absent → reboot
3. cltbld autologs in → TCC.db materializes
4. Next apply: TCC resources actually run

## Test plan

- [ ] Fresh M4 host (cltbld absent at start of apply): puppet apply completes without errors, post-success check triggers reboot, second apply applies TCC perms
- [ ] Already-bootstrapped host (cltbld TCC.db present): TCC resources apply normally, no reboot
- [ ] Kitchen mac suite: \`running_in_test_kitchen\` guard still keeps TCC resources from firing
- [ ] Confirm \`facter -p cltbld_tcc_db_present\` returns the correct boolean on a managed host
- [ ] Linux suites unaffected (fact is confined to Darwin)

## Related

Pairs naturally with #1206 (reboot-survivable bootstrap LaunchDaemon) — together they eliminate the babysitter ssh pattern entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)