### PR TITLE
RELOPS-2372: bump NVIDIA A10 GRID driver to 573.96 (vGPU 18.x)

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -99,8 +99,8 @@ windows:
     name: "538.15_grid_win10_win11_server2019_server2022_dch_64bit_international_azure_swl"
     display_name: "NVIDIA Graphics Driver 538.15"
   gpu_a10:
-    name: "553.62_grid_win10_win11_server2019_server2022_dch_64bit_international_azure_swl"
-    display_name: "NVIDIA Graphics Driver 553.62"
+    name: "573.96_grid_win10_win11_server2022_server2025_dch_64bit_international_azure_swl"
+    display_name: "NVIDIA Graphics Driver 573.96"
   hg:
     version: '6.9'
   nssm:

--- a/test/integration/win116425h2azure/serverspec/role_specific_profiles_spec.rb
+++ b/test/integration/win116425h2azure/serverspec/role_specific_profiles_spec.rb
@@ -6,8 +6,13 @@ if WORKER_FUNCTION == 'tester'
   gpu_key = ROLE_NAME == 'win116425h2azure' ? 'gpu_a10' : 'gpu'
   driver_name = expected_hiera_value(gpu_key, 'name')
 
+  # GRID install completes only after reboot, which kitchen does not perform
+  # mid-converge. Full install + nvidia-smi verification has to happen as part
+  # of worker image validation on a real A10 pool. The size check catches the
+  # case where the blob mirror returns a placeholder or 0-byte file.
   describe file("C:\\Windows\\Temp\\#{driver_name}.exe") do
     it { should exist }
+    its(:size) { should be > 100_000_000 }
   end
 end
 

--- a/test/integration/win116425h2azure/serverspec/role_specific_profiles_spec.rb
+++ b/test/integration/win116425h2azure/serverspec/role_specific_profiles_spec.rb
@@ -9,10 +9,17 @@ if WORKER_FUNCTION == 'tester'
   # GRID install completes only after reboot, which kitchen does not perform
   # mid-converge. Full install + nvidia-smi verification has to happen as part
   # of worker image validation on a real A10 pool. The size check catches the
-  # case where the blob mirror returns a placeholder or 0-byte file.
+  # case where the blob mirror returns a placeholder or 0-byte file. Serverspec
+  # on the winrm backend does not implement file.size, so we shell out.
   describe file("C:\\Windows\\Temp\\#{driver_name}.exe") do
     it { should exist }
-    its(:size) { should be > 100_000_000 }
+  end
+
+  describe powershell_command(
+    "if ((Get-Item 'C:\\Windows\\Temp\\#{driver_name}.exe').Length -gt 100000000) " \
+    "{ exit 0 } else { exit 1 }"
+  ) do
+    its(:exit_status) { should eq 0 }
   end
 end
 


### PR DESCRIPTION
## Summary

- Bumps `gpu_a10` in `data/os/Windows.yaml` from GRID 553.62 (vGPU 17.x) to 573.96 (vGPU 18.x) ahead of Azure's 2026-06-15 deadline for NVadsA10_v5 VMs (Service Health tracking ID `0YSB-WGZ`). After that date, Azure begins rolling out the vGPU 20.x (R595.x) host driver, which is incompatible with anything older than 18.x.
- 573.96 is the current Azure-redistributed GRID 18.6 build for Windows 11 25H2. The installer no longer carries Server 2019 in its filename (vGPU 18.x dropped 2019 support); the 25H2 pool does not run Server 2019, so this is a no-op for us.
- Strengthens the kitchen serverspec for `win116425h2azure` to assert the downloaded installer is `> 100 MB`. The previous check only confirmed the file existed, which would still pass if the blob mirror served a placeholder or 0-byte file.

## Blockers before merge

- The `573.96_grid_win10_win11_server2022_server2025_dch_64bit_international_azure_swl.exe` installer must be uploaded to the `windows.ext_pkg_src` Azure blob mirror first. Source: [Azure N-series Windows driver setup](https://learn.microsoft.com/azure/virtual-machines/windows/n-series-driver-setup) ([direct link](https://download.microsoft.com/download/f7ca3c43-8f24-4365-a4cc-d528574858a8/573.96_grid_win10_win11_server2022_server2025_dch_64bit_international_azure_swl.exe)).
- Without the binary in place, puppet's `file { $driver_exe: source => ... }` will fail during converge.

## Test plan

- [ ] Upload 573.96 installer to the Azure blob backing `windows.ext_pkg_src`
- [ ] CI: `kitchen-windows.yml` converge + verify on `win11-64-25h2`
- [ ] Build `win11-64-25h2-gpu` worker image with the new driver
- [ ] Validate the new image on the alpha pool: confirm `nvidia-smi` returns version `573.96` after first boot
- [ ] Promote to production before 2026-06-15

## Out of scope

- The `gpu.*` entry (538.15) used by `win11-64-24h2-gpu` via `win116424h2azure`. Need to confirm whether that pool runs on A10 hardware. If it does, it needs the same upgrade. Tracked on RELOPS-2372.