### PR TITLE
Expose generic-worker status + pool ID to marlin via snmpd extend (Linux + Mac)

### DIFF
--- a/modules/linux_snmpd/files/snmp_check_gw.sh
+++ b/modules/linux_snmpd/files/snmp_check_gw.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Reports generic-worker process status for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend gw_status /usr/local/bin/snmp_check_gw.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."gw_status"
+if pgrep -f '/generic-worker' >/dev/null 2>&1; then
+  echo "OK - generic-worker running"
+  exit 0
+fi
+echo "CRIT - generic-worker not running"
+exit 2

--- a/modules/linux_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/linux_snmpd/files/snmp_worker_pool_id.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
+# Output is parsed by marlin's linux_worker_pool_id_check.sh and written to InfluxDB
+# as a host_pool record (the same downstream consumer as the Windows pool ID check).
+CONFIG=/etc/generic-worker.config
+if [ ! -f "$CONFIG" ]; then
+  echo "UNKNOWN - $CONFIG not found"
+  exit 3
+fi
+POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
+if [ -z "$POOL" ]; then
+  echo "UNKNOWN - workerType not set in $CONFIG"
+  exit 3
+fi
+echo "OK - worker_pool_id=$POOL"
+exit 0

--- a/modules/linux_snmpd/manifests/init.pp
+++ b/modules/linux_snmpd/manifests/init.pp
@@ -37,6 +37,16 @@ class linux_snmpd {
                   content => template('linux_snmpd/snmpd.conf.erb'),
                   mode    => '0644',
                   notify  => Service['snmpd'];
+
+                '/usr/local/bin/snmp_check_gw.sh':
+                  ensure => file,
+                  source => "puppet:///modules/${module_name}/snmp_check_gw.sh",
+                  mode   => '0755';
+
+                '/usr/local/bin/snmp_worker_pool_id.sh':
+                  ensure => file,
+                  source => "puppet:///modules/${module_name}/snmp_worker_pool_id.sh",
+                  mode   => '0755';
               }
             }
             else {

--- a/modules/macos_snmpd/files/snmp_check_gw.sh
+++ b/modules/macos_snmpd/files/snmp_check_gw.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Reports generic-worker process status for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend gw_status /usr/local/bin/snmp_check_gw.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."gw_status"
+if pgrep -f '/generic-worker' >/dev/null 2>&1; then
+  echo "OK - generic-worker running"
+  exit 0
+fi
+echo "CRIT - generic-worker not running"
+exit 2

--- a/modules/macos_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/macos_snmpd/files/snmp_worker_pool_id.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
+# Output is parsed by marlin's mac_worker_pool_id_check.sh and written to InfluxDB
+# as a host_pool record (the same downstream consumer as the Linux/Windows pool ID checks).
+CONFIG=/etc/generic-worker.config
+if [ ! -f "$CONFIG" ]; then
+  echo "UNKNOWN - $CONFIG not found"
+  exit 3
+fi
+POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
+if [ -z "$POOL" ]; then
+  echo "UNKNOWN - workerType not set in $CONFIG"
+  exit 3
+fi
+echo "OK - worker_pool_id=$POOL"
+exit 0

--- a/modules/macos_snmpd/manifests/init.pp
+++ b/modules/macos_snmpd/manifests/init.pp
@@ -1,0 +1,80 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# macos_snmpd configures net-snmp on macOS workers so marlin can poll them
+# the same way it polls Linux workers (snmpd extend OIDs for gw_status and
+# worker_pool_id, plus the standard MIBs that the linux SNMP services use).
+#
+# NOTE on net-snmp installation:
+#   Modern macOS (>=11) does NOT ship snmpd. macOS 10.15 (Catalina) and older
+#   include /usr/sbin/snmpd. Installing net-snmp on newer macOS is OUT OF SCOPE
+#   for this module — operators must install snmpd via their preferred channel
+#   (pkg, image bake, etc.) and pass the resulting binary path via $snmpd_path.
+#   If snmpd isn't installed at $snmpd_path, the LaunchDaemon will fail to load
+#   and the host won't be SNMP-pollable; marlin will report it as Not Available.
+#
+# Hiera-driven on/off (same shape as linux_snmpd):
+#   snmpd::enabled: false
+class macos_snmpd (
+  String $snmpd_path = '/usr/sbin/snmpd',
+) {
+  $enabled = lookup('snmpd.enabled', { default_value => true })
+
+  if $enabled {
+    $snmpd_ro_secret = lookup('snmpd.ro_community', { default_value => undef })
+
+    if $snmpd_ro_secret and $snmpd_ro_secret != '' {
+      file {
+        default:
+          owner => 'root',
+          group => 'wheel';
+
+        '/etc/snmp':
+          ensure => directory,
+          mode   => '0755';
+
+        '/etc/snmp/snmpd.conf':
+          ensure  => file,
+          content => epp("${module_name}/snmpd.conf.epp", {
+            'snmpd_ro_secret' => $snmpd_ro_secret,
+          }),
+          mode    => '0644',
+          notify  => Service['net.net-snmp.snmpd'];
+
+        '/usr/local/bin/snmp_check_gw.sh':
+          ensure => file,
+          source => "puppet:///modules/${module_name}/snmp_check_gw.sh",
+          mode   => '0755';
+
+        '/usr/local/bin/snmp_worker_pool_id.sh':
+          ensure => file,
+          source => "puppet:///modules/${module_name}/snmp_worker_pool_id.sh",
+          mode   => '0755';
+
+        '/Library/LaunchDaemons/net.net-snmp.snmpd.plist':
+          ensure  => file,
+          content => epp("${module_name}/launchdaemon.plist.epp", {
+            'snmpd_path' => $snmpd_path,
+          }),
+          mode    => '0644',
+          notify  => Service['net.net-snmp.snmpd'];
+      }
+
+      service { 'net.net-snmp.snmpd':
+        ensure  => running,
+        enable  => true,
+        require => File['/Library/LaunchDaemons/net.net-snmp.snmpd.plist'],
+      }
+    }
+    else {
+      notice('snmpd.ro_community is not set, skipping macos_snmpd configuration')
+    }
+  }
+  else {
+    service { 'net.net-snmp.snmpd':
+      ensure => stopped,
+      enable => false,
+    }
+  }
+}

--- a/modules/macos_snmpd/templates/launchdaemon.plist.epp
+++ b/modules/macos_snmpd/templates/launchdaemon.plist.epp
@@ -1,0 +1,25 @@
+<%- | String $snmpd_path | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.net-snmp.snmpd</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $snmpd_path %></string>
+        <string>-f</string>
+        <string>-Lo</string>
+        <string>-c</string>
+        <string>/etc/snmp/snmpd.conf</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/snmpd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/snmpd.log</string>
+</dict>
+</plist>

--- a/modules/macos_snmpd/templates/snmpd.conf.epp
+++ b/modules/macos_snmpd/templates/snmpd.conf.epp
@@ -1,5 +1,6 @@
-# mozilla relops snmpd.conf template
-# v1.0 - 2026-02-18
+<%- | String $snmpd_ro_secret | -%>
+# mozilla relops snmpd.conf template (macOS)
+# v1.0 - 2026-05-15
 
 agentAddress udp:161
 
@@ -9,7 +10,7 @@ sysContact     "relops@mozilla.com"
 # create 'all' view and include all of .1
 view   all         included   .1
 # set a SNMPv1/v2c read-only community (default source) and tie to 'all' view
-rocommunity <%= @snmpd_ro_secret %> default -V all
+rocommunity <%= $snmpd_ro_secret %> default -V all
 
 # expose generic-worker process status and worker pool ID to marlin via
 # NET-SNMP-EXTEND-MIB::nsExtendOutputFull."<token>"


### PR DESCRIPTION
## Summary

Adds two snmpd `extend`-backed scripts so marlin can poll workers over SNMP for:

- **`gw_status`** — whether `generic-worker` is running (`pgrep -f /generic-worker`).
- **`worker_pool_id`** — the worker's pool ID (`workerType`) read from `/etc/generic-worker.config`.

Both pieces are needed by the existing marlin Status/Metrics dashboards. Windows already exposes equivalents via NSCP/NRPE (PR `mozilla-it/marlin#16`); this PR brings Linux and Mac to parity.

## Files

**Linux** — added to the existing `linux_snmpd` module:
- `modules/linux_snmpd/files/snmp_check_gw.sh` (new)
- `modules/linux_snmpd/files/snmp_worker_pool_id.sh` (new)
- `modules/linux_snmpd/manifests/init.pp` — deploys the two scripts to `/usr/local/bin/`
- `modules/linux_snmpd/templates/snmpd.conf.erb` — adds two `extend` lines

**Mac** — new `macos_snmpd` module (mirrors `linux_snmpd`):
- `modules/macos_snmpd/manifests/init.pp`
- `modules/macos_snmpd/files/snmp_check_gw.sh` (identical content to Linux — same binary, same config path)
- `modules/macos_snmpd/files/snmp_worker_pool_id.sh` (identical)
- `modules/macos_snmpd/templates/snmpd.conf.epp`
- `modules/macos_snmpd/templates/launchdaemon.plist.epp` — runs `snmpd` via `/Library/LaunchDaemons/net.net-snmp.snmpd.plist`

## ⚠️ Known limitation on Mac

Modern macOS (>=11) does **not** ship `snmpd`. macOS 10.15 (Catalina) and older include `/usr/sbin/snmpd`. Installing net-snmp on newer macOS is **out of scope for this PR** — operators must install snmpd via their preferred channel (pkg, image bake, etc.) and pass the resulting binary path via the `$snmpd_path` parameter of `macos_snmpd`. If snmpd isn't installed at `$snmpd_path`, the LaunchDaemon will fail to load and the host will appear as Not Available in marlin — a visible failure rather than silent breakage.

The module is included in this PR so the configuration & scripts deploy idempotently the moment net-snmp lands.

## Wiring `macos_snmpd` into roles

Not done in this PR. Recommend adding `include macos_snmpd` to the appropriate base profile (e.g., a `macos_base.pp` similar to `linux_base.pp`) once we agree on the location.

## Test plan

- [ ] After merge + a puppet run on a Linux moonshot host, confirm `/usr/local/bin/snmp_check_gw.sh` and `/usr/local/bin/snmp_worker_pool_id.sh` exist and exit appropriately
- [ ] From marlin1: `snmpget -v2c -c <community> -O qv <host> 'NET-SNMP-EXTEND-MIB::nsExtendOutputFull."gw_status"'` returns `OK - generic-worker running`
- [ ] Same query for `worker_pool_id` returns `OK - worker_pool_id=<pool>`
- [ ] Mac: confirm scripts are deployed; LaunchDaemon error log if net-snmp isn't installed