### PR TITLE
Fix Azure maintain_system immutability and Y: mapping

### DIFF
--- a/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
+++ b/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
@@ -559,13 +559,34 @@ function Set-AzureInstanceMetadataScheduledEvents {
 ## Drive Y is hardcoded in tree. However, we are moving away from mounting a separate Y drive.
 function LinkZY2D {
   param (
+    [string] $source = 'D:\',
+    [string] $drive = 'Y:'
   )
   begin {
     Write-Log -message ('{0} :: begin - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
   }
   process {
-    if ((Test-VolumeExists -DriveLetter 'D') -and (-not (Test-VolumeExists -DriveLetter 'Y'))) {
-      subst Y: D:\
+    $drive_path = ('{0}\' -f $drive)
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+      Write-Log -message ('{0} :: source path {1} does not exist; cannot create {2}' -f $($MyInvocation.MyCommand.Name), $source, $drive) -severity 'WARN'
+      return
+    }
+    if (Test-Path -LiteralPath $drive_path -PathType Container) {
+      Write-Log -message ('{0} :: drive {1} already available' -f $($MyInvocation.MyCommand.Name), $drive) -severity 'DEBUG'
+      return
+    }
+
+    $subst = Join-Path $env:SystemRoot 'System32\subst.exe'
+    & $subst @($drive, $source)
+    if ($LASTEXITCODE -ne 0) {
+      Write-Log -message ('{0} :: subst failed to map {1} to {2}; exit code {3}' -f $($MyInvocation.MyCommand.Name), $drive, $source, $LASTEXITCODE) -severity 'ERROR'
+      return
+    }
+    if (Test-Path -LiteralPath $drive_path -PathType Container) {
+      Write-Log -message ('{0} :: mapped {1} to {2}' -f $($MyInvocation.MyCommand.Name), $drive, $source) -severity 'DEBUG'
+    }
+    else {
+      Write-Log -message ('{0} :: subst reported success but {1} is not available' -f $($MyInvocation.MyCommand.Name), $drive_path) -severity 'ERROR'
     }
   }
   end {
@@ -603,8 +624,8 @@ If (($hand_off_ready -eq 'yes') -and ($managed_by -eq 'taskcluster')) {
   Run-MaintainSystem
   if (((Get-ItemProperty "HKLM:\SOFTWARE\Mozilla\ronin_puppet").inmutable) -eq 'false') {
     Puppet-Run
-    LinkZY2D
   }
+  LinkZY2D
   ## Start worker runner, which starts generic-worker
   Start-WorkerRunner
 }

--- a/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
+++ b/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
@@ -174,11 +174,49 @@ function Check-RoninLock {
   }
 }
 
+function Write-PuppetSlowResourceSummary {
+  param (
+    [string] $LogPath,
+    [int] $Limit = 20
+  )
+  begin {
+    Write-Log -message ('{0} :: begin - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
+  }
+  process {
+    if (!(Test-Path $LogPath)) {
+      Write-Log -message ('{0} :: Puppet log not found: {1}' -f $($MyInvocation.MyCommand.Name), $LogPath) -severity 'WARN'
+      return
+    }
+
+    $slowResources = Get-Content -Path $LogPath -ErrorAction SilentlyContinue | ForEach-Object {
+      if ($_ -match '^(?:\w+:\s+)?(?<resource>.+): Evaluated in (?<seconds>[0-9]+(?:\.[0-9]+)?) seconds$') {
+        [PSCustomObject]@{
+          Seconds  = [double]$Matches.seconds
+          Resource = $Matches.resource.Trim()
+        }
+      }
+    } | Sort-Object -Property Seconds -Descending | Select-Object -First $Limit
+
+    if ($slowResources) {
+      foreach ($resource in $slowResources) {
+        Write-Log -message ('Puppet-Run :: slow resource {0:n3}s {1}' -f $resource.Seconds, $resource.Resource) -severity 'DEBUG'
+      }
+    }
+    else {
+      Write-Log -message ('{0} :: no Puppet evaltrace resource timings found in {1}' -f $($MyInvocation.MyCommand.Name), $LogPath) -severity 'DEBUG'
+    }
+  }
+  end {
+    Write-Log -message ('{0} :: end - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
+  }
+}
+
 function Puppet-Run {
   param (
     [int] $exit,
     [string] $lock = "$env:programdata\PuppetLabs\ronin\semaphore\ronin_run.lock",
     [int] $last_exit = (Get-ItemProperty "HKLM:\SOFTWARE\Mozilla\ronin_puppet").last_run_exit,
+    [string] $run_to_success = 'true',
     [string] $inmutable = (Get-ItemProperty "HKLM:\SOFTWARE\Mozilla\ronin_puppet").inmutable,
     [string] $nodes_def = "$env:systemdrive\ronin\manifests\nodes\odes.pp",
     [string] $logdir = "$env:systemdrive\logs",
@@ -214,6 +252,13 @@ function Puppet-Run {
 
     Set-Location "$env:systemdrive\ronin"
 
+    # Azure images should become immutable after the final Taskcluster boot apply.
+    # Preserve the legacy registry override for debugging nodes that need repeated Puppet runs.
+    $roninOptions = Get-ItemProperty -Path "$roninKey" -Name 'runtosuccess' -ErrorAction SilentlyContinue
+    if (($null -ne $roninOptions) -and ($null -ne $roninOptions.runtosuccess)) {
+      $run_to_success = $roninOptions.runtosuccess
+    }
+
     # Ensure worker pool ID matches what was provisioned.
     # So Puppet can update config files as needed.
     Write-Log -message  ('{0} :: Updating worker pool ID for final Puppet run' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
@@ -229,15 +274,20 @@ function Puppet-Run {
       New-Item -ItemType Directory -Force -Path $fail_dir
     }
     Get-ChildItem -Path $logdir\*.log -Recurse | Move-Item -Destination $logdir\old -ErrorAction SilentlyContinue
+    $puppetLogPath = "$logdir\$log_file"
+    $puppetStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     Write-Log -message  ('{0} :: Initiating Puppet apply .' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-    puppet apply manifests\nodes.pp --onetime --verbose --no-daemonize --no-usecacheonfailure --detailed-exitcodes --no-splay --show_diff --modulepath=modules`;r10k_modules --hiera_config=hiera.yaml --logdest $logdir\$log_file
+    puppet apply manifests\nodes.pp --onetime --verbose --no-daemonize --no-usecacheonfailure --detailed-exitcodes --no-splay --show_diff --evaltrace --summarize --modulepath=modules`;r10k_modules --hiera_config=hiera.yaml --logdest $puppetLogPath
     [int]$puppet_exit = $LastExitCode
+    $puppetStopwatch.Stop()
+    Write-Log -message  ('{0} :: Puppet apply completed in {1:n1} seconds with exit code {2}' -f $($MyInvocation.MyCommand.Name), $puppetStopwatch.Elapsed.TotalSeconds, $puppet_exit) -severity 'DEBUG'
+    Write-PuppetSlowResourceSummary -LogPath $puppetLogPath
 
     if ($run_to_success -eq 'true') {
       if (($puppet_exit -ne 0) -and ($puppet_exit -ne 2)) {
         if ($last_exit -eq 0) {
           Write-Log -message  ('{0} :: Puppet apply failed.' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-          Set-ItemProperty -Path "$ronninKey" -name "last_exit" -value "$puppet_exit"
+          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
           Remove-Item $lock -ErrorAction SilentlyContinue
           # If the Puppet run fails send logs to papertrail
           # Nxlog watches $fail_dir for files names *-puppetrun.log
@@ -245,8 +295,8 @@ function Puppet-Run {
           shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
         }
         elseif ($last_exit -ne 0) {
-          Set-ItemProperty -Path "$ronninKey" -name "last_exit" -value "$puppet_exit"
-          Remove-Item $lock
+          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+          Remove-Item $lock -ErrorAction SilentlyContinue
           Move-Item $logdir\$log_file -Destination $fail_dir
           Write-Log -message  ('{0} :: Puppet apply failed. Waiting 10 minutes beofre Reboot' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
           sleep 600
@@ -255,15 +305,15 @@ function Puppet-Run {
       }
       elseif (($puppet_exit -match 0) -or ($puppet_exit -match 2)) {
         Write-Log -message  ('{0} :: Puppet apply successful' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-        Set-ItemProperty -Path "$ronninKey" -name "last_exit" -value "$puppet_exit"
-        Remove-Item -path $lock
-        Set-ItemProperty -Path HKLM:\SOFTWARE\Mozilla\ronin_puppet -name inmutable -value true
+        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+        Remove-Item -path $lock -ErrorAction SilentlyContinue
+        Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
       }
       else {
         Write-Log -message  ('{0} :: Unable to detrimine state post Puppet apply' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-        Set-ItemProperty -Path "$ronninKey" -name "last_exit" -value "$last_exit"
+        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$last_exit"
         Move-Item $logdir\$log_file -Destination $fail_dir
-        Remove-Item -path $lock
+        Remove-Item -path $lock -ErrorAction SilentlyContinue
         shutdown @('-r', '-t', '600', '-c', 'Reboot; Unveriable state', '-f', '-d', '4:5')
       }
     }

--- a/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
+++ b/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
@@ -284,37 +284,53 @@ function Puppet-Run {
     Write-PuppetSlowResourceSummary -LogPath $puppetLogPath
 
     if ($run_to_success -eq 'true') {
-      if (($puppet_exit -ne 0) -and ($puppet_exit -ne 2)) {
-        if ($last_exit -eq 0) {
-          Write-Log -message  ('{0} :: Puppet apply failed.' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
-          Remove-Item $lock -ErrorAction SilentlyContinue
-          # If the Puppet run fails send logs to papertrail
-          # Nxlog watches $fail_dir for files names *-puppetrun.log
-          Move-Item $logdir\$log_file -Destination $fail_dir
-          shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
-        }
-        elseif ($last_exit -ne 0) {
-          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
-          Remove-Item $lock -ErrorAction SilentlyContinue
-          Move-Item $logdir\$log_file -Destination $fail_dir
-          Write-Log -message  ('{0} :: Puppet apply failed. Waiting 10 minutes beofre Reboot' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-          sleep 600
-          shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
-        }
-      }
-      elseif (($puppet_exit -match 0) -or ($puppet_exit -match 2)) {
-        Write-Log -message  ('{0} :: Puppet apply successful' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+      $handleFailure = {
+        param (
+          [string] $message,
+          [int] $exitCode
+        )
+        Write-Log -message ('{0} :: {1} :: Error code {2}' -f $($MyInvocation.MyCommand.Name), $message, $exitCode) -severity 'DEBUG'
+        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$exitCode"
         Remove-Item -path $lock -ErrorAction SilentlyContinue
-        Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
+        # If the Puppet run fails send logs to papertrail.
+        # Nxlog watches $fail_dir for file names matching *-puppetrun.log.
+        Move-Item $puppetLogPath -Destination $fail_dir -ErrorAction SilentlyContinue
+        if ($last_exit -ne 0) {
+          Write-Log -message  ('{0} :: Puppet apply failed repeatedly. Waiting 10 minutes before reboot' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+          Start-Sleep 600
+        }
+        shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
       }
-      else {
-        Write-Log -message  ('{0} :: Unable to detrimine state post Puppet apply' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$last_exit"
-        Move-Item $logdir\$log_file -Destination $fail_dir
-        Remove-Item -path $lock -ErrorAction SilentlyContinue
-        shutdown @('-r', '-t', '600', '-c', 'Reboot; Unveriable state', '-f', '-d', '4:5')
+
+      switch ($puppet_exit) {
+        0 {
+          Write-Log -message  ('{0} :: Puppet apply succeeded with no changes :: Error code {1}' -f $($MyInvocation.MyCommand.Name), $puppet_exit) -severity 'DEBUG'
+          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+          Remove-Item -path $lock -ErrorAction SilentlyContinue
+          Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
+        }
+        1 {
+          & $handleFailure 'Puppet apply failed' $puppet_exit
+        }
+        2 {
+          Write-Log -message  ('{0} :: Puppet apply succeeded, and some resources were changed :: Error code {1}' -f $($MyInvocation.MyCommand.Name), $puppet_exit) -severity 'DEBUG'
+          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+          Remove-Item -path $lock -ErrorAction SilentlyContinue
+          Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
+        }
+        4 {
+          & $handleFailure 'Puppet apply succeeded, but some resources failed' $puppet_exit
+        }
+        6 {
+          & $handleFailure 'Puppet apply succeeded, but included changes and failures' $puppet_exit
+        }
+        Default {
+          Write-Log -message  ('{0} :: Unable to determine state post Puppet apply :: Error code {1}' -f $($MyInvocation.MyCommand.Name), $puppet_exit) -severity 'DEBUG'
+          Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$last_exit"
+          Move-Item $puppetLogPath -Destination $fail_dir -ErrorAction SilentlyContinue
+          Remove-Item -path $lock -ErrorAction SilentlyContinue
+          shutdown @('-r', '-t', '600', '-c', 'Reboot; Unverifiable Puppet state', '-f', '-d', '4:5')
+        }
       }
     }
   }

--- a/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
+++ b/modules/win_scheduled_tasks/files/azure-maintainsystem.ps1
@@ -284,23 +284,8 @@ function Puppet-Run {
     Write-PuppetSlowResourceSummary -LogPath $puppetLogPath
 
     if ($run_to_success -eq 'true') {
-      $handleFailure = {
-        param (
-          [string] $message,
-          [int] $exitCode
-        )
-        Write-Log -message ('{0} :: {1} :: Error code {2}' -f $($MyInvocation.MyCommand.Name), $message, $exitCode) -severity 'DEBUG'
-        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$exitCode"
-        Remove-Item -path $lock -ErrorAction SilentlyContinue
-        # If the Puppet run fails send logs to papertrail.
-        # Nxlog watches $fail_dir for file names matching *-puppetrun.log.
-        Move-Item $puppetLogPath -Destination $fail_dir -ErrorAction SilentlyContinue
-        if ($last_exit -ne 0) {
-          Write-Log -message  ('{0} :: Puppet apply failed repeatedly. Waiting 10 minutes before reboot' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-          Start-Sleep 600
-        }
-        shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
-      }
+      $puppet_failed = $false
+      $puppet_failure_message = $null
 
       switch ($puppet_exit) {
         0 {
@@ -310,7 +295,8 @@ function Puppet-Run {
           Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
         }
         1 {
-          & $handleFailure 'Puppet apply failed' $puppet_exit
+          $puppet_failed = $true
+          $puppet_failure_message = 'Puppet apply failed'
         }
         2 {
           Write-Log -message  ('{0} :: Puppet apply succeeded, and some resources were changed :: Error code {1}' -f $($MyInvocation.MyCommand.Name), $puppet_exit) -severity 'DEBUG'
@@ -319,10 +305,12 @@ function Puppet-Run {
           Set-ItemProperty -Path "$roninKey" -name inmutable -value 'true'
         }
         4 {
-          & $handleFailure 'Puppet apply succeeded, but some resources failed' $puppet_exit
+          $puppet_failed = $true
+          $puppet_failure_message = 'Puppet apply succeeded, but some resources failed'
         }
         6 {
-          & $handleFailure 'Puppet apply succeeded, but included changes and failures' $puppet_exit
+          $puppet_failed = $true
+          $puppet_failure_message = 'Puppet apply succeeded, but included changes and failures'
         }
         Default {
           Write-Log -message  ('{0} :: Unable to determine state post Puppet apply :: Error code {1}' -f $($MyInvocation.MyCommand.Name), $puppet_exit) -severity 'DEBUG'
@@ -331,6 +319,19 @@ function Puppet-Run {
           Remove-Item -path $lock -ErrorAction SilentlyContinue
           shutdown @('-r', '-t', '600', '-c', 'Reboot; Unverifiable Puppet state', '-f', '-d', '4:5')
         }
+      }
+      if ($puppet_failed) {
+        Write-Log -message ('{0} :: {1} :: Error code {2}' -f $($MyInvocation.MyCommand.Name), $puppet_failure_message, $puppet_exit) -severity 'DEBUG'
+        Set-ItemProperty -Path "$roninKey" -name "last_run_exit" -value "$puppet_exit"
+        Remove-Item -path $lock -ErrorAction SilentlyContinue
+        # If the Puppet run fails send logs to papertrail.
+        # Nxlog watches $fail_dir for file names matching *-puppetrun.log.
+        Move-Item $puppetLogPath -Destination $fail_dir -ErrorAction SilentlyContinue
+        if (($last_exit -ne 0) -and ($last_exit -ne 2)) {
+          Write-Log -message  ('{0} :: Puppet apply failed repeatedly. Waiting 10 minutes before reboot' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+          Start-Sleep 600
+        }
+        shutdown @('-r', '-t', '0', '-c', 'Reboot; Puppet apply failed', '-f', '-d', '4:5')
       }
     }
   }

--- a/modules/win_taskcluster/files/task-user-init.ps1
+++ b/modules/win_taskcluster/files/task-user-init.ps1
@@ -92,6 +92,36 @@ function Disable-OneDrive {
 
 }
 
+function Mount-TaskUserYDrive {
+    param (
+        [string] $source = 'D:\',
+        [string] $drive = 'Y:'
+    )
+
+    $drive_path = ('{0}\' -f $drive)
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+        Write-Log -Message ('{0} :: source path {1} does not exist; cannot create {2}' -f $($MyInvocation.MyCommand.Name), $source, $drive) -severity 'ERROR'
+        exit 1
+    }
+    if (Test-Path -LiteralPath $drive_path -PathType Container) {
+        Write-Log -Message ('{0} :: drive {1} already available for task user' -f $($MyInvocation.MyCommand.Name), $drive) -severity 'DEBUG'
+        return
+    }
+
+    $subst = Join-Path $env:SystemRoot 'System32\subst.exe'
+    & $subst @($drive, $source)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log -Message ('{0} :: subst failed to map {1} to {2}; exit code {3}' -f $($MyInvocation.MyCommand.Name), $drive, $source, $LASTEXITCODE) -severity 'ERROR'
+        exit 1
+    }
+    if (-not (Test-Path -LiteralPath $drive_path -PathType Container)) {
+        Write-Log -Message ('{0} :: subst reported success but {1} is not available for task user' -f $($MyInvocation.MyCommand.Name), $drive_path) -severity 'ERROR'
+        exit 1
+    }
+
+    Write-Log -Message ('{0} :: mapped {1} to {2} for task user' -f $($MyInvocation.MyCommand.Name), $drive, $source) -severity 'DEBUG'
+}
+
 $DhcpDomain = ((Get-ItemProperty 'HKLM:SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters').'DhcpDomain')
 
 switch -Regex ($true) {
@@ -146,6 +176,10 @@ catch {
 while (-not (Get-LocalUser -Name $localuser -ErrorAction SilentlyContinue)) {
     Write-Log -Message ('{0} :: {1} - {2:o}' -f $($MyInvocation.MyCommand.Name), "Waiting for $localuser to be created", (Get-Date).ToUniversalTime()) -severity 'DEBUG'
     Start-Sleep -Seconds 5
+}
+
+if ($location -eq "azure") {
+    Mount-TaskUserYDrive
 }
 
 switch ($os_version) {


### PR DESCRIPTION
## Summary
- treat Puppet/OpenVox detailed exit codes like worker-images: `0`/`2` are success, `1`/`4`/`6` are failure
- mark `inmutable=true` only after the post-bootstrap Puppet run succeeds
- keep the host `Y:` mapping available on immutable boots and map `Y:` again in `task-user-init.ps1` for the generic-worker task user
- add Puppet timing/evaltrace summary logging for first-boot diagnostics

## Why this fixes it
The traced worker did not fail because Puppet failed. Puppet exited `2`, which means success with changes.

The task failed later because `run-task` used `HG_STORE_PATH=y:/hg-shared`. Before this PR, `Y:` was created only in the mutable boot path by the SYSTEM `maintain_system` task, after Puppet ran. That mapping could exist for SYSTEM, but `subst` mappings are session-scoped, so a new generic-worker task user did not reliably see it; on later immutable boots, the host-side `LinkZY2D` call was skipped too. This PR keeps the host mapping on immutable boots and creates `Y:` inside each task-user session before task commands run.

The post-bootstrap Puppet run still matters because it is the pass that applies the machine's final runtime state after bootstrap changes are in place. Once that run exits `0` or `2`, the image can be marked immutable; if it exits `1`, `4`, or `6`, the boot should stay mutable and fail instead of hiding a bad catalog run.

## Validation
Local checks:
- PowerShell parse check for `azure-maintainsystem.ps1` and `task-user-init.ps1`
- regex sanity check for Puppet evaltrace parsing
- `git diff --check`
- `Invoke-ScriptAnalyzer` reports existing style warnings only

Worker-images revalidation:
- Run: https://github.com/mozilla-platform-ops/worker-images/actions/runs/26177629342
- Run uses this branch: `fix/azure-maintainsystem-inmutable`
- Packer built win10, win11 24H2, win11 25H2, ARM 25H2 tester, and win2022 successfully. ARM 24H2 tester failed early during WinRM test-file upload, before Puppet validation.
- os-integration results:
  - win10 passed: https://firefox-ci-tc.services.mozilla.com/tasks/groups/W7e7LmloSOaBAx_xjlB0MQ
  - win11 25H2 passed: https://firefox-ci-tc.services.mozilla.com/tasks/groups/bKmhWnebQemT48K0hQtssQ
  - ARM 25H2 tester passed: https://firefox-ci-tc.services.mozilla.com/tasks/groups/YYR7TvgxRSy31GSaapFE4w
  - win11 24H2 had 3 Gecko browser-chrome timeouts in `browser_utility_geolocation_crashed.js`: https://firefox-ci-tc.services.mozilla.com/tasks/groups/cOeyEtEMT6m9t3Oq2wiIUQ

Direct startup-test evidence for the previous `y:/hg-shared` failure path:
- 24H2 win64 startup passed: https://firefox-ci-tc.services.mozilla.com/tasks/VlTM5I5GTWmtQjEWtamF5A
- 25H2 win64 startup passed: https://firefox-ci-tc.services.mozilla.com/tasks/HQIvlbFuSoOgQQJ43v2WZg
- Both logs still show the `HG_STORE_PATH (y:/hg-shared)` warning, but no `FileNotFoundError: 'y:/'`; checkout continues under `D:/task_...`, Firefox runs for 30 seconds, and the tasks exit `0` with `Result: SUCCEEDED`.

Same-worker post-bootstrap evidence:
- In the 24H2 integration group, `vm-f9snmhsoqga9tf0txdfmrgepikayjryo0iv` ran `AK0sAoY1Qt-YojELHs3AkQ` first, then rebooted into a new generic-worker task user and ran `UUMjgX34QvmLlxcIkK9Lag` on the same VM; both completed successfully.
- Papertrail for that worker shows the initial boot Puppet apply completed with exit code `2` at `2026-05-20 17:57:46Z`. After the first task resolved, later boot-time `maintain_system` passes at `18:04:26Z` and `18:19:11Z` ran the immutable path: `Run-MaintainSystem`, `LinkZY2D :: mapped Y: to D:\\`, and `Start-WorkerRunner`, with no second Puppet apply in that window.
- Worker-runner reported `Resolved 1 tasks in total so far` at `18:03:50Z` and `Resolved 2 tasks in total so far` at `18:18:40Z`, confirming same-VM reuse across the generic-worker reboot/new-task-user path.

Current PR check note:
- The earlier `win116425h2azure` serverspec failure was from a stale-branch NVIDIA A10 driver mismatch after `RELOPS-2372: bump NVIDIA A10 GRID driver to 573.96 (#1218)` landed on `master`.
- This branch now includes that `master` merge, so the driver data and serverspec expectation are aligned; rerun checks should not hit that mismatch.

Original failure examples from the earlier cancelled run:
- https://firefox-ci-tc.services.mozilla.com/tasks/bi9UFQzFR9qVqTZQdwoeEw
- https://firefox-ci-tc.services.mozilla.com/tasks/Ow712ybRTieMC7SRDmScoA




