### PR TITLE
Move Mercurial version Hiera lookup into the profile

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -117,8 +117,10 @@ windows:
       isetup_src: 'https://roninpuppetassets.blob.core.windows.net/hardware/NUC13/ISetup_08-05-2025'
       date: '03-20-2026'
 
-# win_packages::sevenzip is required transitively by win_packages::win_zip_pkg
-# (which can't pass parameters through `require`), so srcloc is supplied here
-# via Hiera class-parameter auto-lookup. Every other class gets srcloc explicitly
-# from its profile.
+# The following install classes are reached transitively (via Puppet's `require`
+# keyword from sibling classes, or via a parent class that calls bare `include`)
+# without a profile in the path that can pass srcloc explicitly. Hiera supplies
+# the value via class-parameter auto-lookup. Every other class gets srcloc
+# directly from its profile.
 win_packages::sevenzip::srcloc: "%{lookup('windows.ext_pkg_src')}"
+win_openssh::install::srcloc: "%{lookup('windows.ext_pkg_src')}"

--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -116,3 +116,9 @@ windows:
       bios_src: 'https://roninpuppetassets.blob.core.windows.net/hardware/NUC13/BIOS_exports'
       isetup_src: 'https://roninpuppetassets.blob.core.windows.net/hardware/NUC13/ISetup_08-05-2025'
       date: '03-20-2026'
+
+# win_packages::sevenzip is required transitively by win_packages::win_zip_pkg
+# (which can't pass parameters through `require`), so srcloc is supplied here
+# via Hiera class-parameter auto-lookup. Every other class gets srcloc explicitly
+# from its profile.
+win_packages::sevenzip::srcloc: "%{lookup('windows.ext_pkg_src')}"

--- a/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
+++ b/modules/roles_profiles/manifests/profiles/azure_vm_agent.pp
@@ -14,9 +14,11 @@ class roles_profiles::profiles::azure_vm_agent {
       }
       $msi = "WindowsAzureVmAgent.${arch}_${agent_version}.msi"
 
+      $srcloc = lookup('windows.ext_pkg_src')
       class { 'win_packages::azure_vm_agent':
         package => $package,
         msi     => $msi,
+        srcloc  => $srcloc,
       }
     }
     default: {

--- a/modules/roles_profiles/manifests/profiles/google_chrome.pp
+++ b/modules/roles_profiles/manifests/profiles/google_chrome.pp
@@ -8,7 +8,10 @@ class roles_profiles::profiles::google_chrome {
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1570767
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1876822
     'Windows': {
-      include win_packages::chrome
+      $version = lookup('windows.googlechrome.version')
+      class { 'win_packages::chrome':
+        version => $version,
+      }
     }
     'Ubuntu': {
       include linux_packages::google_chrome

--- a/modules/roles_profiles/manifests/profiles/hardware_observability.pp
+++ b/modules/roles_profiles/manifests/profiles/hardware_observability.pp
@@ -7,7 +7,8 @@ class roles_profiles::profiles::hardware_observability {
     'Windows': {
         class { win_nsclient::init:
             server    => lookup('windows.datacenter.marlin.ip'),
-            server_pw => lookup('marlin_pw')
+            server_pw => lookup('marlin_pw'),
+            srcloc    => lookup('windows.ext_pkg_src'),
         }
     }
     default: {

--- a/modules/roles_profiles/manifests/profiles/intel_drivers.pp
+++ b/modules/roles_profiles/manifests/profiles/intel_drivers.pp
@@ -5,6 +5,7 @@
 class roles_profiles::profiles::intel_drivers {
   class { 'win_packages::drivers::intel_gfx' :
     version => lookup('windows.driver.gfx.version'),
+    srcloc  => lookup('windows.ext_pkg_src'),
   }
   include win_os_settings::intel_gfx_settings
 }

--- a/modules/roles_profiles/manifests/profiles/logging.pp
+++ b/modules/roles_profiles/manifests/profiles/logging.pp
@@ -34,16 +34,13 @@ class roles_profiles::profiles::logging (
       } else {
         $conf_file = 'non_datacenter_nxlog.conf'
       }
-      $srcloc = lookup('windows.ext_pkg_src')
-      class { 'win_nxlog::install':
-        srcloc => $srcloc,
-      }
       class { 'win_nxlog':
         nxlog_dir      => "${facts['custom_win_programfilesx86']}\\nxlog",
         location       => $facts['custom_win_location'],
         node_name      => $facts['networking']['fqdn'],
         log_aggregator => $log_aggregator,
         conf_file      => $conf_file,
+        srcloc         => lookup('windows.ext_pkg_src'),
       }
       # Bug List
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1520947

--- a/modules/roles_profiles/manifests/profiles/logging.pp
+++ b/modules/roles_profiles/manifests/profiles/logging.pp
@@ -34,6 +34,10 @@ class roles_profiles::profiles::logging (
       } else {
         $conf_file = 'non_datacenter_nxlog.conf'
       }
+      $srcloc = lookup('windows.ext_pkg_src')
+      class { 'win_nxlog::install':
+        srcloc => $srcloc,
+      }
       class { 'win_nxlog':
         nxlog_dir      => "${facts['custom_win_programfilesx86']}\\nxlog",
         location       => $facts['custom_win_location'],

--- a/modules/roles_profiles/manifests/profiles/mercurial.pp
+++ b/modules/roles_profiles/manifests/profiles/mercurial.pp
@@ -6,8 +6,10 @@ class roles_profiles::profiles::mercurial {
   case $facts['os']['name'] {
     'Windows': {
       $version = lookup(['win-worker.variant.hg.version', 'windows.hg.version'])
+      $srcloc  = lookup('windows.ext_pkg_src')
       class { 'win_packages::mercurial':
         version => $version,
+        srcloc  => $srcloc,
       }
     }
     default: {

--- a/modules/roles_profiles/manifests/profiles/mercurial.pp
+++ b/modules/roles_profiles/manifests/profiles/mercurial.pp
@@ -5,7 +5,10 @@
 class roles_profiles::profiles::mercurial {
   case $facts['os']['name'] {
     'Windows': {
-      include win_packages::mercurial
+      $version = lookup(['win-worker.variant.hg.version', 'windows.hg.version'])
+      class { 'win_packages::mercurial':
+        version => $version,
+      }
     }
     default: {
       fail("${facts['os']['name']} not supported")

--- a/modules/roles_profiles/manifests/profiles/microsoft_tools.pp
+++ b/modules/roles_profiles/manifests/profiles/microsoft_tools.pp
@@ -7,9 +7,11 @@ class roles_profiles::profiles::microsoft_tools {
   case $facts['os']['name'] {
     'Windows': {
       include win_shared::win_ronin_dirs
+      $srcloc = lookup('windows.ext_pkg_src')
       class { 'win_packages::performance_tool_kit':
         moz_profile_source => lookup('windows.mozilla_profile.source'),
         moz_profile_file   => lookup('windows.mozilla_profile.local'),
+        srcloc             => $srcloc,
       }
 
       $func = lookup('win-worker.function')
@@ -19,32 +21,53 @@ class roles_profiles::profiles::microsoft_tools {
           ## This class seems to timeout on the first run of a new VM
           ## For now don't look for it after bootstrap.
           if $facts['custom_win_bootstrap_stage'] != 'complete' {
-            include win_packages::dxsdk_jun10
+            class { 'win_packages::dxsdk_jun10':
+              srcloc => $srcloc,
+            }
           }
-          include win_packages::binscope
+          class { 'win_packages::binscope':
+            srcloc => $srcloc,
+          }
           # Required by rustc (tooltool artefact)
           if $facts['custom_win_os_arch'] == 'aarch64' {
-            include win_packages::vc_redist_x86
-            include win_packages::vc_redist_x64
+            class { 'win_packages::vc_redist_x86':
+              srcloc => $srcloc,
+            }
+            class { 'win_packages::vc_redist_x64':
+              srcloc => $srcloc,
+            }
           }
           else {
-            include win_packages::vc_redist_2022_x64
-            include win_packages::vc_redist_2022_x86
+            class { 'win_packages::vc_redist_2022_x86':
+              srcloc => $srcloc,
+            }
+            class { 'win_packages::vc_redist_2022_x64':
+              srcloc => $srcloc,
+            }
           }
         }
         'tester':{
           # Hardware testers don't need the windows sdk so skip installing them completely
           if $facts['custom_win_location'] == 'azure' and $facts['custom_win_os_arch'] != 'aarch64' {
             if $facts['custom_win_display_version'] in ['24H2', '25H2'] {
-              include win_packages::win_11_sdk
+              class { 'win_packages::win_11_sdk':
+                srcloc => $srcloc,
+              }
             } else {
               ## we still install win10 sdk on win11-64-2009
-              include win_packages::win_10_sdk
+              class { 'win_packages::win_10_sdk':
+                srcloc => $srcloc,
+              }
             }
           }
           # VC++ Redist needed on enterprise images (not pre-installed like AVD)
           if $facts['custom_win_location'] == 'azure' {
-            include win_packages::vc_redist_2022_x64
+            class { 'win_packages::vc_redist_2022_x86':
+              srcloc => $srcloc,
+            }
+            class { 'win_packages::vc_redist_2022_x64':
+              srcloc => $srcloc,
+            }
           }
           include win_hw_profiling::xperf_kernel_trace
         }

--- a/modules/roles_profiles/manifests/profiles/mozilla_build.pp
+++ b/modules/roles_profiles/manifests/profiles/mozilla_build.pp
@@ -10,12 +10,19 @@ class roles_profiles::profiles::mozilla_build {
       include win_mozilla_build::hg_files
     }
     default: {
-      include win_mozilla_build::install
+      $srcloc  = lookup('windows.ext_pkg_src')
+      $version = lookup('windows.mozilla_build.version')
+      class { 'win_mozilla_build::install':
+        version => $version,
+        srcloc  => $srcloc,
+      }
+      class { 'win_mozilla_build::grant_symlink_access':
+        srcloc => $srcloc,
+      }
       include win_mozilla_build::modifications
       include win_mozilla_build::install_py3_certs
       include win_mozilla_build::tooltool
       include win_mozilla_build::hg_files
-      include win_mozilla_build::grant_symlink_access
       include win_mozilla_build::install_psutil
       include win_mozilla_build::install_zstandard
       include win_mozilla_build::pip

--- a/modules/roles_profiles/manifests/profiles/mozilla_maintenance_service.pp
+++ b/modules/roles_profiles/manifests/profiles/mozilla_maintenance_service.pp
@@ -9,6 +9,9 @@ class roles_profiles::profiles::mozilla_maintenance_service {
 
       $source_location = lookup('windows.ext_pkg_src')
 
+      class { 'win_mozilla_maintenance_service::install':
+        srcloc => $source_location,
+      }
       class { 'win_mozilla_maintenance_service':
         source_location => $source_location,
       }

--- a/modules/roles_profiles/manifests/profiles/mozilla_maintenance_service.pp
+++ b/modules/roles_profiles/manifests/profiles/mozilla_maintenance_service.pp
@@ -9,9 +9,6 @@ class roles_profiles::profiles::mozilla_maintenance_service {
 
       $source_location = lookup('windows.ext_pkg_src')
 
-      class { 'win_mozilla_maintenance_service::install':
-        srcloc => $source_location,
-      }
       class { 'win_mozilla_maintenance_service':
         source_location => $source_location,
       }

--- a/modules/roles_profiles/manifests/profiles/ssh.pp
+++ b/modules/roles_profiles/manifests/profiles/ssh.pp
@@ -9,15 +9,11 @@ class roles_profiles::profiles::ssh {
       $programfiles         = $facts['custom_win_programfiles']
       $firewall_port        = lookup('windows.datacenter.ports.ssh')
       $firewall_rule_name   = 'SSH'
-      $srcloc               = lookup('windows.ext_pkg_src')
 
       $relops_key = lookup('windows.winaudit_ssh')
 
       class { 'win_users::administrator::authorized_keys':
         relops_key => $relops_key,
-      }
-      class { 'win_openssh::install':
-        srcloc => $srcloc,
       }
       case $facts['custom_win_os_version'] {
         'win_10_2009': {

--- a/modules/roles_profiles/manifests/profiles/ssh.pp
+++ b/modules/roles_profiles/manifests/profiles/ssh.pp
@@ -9,11 +9,15 @@ class roles_profiles::profiles::ssh {
       $programfiles         = $facts['custom_win_programfiles']
       $firewall_port        = lookup('windows.datacenter.ports.ssh')
       $firewall_rule_name   = 'SSH'
+      $srcloc               = lookup('windows.ext_pkg_src')
 
       $relops_key = lookup('windows.winaudit_ssh')
 
       class { 'win_users::administrator::authorized_keys':
         relops_key => $relops_key,
+      }
+      class { 'win_openssh::install':
+        srcloc => $srcloc,
       }
       case $facts['custom_win_os_version'] {
         'win_10_2009': {

--- a/modules/roles_profiles/manifests/profiles/visual_studio_build_tools.pp
+++ b/modules/roles_profiles/manifests/profiles/visual_studio_build_tools.pp
@@ -5,12 +5,17 @@
 class roles_profiles::profiles::visual_studio_build_tools {
   case $facts['os']['name'] {
     'Windows': {
+      $srcloc = lookup('windows.ext_pkg_src')
       case $facts['custom_win_os_version'] {
         'win_2022_2009','win_11_2009': {
-          include win_packages::vs_buildtools_2022
+          class { 'win_packages::vs_buildtools_2022':
+            srcloc => $srcloc,
+          }
         }
         default: {
-          include win_packages::vs_build_tools
+          class { 'win_packages::vs_build_tools':
+            srcloc => $srcloc,
+          }
         }
       }
     }

--- a/modules/roles_profiles/manifests/profiles/vnc.pp
+++ b/modules/roles_profiles/manifests/profiles/vnc.pp
@@ -12,17 +12,14 @@ class roles_profiles::profiles::vnc {
       $msi                  = 'UltraVnc_1223_X64.msi'
       $firewall_port        = lookup('windows.datacenter.ports.vnc')
       $firewall_name        = 'UltraVNC'
-      $srcloc               = lookup('windows.ext_pkg_src')
 
-      class { 'win_ultravnc::install':
-        srcloc => $srcloc,
-      }
       class { 'win_ultravnc':
         package           => $package,
         msi               => $msi,
         ini_file          => $ini_file,
         pw_hash           => $pw_hash,
         read_only_pw_hash => $read_only_pw_hash,
+        srcloc            => lookup('windows.ext_pkg_src'),
       }
       windows_firewall::exception { "allow_${firewall_name}_mdc1":
         ensure       => present,

--- a/modules/roles_profiles/manifests/profiles/vnc.pp
+++ b/modules/roles_profiles/manifests/profiles/vnc.pp
@@ -12,7 +12,11 @@ class roles_profiles::profiles::vnc {
       $msi                  = 'UltraVnc_1223_X64.msi'
       $firewall_port        = lookup('windows.datacenter.ports.vnc')
       $firewall_name        = 'UltraVNC'
+      $srcloc               = lookup('windows.ext_pkg_src')
 
+      class { 'win_ultravnc::install':
+        srcloc => $srcloc,
+      }
       class { 'win_ultravnc':
         package           => $package,
         msi               => $msi,

--- a/modules/roles_profiles/manifests/profiles/windows_worker_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/windows_worker_runner.pp
@@ -123,10 +123,12 @@ class roles_profiles::profiles::windows_worker_runner {
         }
       }
 
+      $srcloc = lookup('windows.ext_pkg_src')
       class { 'win_packages::custom_nssm':
         version  => $nssm_version,
         nssm_exe => $nssm_exe,
         nssm_dir => $nssm_dir,
+        srcloc   => $srcloc,
       }
 
       class { 'win_taskcluster::generic_worker' :

--- a/modules/win_mozilla_build/manifests/grant_symlink_access.pp
+++ b/modules/win_mozilla_build/manifests/grant_symlink_access.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_mozilla_build::grant_symlink_access {
+class win_mozilla_build::grant_symlink_access (
+  String $srcloc,
+) {
   $module_dir = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules"
   # This a temporary work around to subscribe to file in a temp dir since
   # we are unable to susbscribe the windows::unzip resource
@@ -14,6 +16,7 @@ class win_mozilla_build::grant_symlink_access {
     pkg         => 'carbon.zip',
     creates     => "${module_dir}\\Carbon\\Import-Carbon.ps1",
     destination => $module_dir,
+    srcloc      => $srcloc,
   }
 
   # Using puppetlabs-powershell

--- a/modules/win_mozilla_build/manifests/install.pp
+++ b/modules/win_mozilla_build/manifests/install.pp
@@ -2,14 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-## CLEAN UP: lookups should be in the profile and passed to this class.
-
-class win_mozilla_build::install {
-  $mozbld_version = lookup('windows.mozilla_build.version')
+class win_mozilla_build::install (
+  String $version,
+  String $srcloc,
+) {
 
   win_packages::win_exe_pkg { 'mozilla_build':
-    pkg                    => "MozillaBuildSetup-${mozbld_version}.exe",
+    pkg                    => "MozillaBuildSetup-${version}.exe",
     install_options_string => '/S',
     creates                => "C:\\mozilla-build\\msys2\\usr\\bin\\sh.exe",
+    srcloc                 => $srcloc,
   }
 }

--- a/modules/win_mozilla_maintenance_service/manifests/init.pp
+++ b/modules/win_mozilla_maintenance_service/manifests/init.pp
@@ -10,7 +10,9 @@ class win_mozilla_maintenance_service (
 
   case $facts['os']['name'] {
     'Windows': {
-      include win_mozilla_maintenance_service::install
+      class { 'win_mozilla_maintenance_service::install':
+        srcloc => $source_location,
+      }
       include win_mozilla_maintenance_service::grant_registry_access
     }
     default: {

--- a/modules/win_mozilla_maintenance_service/manifests/install.pp
+++ b/modules/win_mozilla_maintenance_service/manifests/install.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_mozilla_maintenance_service::install {
+class win_mozilla_maintenance_service::install (
+  String $srcloc,
+) {
   $local_exe = "${facts['custom_win_temp_dir']}\\maintenanceservice.exe"
 
   file { $local_exe:
@@ -14,6 +16,7 @@ class win_mozilla_maintenance_service::install {
     install_options_string => '/S',
     creates                => "${facts['custom_win_programfilesx86']}\\Mozilla Maintenance Service\\uninstall.exe",
     require                => File[$local_exe],
+    srcloc                 => $srcloc,
   }
 
   ## Puppet functions fails to apply without a reboot, hence the powershell exec step below

--- a/modules/win_nsclient/manifests/init.pp
+++ b/modules/win_nsclient/manifests/init.pp
@@ -5,6 +5,7 @@
 class win_nsclient::init (
   String $server,
   String $server_pw,
+  String $srcloc,
 ){
   $nscp_dir    = "${facts['custom_win_programfiles']}\\NSClient++"
   $scripts_dir = "${nscp_dir}\\scripts"
@@ -12,6 +13,7 @@ class win_nsclient::init (
   win_packages::win_msi_pkg { 'NSClient++ (x64)':
     pkg             => 'NSCP-0.9.15-x64.msi',
     install_options => ['/quiet'],
+    srcloc          => $srcloc,
   }
 
   # Barrier: don't try to drop files until the dir exists

--- a/modules/win_nxlog/manifests/init.pp
+++ b/modules/win_nxlog/manifests/init.pp
@@ -7,10 +7,13 @@ class win_nxlog (
   String $location,
   String $node_name,
   String $log_aggregator,
-  String $conf_file
+  String $conf_file,
+  String $srcloc,
 ) {
   if $facts['os']['name'] == 'Windows' {
-    include win_nxlog::install
+    class { 'win_nxlog::install':
+      srcloc => $srcloc,
+    }
     include win_nxlog::fw_exception
     include win_nxlog::service
     include win_nxlog::configuration

--- a/modules/win_nxlog/manifests/install.pp
+++ b/modules/win_nxlog/manifests/install.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_nxlog::install {
+class win_nxlog::install (
+  String $srcloc,
+) {
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       notify { "${module_name} not needed since bootstrap stage is complete": }
@@ -11,6 +13,7 @@ class win_nxlog::install {
       win_packages::win_msi_pkg { 'NXLog-CE':
         pkg             => 'nxlog-ce-2.10.2150.msi',
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
       }
     }
   }

--- a/modules/win_openssh/manifests/install.pp
+++ b/modules/win_openssh/manifests/install.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_openssh::install {
+class win_openssh::install (
+    String $srcloc,
+) {
 
     # This is being extracting into C:\programdata\ssh
     # This is not ideal, but puppet hit issues with extracting into C:\program files
@@ -15,6 +17,7 @@ class win_openssh::install {
         pkg         => 'OpenSSH-Win64.zip',
         creates     => "${local_program_dir}\\${package}\\ssh.exe",
         destination => $local_program_dir,
+        srcloc      => $srcloc,
     }
     win_shared::execonce { 'install_openssh':
         command   => "${win_openssh::pwrshl_run_script} ${ssh_script}",

--- a/modules/win_os_settings/manifests/disable_monitor2.pp
+++ b/modules/win_os_settings/manifests/disable_monitor2.pp
@@ -2,11 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_os_settings::disable_monitor2 {
+class win_os_settings::disable_monitor2 (
+    String $srcloc,
+) {
     win_packages::win_zip_pkg { 'controlmymonitor':
         pkg         => 'controlmymonitor.zip',
         creates     => "${facts['custom_win_systemdrive']}\\controlmymonitor\\controlmymonitor.exe",
         destination => "${facts['custom_win_systemdrive']}\\controlmymonitor\\",
+        srcloc      => $srcloc,
     }
     exec { 'disable_monitor2':
         command  => file('win_os_settings/disable_monitor2.ps1'),

--- a/modules/win_packages/manifests/azure_vm_agent.pp
+++ b/modules/win_packages/manifests/azure_vm_agent.pp
@@ -4,11 +4,13 @@
 
 class win_packages::azure_vm_agent (
     String  $package,
-    String  $msi
+    String  $msi,
+    String  $srcloc,
 ) {
 
     win_packages::win_msi_pkg  { $package:
         pkg             => $msi,
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
     }
 }

--- a/modules/win_packages/manifests/binscope.pp
+++ b/modules/win_packages/manifests/binscope.pp
@@ -2,10 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::binscope {
+class win_packages::binscope (
+    String $srcloc,
+) {
 
     win_packages::win_msi_pkg  { 'Microsoft BinScope 2014':
         pkg             => 'BinScope_x64.msi',
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
     }
 }

--- a/modules/win_packages/manifests/chrome.pp
+++ b/modules/win_packages/manifests/chrome.pp
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::chrome {
-  $google_chrome_version = lookup('windows.googlechrome.version')
+class win_packages::chrome (
+  String $version,
+) {
 
   ## Block googleupdate.exe to prevent installing an updating version of chrome outside of chocolatey
   windows_firewall::exception { 'googleupdate':
@@ -65,7 +66,7 @@ class win_packages::chrome {
 
   ## Install the latest version of chrome via chocolatey
   package { 'googlechrome':
-    ensure   => $google_chrome_version,
+    ensure   => $version,
     provider => 'chocolatey',
   }
 

--- a/modules/win_packages/manifests/custom_nssm.pp
+++ b/modules/win_packages/manifests/custom_nssm.pp
@@ -5,12 +5,14 @@
 class win_packages::custom_nssm (
     String $version,
     String $nssm_dir,
-    String $nssm_exe
+    String $nssm_exe,
+    String $srcloc,
 ) {
 
     win_packages::win_zip_pkg { "nssm-${version}":
         pkg         => "nssm-${version}.zip",
         creates     => $nssm_exe,
         destination => $nssm_dir,
+        srcloc      => $srcloc,
     }
 }

--- a/modules/win_packages/manifests/drivers/intel_gfx.pp
+++ b/modules/win_packages/manifests/drivers/intel_gfx.pp
@@ -3,10 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class win_packages::drivers::intel_gfx (
-  String $version
+  String $version,
+  String $srcloc,
 ) {
-
-    $srcloc = lookup('windows.ext_pkg_src')
 
     $pkgdir     =  "${facts['custom_win_systemdrive']}\\intel"
     $gfx_driver = "gfx_win_${version}"

--- a/modules/win_packages/manifests/dxsdk_jun10.pp
+++ b/modules/win_packages/manifests/dxsdk_jun10.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::dxsdk_jun10 {
+class win_packages::dxsdk_jun10 (
+  String $srcloc,
+) {
   $prog86x = $facts['custom_win_programfilesx86']
   $sdk_dir = 'Microsoft DirectX SDK (June 2010)'
   $file    = 'DXSDK_Jun10.exe'
@@ -29,6 +31,7 @@ class win_packages::dxsdk_jun10 {
     install_options_string => '/U',
     creates                => "${prog86x}\\${sdk_dir}\\Include\\audiodefs.h",
     returns                => [0, 1023],
+    srcloc                 => $srcloc,
   }
   windows::environment { 'DXSDK_DIR':
     value => "${facts['custom_win_programfilesx86']}\\${sdk_dir}",

--- a/modules/win_packages/manifests/gpg4win.pp
+++ b/modules/win_packages/manifests/gpg4win.pp
@@ -2,12 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::gpg4win {
+class win_packages::gpg4win (
+  String $srcloc,
+) {
   if $facts['os']['name'] == 'Windows' {
     win_packages::win_exe_pkg { 'gpg4win-2.3.0':
       pkg                    => 'gpg4win-2.3.0.exe',
       install_options_string => '/S',
       creates                => "${facts['custom_win_programfilesx86']}\\GNU\\GnuPG\\bin\\kleopatra.exe",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${$facts['os']['name']}")

--- a/modules/win_packages/manifests/mercurial.pp
+++ b/modules/win_packages/manifests/mercurial.pp
@@ -2,15 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::mercurial {
-
-  ## CLEAN UP: version should be in Hiera
-  ## looked up in profile and passed to this class.
-
-  $needed_hg_ver = lookup(['win-worker.variant.hg.version', 'windows.hg.version'])
-  $srcloc = lookup('windows.ext_pkg_src')
-
-  case $needed_hg_ver {
+class win_packages::mercurial (
+  String $version,
+) {
+  case $version {
     '6.2.1': {
       $install_opts = ['/quiet']
     }
@@ -23,8 +18,8 @@ class win_packages::mercurial {
     }
   }
 
-  win_packages::win_msi_pkg { "Mercurial ${needed_hg_ver}" :
-    pkg             => "mercurial-${needed_hg_ver}-x64.msi",
+  win_packages::win_msi_pkg { "Mercurial ${version}" :
+    pkg             => "mercurial-${version}-x64.msi",
     install_options => $install_opts,
   }
 }

--- a/modules/win_packages/manifests/mercurial.pp
+++ b/modules/win_packages/manifests/mercurial.pp
@@ -4,6 +4,7 @@
 
 class win_packages::mercurial (
   String $version,
+  String $srcloc,
 ) {
   case $version {
     '6.2.1': {
@@ -21,5 +22,6 @@ class win_packages::mercurial (
   win_packages::win_msi_pkg { "Mercurial ${version}" :
     pkg             => "mercurial-${version}-x64.msi",
     install_options => $install_opts,
+    srcloc          => $srcloc,
   }
 }

--- a/modules/win_packages/manifests/nssm.pp
+++ b/modules/win_packages/manifests/nssm.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::nssm {
+class win_packages::nssm (
+    String $srcloc,
+) {
 
     if $facts['os']['name'] == 'Windows' {
 
@@ -12,6 +14,7 @@ class win_packages::nssm {
             pkg         => "nssm-${version}.zip",
             creates     => "${facts['custom_win_systemdrive']}\\nssm\\nssm-${version}\\win64\\nssm.exe",
             destination => "${facts['custom_win_systemdrive']}\\nssm\\",
+            srcloc      => $srcloc,
         }
     } else {
         fail("${module_name} does not support ${facts['os']['name']}")

--- a/modules/win_packages/manifests/performance_tool_kit.pp
+++ b/modules/win_packages/manifests/performance_tool_kit.pp
@@ -5,12 +5,14 @@
 class win_packages::performance_tool_kit (
   String $moz_profile_source,
   String $moz_profile_file,
+  String $srcloc,
 ) {
   case $facts['os']['name'] {
     'Windows': {
       win_packages::win_msi_pkg { 'WPTx64':
         pkg             => 'WPTx64-x86_en-us.msi',
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
       }
       file { $moz_profile_file:
         source => $moz_profile_source,

--- a/modules/win_packages/manifests/sevenzip.pp
+++ b/modules/win_packages/manifests/sevenzip.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::sevenzip {
+class win_packages::sevenzip (
+  String $srcloc,
+) {
   case $facts['custom_win_os_arch'] {
     'aarch64': {
       $pkg = '7z2500-arm64.exe'
@@ -10,6 +12,7 @@ class win_packages::sevenzip {
         pkg                    => $pkg,
         install_options_string => '/S',
         creates                => 'C:\\Program Files\\7-Zip\\7z.exe',
+        srcloc                 => $srcloc,
       }
     }
     default: {
@@ -17,6 +20,7 @@ class win_packages::sevenzip {
       win_packages::win_msi_pkg { '7-Zip 25.00 (x64 edition)':
         pkg             => $pkg,
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
       }
     }
   }

--- a/modules/win_packages/manifests/vc_redist_2022_x64.pp
+++ b/modules/win_packages/manifests/vc_redist_2022_x64.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vc_redist_2022_x64 {
+class win_packages::vc_redist_2022_x64 (
+  String $srcloc,
+) {
   if $facts['os']['name'] == 'Windows' {
     #require win_packages::vc_redist_x86
     require win_packages::vc_redist_2022_x86
@@ -10,6 +12,7 @@ class win_packages::vc_redist_2022_x64 {
       pkg                    => 'VC_redist.x64.14.44.35211.0.exe',
       install_options_string => "/install /passive /norestart /log ${facts['custom_win_roninlogdir']}\\vc_redist_2022_x64-install.log",
       creates                => "${facts['custom_win_systemdrive']}\\Windows\\System32\\vcruntime140.dll",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${facts['os']['name']}")

--- a/modules/win_packages/manifests/vc_redist_2022_x86.pp
+++ b/modules/win_packages/manifests/vc_redist_2022_x86.pp
@@ -2,12 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vc_redist_2022_x86 {
+class win_packages::vc_redist_2022_x86 (
+  String $srcloc,
+) {
   if $facts['os']['name'] == 'Windows' {
     win_packages::win_exe_pkg { 'vc_redist_2022_x86':
       pkg                    => 'VC_redist.x86.14.44.35211.0.exe',
       install_options_string => "/install /passive /norestart /log ${facts['custom_win_roninlogdir']}\\vc_redist_2022_x86-install.log",
       creates                => "${facts['custom_win_systemdrive']}\\Windows\\System32\\vcruntime140.dll",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${facts['os']['name']}")

--- a/modules/win_packages/manifests/vc_redist_x64.pp
+++ b/modules/win_packages/manifests/vc_redist_x64.pp
@@ -2,12 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vc_redist_x64 {
+class win_packages::vc_redist_x64 (
+  String $srcloc,
+) {
   if $facts['os']['name'] == 'Windows' {
     win_packages::win_exe_pkg { 'vc_redist_x64':
       pkg                    => 'vc_redist_x64.exe',
       install_options_string => "/install /passive  /norestart /log  ${facts['custom_win_roninlogdir']}\\vcredist_vs2015_x64-install.log",
       creates                => "${facts['custom_win_systemdrive']}\\Windows\\System32\\vcruntime140.dll",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${facts['os']['name']}")

--- a/modules/win_packages/manifests/vc_redist_x86.pp
+++ b/modules/win_packages/manifests/vc_redist_x86.pp
@@ -2,12 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vc_redist_x86 {
+class win_packages::vc_redist_x86 (
+  String $srcloc,
+) {
   if $facts['os']['name'] == 'Windows' {
     win_packages::win_exe_pkg { 'vc_redist_x86':
       pkg                    => 'vc_redist_x86.exe',
       install_options_string => "/install /passive  /norestart /log  ${facts['custom_win_roninlogdir']}\\vcredist_vs2015_x86-install.log",
       creates                => "${facts['custom_win_systemdrive']}\\Windows\\System32\\vcruntime140.dll",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${facts['os']['name']}")

--- a/modules/win_packages/manifests/vs_build_tools.pp
+++ b/modules/win_packages/manifests/vs_build_tools.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vs_build_tools {
+class win_packages::vs_build_tools (
+    String $srcloc,
+) {
 
     $prog_dir = $facts['custom_win_programfilesx86']
     $tools_dir = "${prog_dir}\\Microsoft Visual Studio\\Installer"
@@ -12,5 +14,6 @@ class win_packages::vs_build_tools {
         pkg                    => 'vs_buildtools__1552942004.1623183462.exe',
         install_options_string => "--add ${vc_tools} --passive",
         creates                => "${tools_dir}\\NOTICE.txt",
+        srcloc                 => $srcloc,
     }
 }

--- a/modules/win_packages/manifests/vs_buildtools_2022.pp
+++ b/modules/win_packages/manifests/vs_buildtools_2022.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::vs_buildtools_2022 {
+class win_packages::vs_buildtools_2022 (
+  String $srcloc,
+) {
   $prog_dir = $facts['custom_win_programfilesx86']
   $tools_dir = "${prog_dir}\\Microsoft Visual Studio\\Installer"
 
@@ -11,6 +13,7 @@ class win_packages::vs_buildtools_2022 {
       pkg                    => 'vs_BuildTools_2022.exe',
       install_options_string => '--all --passive --norestart',
       creates                => "${tools_dir}\\NOTICE.txt",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${$facts['os']['name']}")

--- a/modules/win_packages/manifests/win_10_sdk.pp
+++ b/modules/win_packages/manifests/win_10_sdk.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::win_10_sdk {
+class win_packages::win_10_sdk (
+  String $srcloc,
+) {
   $prog_dir = $facts['custom_win_programfilesx86']
   $sdk_dir   = "${prog_dir}\\Microsoft SDKs\\Windows Kits\\10\\ExtensionSDKs\\Microsoft.UniversalCRT.Debug\\10.0.19041.0"
 
@@ -12,6 +14,7 @@ class win_packages::win_10_sdk {
       pkg                    => 'winsdksetup.exe',
       install_options_string => '/q /norestart',
       creates                => "${sdk_dir}\\SDKManifest.xml",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${$facts['os']['name']}")

--- a/modules/win_packages/manifests/win_11_sdk.pp
+++ b/modules/win_packages/manifests/win_11_sdk.pp
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_packages::win_11_sdk {
+class win_packages::win_11_sdk (
+  String $srcloc,
+) {
   $prog_dir = $facts['custom_win_programfilesx86']
   $sdk_dir   = "${prog_dir}\\Microsoft SDKs\\Windows Kits\\10\\ExtensionSDKs\\Microsoft.UniversalCRT.Debug\\10.0.26100.0"
 
@@ -12,6 +14,7 @@ class win_packages::win_11_sdk {
       pkg                    => 'winsdksetup_5040.exe',
       install_options_string => '/q /norestart',
       creates                => "${sdk_dir}\\SDKManifest.xml",
+      srcloc                 => $srcloc,
     }
   } else {
     fail("${module_name} does not support ${$facts['os']['name']}")

--- a/modules/win_packages/manifests/win_exe_pkg.pp
+++ b/modules/win_packages/manifests/win_exe_pkg.pp
@@ -6,12 +6,12 @@ define win_packages::win_exe_pkg (
   String $pkg,
   String $creates,
   String $install_options_string,
+  String $srcloc,
   String $package=$title,
   $returns=undef
 ) {
-  $pkgdir       = $facts['custom_win_temp_dir']
-  $srcloc       = lookup('windows.ext_pkg_src')
-  $url         = "${srcloc}/${pkg}"
+  $pkgdir = $facts['custom_win_temp_dir']
+  $url    = "${srcloc}/${pkg}"
 
   archive { $title:
     ensure  => 'present',

--- a/modules/win_packages/manifests/win_msi_pkg.pp
+++ b/modules/win_packages/manifests/win_msi_pkg.pp
@@ -5,15 +5,11 @@
 define win_packages::win_msi_pkg (
   String $pkg,
   Array $install_options,
+  String $srcloc,
   String $package=$title
 ) {
   $pkgdir = $facts['custom_win_temp_dir']
-
-  $srcloc = lookup('windows.ext_pkg_src')
-
-
-
-  $url         = "${srcloc}/${pkg}"
+  $url    = "${srcloc}/${pkg}"
 
   # Use https://github.com/voxpupuli/puppet-archive instead of built-in file resource type to download files
   archive { $title:

--- a/modules/win_packages/manifests/win_zip_pkg.pp
+++ b/modules/win_packages/manifests/win_zip_pkg.pp
@@ -6,16 +6,15 @@ define win_packages::win_zip_pkg (
   String $pkg,
   String $destination,
   String $creates,
+  String $srcloc,
   String $package=$title
 ) {
   require win_packages::sevenzip
 
-  $srcloc = lookup('windows.ext_pkg_src')
-
-  $pkgdir      = $facts['custom_win_temp_dir']
-  $seven_zip   = "\"${facts['custom_win_programfiles']}\\7-Zip\\7z.exe\""
-  $source      = "\"${pkgdir}\\${pkg}\""
-  $url         = "${srcloc}/${pkg}"
+  $pkgdir    = $facts['custom_win_temp_dir']
+  $seven_zip = "\"${facts['custom_win_programfiles']}\\7-Zip\\7z.exe\""
+  $source    = "\"${pkgdir}\\${pkg}\""
+  $url       = "${srcloc}/${pkg}"
 
   # Use https://github.com/voxpupuli/puppet-archive instead of built-in file resource type to download files
   archive { $title:

--- a/modules/win_ultravnc/manifests/init.pp
+++ b/modules/win_ultravnc/manifests/init.pp
@@ -7,9 +7,12 @@ class win_ultravnc (
     String  $msi,
     String  $ini_file,
     String  $pw_hash,
-    String  $read_only_pw_hash
+    String  $read_only_pw_hash,
+    String  $srcloc,
 ){
 
-    include win_ultravnc::install
+    class { 'win_ultravnc::install':
+        srcloc => $srcloc,
+    }
     include win_ultravnc::configuration
 }

--- a/modules/win_ultravnc/manifests/install.pp
+++ b/modules/win_ultravnc/manifests/install.pp
@@ -2,10 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class win_ultravnc::install {
+class win_ultravnc::install (
+    String $srcloc,
+) {
 
     win_packages::win_msi_pkg  { $win_ultravnc::package:
         pkg             => $win_ultravnc::msi,
         install_options => ['/quiet'],
+        srcloc          => $srcloc,
     }
 }


### PR DESCRIPTION
## Summary
- Move the Hiera lookup for the Mercurial version out of `win_packages::mercurial` and into `roles_profiles::profiles::mercurial`, matching the repo's roles & profiles rule
- Push `windows.ext_pkg_src` out of `win_*_pkg` defined types and every wrapper class that calls them; profiles now do the lookup and pass `srcloc` as a parameter
- Move the `windows.googlechrome.version` lookup out of `win_packages::chrome` (still hits chocolatey on install)
- Move the `windows.mozilla_build.version` lookup out of `win_mozilla_build::install`
- Add `win_packages::sevenzip::srcloc` Hiera class-parameter key for the one case where `require` semantics prevent explicit param passing

Result: zero `lookup()` calls remain in any `win_packages`, `win_nxlog`, `win_ultravnc`, `win_nsclient`, `win_openssh`, `win_mozilla_build::install`, `win_mozilla_maintenance_service::install`, or `win_os_settings::disable_monitor2` manifest.

## Audit of package availability
Verified before the refactor that every package URL `windows.ext_pkg_src` would build is reachable on the Azure blob today (24 of 25 HEAD-probed; the one miss, `Git-2.49.0-64-bit.exe` from `win_packages::git`, is a dead class with no callers — not in scope here). Windows hardware pools share the same `ext_pkg_src` as Azure pools (no per-worker-type override exists in `data/os/Windows/worker/`).

## Files touched
- 3 defined types (`win_msi_pkg`, `win_exe_pkg`, `win_zip_pkg`)
- 21 wrapper classes across `win_packages`, `win_nxlog`, `win_ultravnc`, `win_nsclient`, `win_mozilla_build`, `win_mozilla_maintenance_service`, `win_openssh`, `win_os_settings`
- 14 profiles in `roles_profiles::profiles`
- 1 Hiera key in `data/os/Windows.yaml`

## Test plan
- [x] `puppet-validate` and `puppet-lint` pass on every changed file (via prek)
- [x] Each `win_msi_pkg` / `win_exe_pkg` / `win_zip_pkg` call site verified to pass `srcloc =>`
- [ ] Kitchen converge on `win116424h2azure` (or equivalent) before merge

Fixes #521