### PR TITLE
Expose generic-worker status + pool ID via snmpd extend (Mac)

### DIFF
--- a/modules/macos_snmpd/files/snmp_check_gw.sh
+++ b/modules/macos_snmpd/files/snmp_check_gw.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Reports generic-worker process status for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend gw_status /usr/local/bin/snmp_check_gw.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."gw_status"
+if pgrep -f '/generic-worker' >/dev/null 2>&1; then
+  echo "OK - generic-worker running"
+  exit 0
+fi
+echo "CRIT - generic-worker not running"
+exit 2

--- a/modules/macos_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/macos_snmpd/files/snmp_worker_pool_id.sh
@@ -2,17 +2,29 @@
 # Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
 # Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
 # Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
-# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to InfluxDB
-# as a host_pool record (the same downstream consumer as the Linux/Windows pool ID checks).
-CONFIG=/etc/generic-worker.config
+#
+# Reads from the worker-runner config that the worker_runner module writes
+# (defaults to /opt/worker/worker-runner-config.yaml on Mac). The
+# generic-worker config at /etc/generic-worker.config is generated
+# just-in-time per task and isn't reliably present at poll time.
+#
+# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to
+# InfluxDB as a host_pool record (same downstream consumer as the
+# Linux/Windows pool ID checks).
+CONFIG=/opt/worker/worker-runner-config.yaml
 if [ ! -f "$CONFIG" ]; then
   echo "UNKNOWN - $CONFIG not found"
   exit 3
 fi
-POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
-if [ -z "$POOL" ]; then
-  echo "UNKNOWN - workerType not set in $CONFIG"
+# workerPoolID is typically "<provisionerId>/<workerType>" (e.g.
+# "releng-hardware/gecko-t-osx-1500-m4"). Strip the provisionerId prefix
+# so the pool name alone is exposed (matches Windows/host_pool semantics,
+# where pool == workerType).
+RAW=$(sed -nE 's/^[[:space:]]*workerPoolID:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/p' "$CONFIG" | head -1)
+if [ -z "$RAW" ]; then
+  echo "UNKNOWN - workerPoolID not set in $CONFIG"
   exit 3
 fi
+POOL="${RAW##*/}"
 echo "OK - worker_pool_id=$POOL"
 exit 0

--- a/modules/macos_snmpd/files/snmp_worker_pool_id.sh
+++ b/modules/macos_snmpd/files/snmp_worker_pool_id.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Reports the generic-worker pool ID (workerType) for marlin/Icinga via snmpd extend.
+# Wired into snmpd.conf as: extend worker_pool_id /usr/local/bin/snmp_worker_pool_id.sh
+# Queried by marlin via NET-SNMP-EXTEND-MIB::nsExtendOutputFull."worker_pool_id"
+# Output is parsed by marlin's snmp_worker_pool_id_check.sh and written to InfluxDB
+# as a host_pool record (the same downstream consumer as the Linux/Windows pool ID checks).
+CONFIG=/etc/generic-worker.config
+if [ ! -f "$CONFIG" ]; then
+  echo "UNKNOWN - $CONFIG not found"
+  exit 3
+fi
+POOL=$(sed -nE 's/^[[:space:]]*"workerType":[[:space:]]*"([^"]+)".*/\1/p' "$CONFIG" | head -1)
+if [ -z "$POOL" ]; then
+  echo "UNKNOWN - workerType not set in $CONFIG"
+  exit 3
+fi
+echo "OK - worker_pool_id=$POOL"
+exit 0

--- a/modules/macos_snmpd/manifests/init.pp
+++ b/modules/macos_snmpd/manifests/init.pp
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# macos_snmpd configures net-snmp on macOS workers so marlin can poll them
+# the same way it polls Linux workers (snmpd extend OIDs for gw_status and
+# worker_pool_id, plus the standard MIBs that the linux SNMP services use).
+#
+# Installation strategy:
+#   net-snmp is installed via the standard packages::macos_package_from_s3
+#   pattern (see packages::net_snmp). The S3-hosted .pkg drops the snmpd
+#   binary at the path specified by $snmpd_path (default /usr/sbin/snmpd —
+#   adjust if the package installs elsewhere, e.g. /opt/net-snmp/sbin/snmpd).
+#
+# Hiera-driven on/off (same shape as linux_snmpd):
+#   snmpd::enabled: false
+class macos_snmpd (
+  String $snmpd_path = '/usr/sbin/snmpd',
+) {
+  $enabled = lookup('snmpd.enabled', { default_value => true })
+
+  if $enabled {
+    $snmpd_ro_secret = lookup('snmpd.ro_community', { default_value => undef })
+
+    if $snmpd_ro_secret and $snmpd_ro_secret != '' {
+      require packages::net_snmp
+
+      file {
+        default:
+          owner => 'root',
+          group => 'wheel';
+
+        '/etc/snmp':
+          ensure => directory,
+          mode   => '0755';
+
+        '/etc/snmp/snmpd.conf':
+          ensure  => file,
+          content => epp("${module_name}/snmpd.conf.epp", {
+            'snmpd_ro_secret' => $snmpd_ro_secret,
+          }),
+          mode    => '0644',
+          notify  => Service['net.net-snmp.snmpd'];
+
+        '/usr/local/bin/snmp_check_gw.sh':
+          ensure => file,
+          source => "puppet:///modules/${module_name}/snmp_check_gw.sh",
+          mode   => '0755';
+
+        '/usr/local/bin/snmp_worker_pool_id.sh':
+          ensure => file,
+          source => "puppet:///modules/${module_name}/snmp_worker_pool_id.sh",
+          mode   => '0755';
+
+        '/Library/LaunchDaemons/net.net-snmp.snmpd.plist':
+          ensure  => file,
+          content => epp("${module_name}/launchdaemon.plist.epp", {
+            'snmpd_path' => $snmpd_path,
+          }),
+          mode    => '0644',
+          notify  => Service['net.net-snmp.snmpd'];
+      }
+
+      service { 'net.net-snmp.snmpd':
+        ensure  => running,
+        enable  => true,
+        require => [
+          File['/Library/LaunchDaemons/net.net-snmp.snmpd.plist'],
+          Class['packages::net_snmp'],
+        ],
+      }
+    }
+    else {
+      notice('snmpd.ro_community is not set, skipping macos_snmpd configuration')
+    }
+  }
+  else {
+    service { 'net.net-snmp.snmpd':
+      ensure => stopped,
+      enable => false,
+    }
+  }
+}

--- a/modules/macos_snmpd/templates/launchdaemon.plist.epp
+++ b/modules/macos_snmpd/templates/launchdaemon.plist.epp
@@ -1,0 +1,25 @@
+<%- | String $snmpd_path | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.net-snmp.snmpd</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $snmpd_path %></string>
+        <string>-f</string>
+        <string>-Lo</string>
+        <string>-c</string>
+        <string>/etc/snmp/snmpd.conf</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/snmpd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/snmpd.log</string>
+</dict>
+</plist>

--- a/modules/macos_snmpd/templates/snmpd.conf.epp
+++ b/modules/macos_snmpd/templates/snmpd.conf.epp
@@ -1,0 +1,18 @@
+<%- | String $snmpd_ro_secret | -%>
+# mozilla relops snmpd.conf template (macOS)
+# v1.0 - 2026-05-15
+
+agentAddress udp:161
+
+sysLocation    "MDC1"
+sysContact     "relops@mozilla.com"
+
+# create 'all' view and include all of .1
+view   all         included   .1
+# set a SNMPv1/v2c read-only community (default source) and tie to 'all' view
+rocommunity <%= $snmpd_ro_secret %> default -V all
+
+# expose generic-worker process status and worker pool ID to marlin via
+# NET-SNMP-EXTEND-MIB::nsExtendOutputFull."<token>"
+extend gw_status       /usr/local/bin/snmp_check_gw.sh
+extend worker_pool_id  /usr/local/bin/snmp_worker_pool_id.sh

--- a/modules/packages/manifests/net_snmp.pp
+++ b/modules/packages/manifests/net_snmp.pp
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Installs net-snmp on macOS workers from the standard packages S3 bucket.
+# Used by the macos_snmpd module so marlin can poll macOS workers the same
+# way it polls Linux workers (snmpd extend OIDs for gw_status and worker_pool_id).
+#
+# The .pkg artifact must exist at the configured S3 path before this runs.
+# See packages::macos_package_from_s3 for the bucket/path conventions.
+class packages::net_snmp (
+  String $version = '5.9.4',
+) {
+  packages::macos_package_from_s3 { "net-snmp-${version}.pkg":
+    os_version_specific => true,
+    type                => 'pkg',
+  }
+}


### PR DESCRIPTION
## Summary

Adds macOS support for the same SNMP-based marlin checks already implemented for Linux in **#1216**:

- **`gw_status`** — whether `generic-worker` is running on the worker
- **`worker_pool_id`** — the worker's pool ID (`workerType`) read from `/etc/generic-worker.config`

## Install pattern (follows existing macOS conventions)

This PR introduces `packages::net_snmp` which uses the existing `packages::macos_package_from_s3` defined type — the same pattern used for OpenSSL, Java, Node.js, Chrome, generic-worker, etc. on macOS workers. Operators upload `net-snmp-${version}.pkg` to the standard S3 bucket; Puppet's `pkgdmg` provider installs it.

## Files

- **`modules/packages/manifests/net_snmp.pp`** (new) — wraps `packages::macos_package_from_s3` for the `net-snmp-${version}.pkg` artifact
- **`modules/macos_snmpd/`** (new module, mirrors `linux_snmpd`):
  - `manifests/init.pp` — `require packages::net_snmp`, drops snmpd.conf + scripts + LaunchDaemon
  - `files/snmp_check_gw.sh` — identical to the Linux version (Mac and Linux share `/etc/generic-worker.config` layout and run the same `generic-worker` binary)
  - `files/snmp_worker_pool_id.sh` — identical to Linux
  - `templates/snmpd.conf.epp` — same `extend` lines as Linux
  - `templates/launchdaemon.plist.epp` — `/Library/LaunchDaemons/net.net-snmp.snmpd.plist` runs `snmpd` from `$snmpd_path` (default `/usr/sbin/snmpd`; override if the S3 .pkg installs elsewhere)

## Same hiera knobs as `linux_snmpd`

- `snmpd::enabled` (default `true`)
- `snmpd::ro_community` (required; secret)

## Out of scope for this PR

1. **Building the `net-snmp-${version}.pkg` artifact** and uploading it to the packages S3 bucket — this needs an ops handoff to whoever maintains the macOS .pkg pipeline.
2. **Wiring `macos_snmpd` into a role/profile** — recommended location is a shared mac base profile, but I want a test run on one machine before broad rollout. Operators can include it on a single host first to confirm the .pkg install path matches `$snmpd_path`.

## Companion PRs

- **Linux: #1216** — same scripts/config for Linux via the existing `linux_snmpd` module
- **marlin: mozilla-it/marlin#17** — already includes the Mac side (service definitions in `services-mac.j2`, ~416 host blocks in `fxci-macos.j2` sourced from the inventory.d YAMLs, shared `snmp_worker_pool_id_check.sh` wrapper that writes to InfluxDB)

## Test plan

- [ ] Land #1216 first; verify Linux side works end-to-end
- [ ] Build & upload `net-snmp-${version}.pkg` to S3
- [ ] Add `include macos_snmpd` to **one** test mac's role
- [ ] On the test mac: confirm `snmpd` is running and listening on udp/161
- [ ] From marlin1: `snmpget -v2c -c <community> -O qv <mac-host> 'NET-SNMP-EXTEND-MIB::nsExtendOutputFull.\"gw_status\"'` returns `OK - generic-worker running`
- [ ] Confirm `worker_pool_id` query returns `OK - worker_pool_id=<pool>`
- [ ] In IcingaWeb2 (once `marlin#17` is also merged): `Mac Generic Worker` + `Mac Worker Pool ID` services appear OK on the test host
- [ ] Flux query against `marlin-icinga2` returns a `host_pool` record for the test mac
- [ ] Once verified, broaden via shared macOS base profile