### PR TITLE
Expose generic-worker status + pool ID via snmpd extend (Linux)

### DIFF
--- a/modules/linux_snmpd/files/snmp_check_gw.sh
+++ b/modules/linux_snmpd/files/snmp_check_gw.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Reports generic-worker process status for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend gw_status /usr/local/bin/snmp_check_gw.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."gw_status"
+if pgrep -f '/generic-worker' >/dev/null 2>&1; then
+  echo "OK - generic-worker running"
+  exit 0
+fi
+echo "CRIT - generic-worker not running"
+exit 2

--- a/modules/linux_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/linux_snmpd/files/snmp_worker_pool_id.sh
@@ -2,17 +2,29 @@
 # Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
 # Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
 # Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
-# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to InfluxDB
-# as a host_pool record (the same downstream consumer as the Windows pool ID check).
-CONFIG=/etc/generic-worker.config
+#
+# Reads from /etc/start-worker.yml (the worker-runner config). The
+# generic-worker config at /etc/generic-worker.config is *generated
+# just-in-time* per task and isn't reliably present at poll time, so we
+# pull the pool ID from the always-present worker-runner config instead.
+#
+# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to
+# InfluxDB as a host_pool record (same downstream consumer as the
+# Windows/Mac pool ID checks).
+CONFIG=/etc/start-worker.yml
 if [ ! -f "$CONFIG" ]; then
   echo "UNKNOWN - $CONFIG not found"
   exit 3
 fi
-POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
-if [ -z "$POOL" ]; then
-  echo "UNKNOWN - workerType not set in $CONFIG"
+# workerPoolID is typically "<provisionerId>/<workerType>" (e.g.
+# "releng-hardware/gecko-t-linux-talos-1804"). Strip the provisionerId
+# prefix so the pool name alone is exposed (matches Windows/host_pool
+# semantics, where pool == workerType).
+RAW=$(sed -nE 's/^[[:space:]]*workerPoolID:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/p' "$CONFIG" | head -1)
+if [ -z "$RAW" ]; then
+  echo "UNKNOWN - workerPoolID not set in $CONFIG"
   exit 3
 fi
+POOL="${RAW##*/}"
 echo "OK - worker_pool_id=$POOL"
 exit 0

--- a/modules/linux_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/linux_snmpd/files/snmp_worker_pool_id.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
+# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to InfluxDB
+# as a host_pool record (the same downstream consumer as the Windows pool ID check).
+CONFIG=/etc/generic-worker.config
+if [ ! -f "$CONFIG" ]; then
+  echo "UNKNOWN - $CONFIG not found"
+  exit 3
+fi
+POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
+if [ -z "$POOL" ]; then
+  echo "UNKNOWN - workerType not set in $CONFIG"
+  exit 3
+fi
+echo "OK - worker_pool_id=$POOL"
+exit 0

--- a/modules/linux_snmpd/manifests/init.pp
+++ b/modules/linux_snmpd/manifests/init.pp
@@ -37,6 +37,16 @@ class linux_snmpd {
                   content => template('linux_snmpd/snmpd.conf.erb'),
                   mode    => '0644',
                   notify  => Service['snmpd'];
+
+                '/usr/local/bin/snmp_check_gw.sh':
+                  ensure => file,
+                  source => "puppet:///modules/${module_name}/snmp_check_gw.sh",
+                  mode   => '0755';
+
+                '/usr/local/bin/snmp_worker_pool_id.sh':
+                  ensure => file,
+                  source => "puppet:///modules/${module_name}/snmp_worker_pool_id.sh",
+                  mode   => '0755';
               }
             }
             else {

--- a/modules/linux_snmpd/templates/snmpd.conf.erb
+++ b/modules/linux_snmpd/templates/snmpd.conf.erb
@@ -10,3 +10,8 @@ sysContact     "relops@mozilla.com"
 view   all         included   .1
 # set a SNMPv1/v2c read-only community (default source) and tie to 'all' view
 rocommunity <%= @snmpd_ro_secret %> default -V all
+
+# expose generic-worker process status and worker pool ID to marlin via
+# NET-SNMP-EXTEND-MIB::nsExtendOutputFull."<token>"
+extend gw_status       /usr/local/bin/snmp_check_gw.sh
+extend worker_pool_id  /usr/local/bin/snmp_worker_pool_id.sh


### PR DESCRIPTION
## Summary

Adds two snmpd `extend`-backed scripts so marlin can poll Linux workers over SNMP for:

- **`gw_status`** — whether `generic-worker` is running (`pgrep -f /generic-worker`).
- **`worker_pool_id`** — the worker's pool ID (`workerType`) read from `/etc/generic-worker.config`.

Both pieces are consumed by the existing marlin Status/Metrics dashboards (RelSRE → FXCI Hardware Workers → Linux). Windows already exposes equivalents via NSCP/NRPE (PR mozilla-it/marlin#16); this PR brings Linux to parity.

## Files

- `modules/linux_snmpd/files/snmp_check_gw.sh` (new)
- `modules/linux_snmpd/files/snmp_worker_pool_id.sh` (new)
- `modules/linux_snmpd/manifests/init.pp` — deploys the two scripts to `/usr/local/bin/`
- `modules/linux_snmpd/templates/snmpd.conf.erb` — adds two `extend` lines

## Companion PRs

- **marlin: mozilla-it/marlin#17** — adds the Icinga service definitions, the wrapper script that snmpgets the worker_pool_id and writes to InfluxDB's host_pool measurement, and the Mac counterpart in marlin.
- **Mac (separate ronin PR, coming next):** new \`macos_snmpd\` module using \`packages::macos_package_from_s3\` to install net-snmp from the standard S3 bucket.

## Test plan

- [ ] After merge + a puppet run on a Linux moonshot host: `/usr/local/bin/snmp_check_gw.sh` and `/usr/local/bin/snmp_worker_pool_id.sh` exist and exit 0
- [ ] From marlin1: `snmpget -v2c -c <community> -O qv <host> 'NET-SNMP-EXTEND-MIB::nsExtendOutputFull.\"gw_status\"'` returns `OK - generic-worker running`
- [ ] Same query for `worker_pool_id` returns `OK - worker_pool_id=<pool>`
- [ ] In IcingaWeb2 (once mozilla-it/marlin#17 is also merged) services `Linux Generic Worker` + `Linux Worker Pool ID` appear OK
- [ ] Flux query against `marlin-icinga2` returns `host_pool` records for `t-linux64-ms-*` hostnames