### PR TITLE
ci: drop ubuntu -backports from kitchen docker sources

### DIFF
--- a/.kitchen_configs/kitchen.docker.yml
+++ b/.kitchen_configs/kitchen.docker.yml
@@ -23,6 +23,8 @@ driver:
     - sh -c 'printf "%s\n" "Acquire::Retries \"6\";" "Acquire::http::Pipeline-Depth \"0\";" "Acquire::http::No-Cache \"true\";" "Acquire::http::Timeout \"30\";" > /etc/apt/apt.conf.d/80-retries'
     # Fetch mirrors, exclude archive.ubuntu.com, pick first one, and update sources.list
     - sh -c 'MIRROR=$(curl -fsSL http://mirrors.ubuntu.com/mirrors.txt | grep -vE "(archive\.ubuntu\.com|us\.archive\.ubuntu\.com)" | head -n1); MIRROR=${MIRROR:-http://mirror.math.princeton.edu/pub/ubuntu/}; MIRROR=${MIRROR%/}; sed -i "s|http://archive.ubuntu.com/ubuntu|${MIRROR}|g" /etc/apt/sources.list'
+    # Drop -backports — frequently mid-sync on community mirrors and unused by our install
+    - sed -i '/-backports/d' /etc/apt/sources.list
     # clean lists, then update with retries
     - rm -rf /var/lib/apt/lists/*
     - apt-get -o Acquire::Retries=6 update -y


### PR DESCRIPTION
## Summary
- Strip `-backports` lines from `/etc/apt/sources.list` in the kitchen Docker bootstrap before `apt-get update`.
- Community Ubuntu mirrors frequently serve mid-sync metadata for `jammy-backports/universe`; `apt-get update` aborts on hash mismatch without retrying, killing the build through no fault of the PR.
- Nothing the kitchen bootstrap installs (`dbus`) needs backports.

## Test plan
- [ ] `kitchen-linux` workflow passes on this PR
- [ ] Re-run the workflow 2–3 times to confirm the previously-flaky bitbar-ubuntu-2204 suite stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)