### PR TITLE
linux talos: install linux-tools + allow cltbld sudo perf (bug 2031822)

### DIFF
--- a/modules/linux_packages/manifests/linux_tools.pp
+++ b/modules/linux_packages/manifests/linux_tools.pp
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class linux_packages::linux_tools {
+
+    package { 'linux-tools-generic':
+        ensure => present,
+    }
+
+}

--- a/modules/roles_profiles/manifests/profiles/linux_perf_profiling.pp
+++ b/modules/roles_profiles/manifests/profiles/linux_perf_profiling.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Installs the linux-tools package (provides `perf`) and grants cltbld
+# sudo access to run it. Used by Linux talos roles to support performance
+# profiling investigations (bug 2031822).
+class roles_profiles::profiles::linux_perf_profiling {
+
+  require linux_packages::linux_tools
+
+  sudo::custom { 'allow_cltbld_perf':
+    user    => 'cltbld',
+    command => '/usr/bin/perf',
+  }
+
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_linux_2404_talos.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_linux_2404_talos.pp
@@ -18,4 +18,7 @@ class roles_profiles::roles::gecko_t_linux_2404_talos {
 
   # talos stuff
   include roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker
+
+  # perf profiling support (bug 2031822)
+  include roles_profiles::profiles::linux_perf_profiling
 }

--- a/modules/roles_profiles/manifests/roles/gecko_t_linux_talos.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_linux_talos.pp
@@ -19,4 +19,7 @@ class roles_profiles::roles::gecko_t_linux_talos {
 
     # talos stuff
     include ::roles_profiles::profiles::gecko_t_linux_talos_generic_worker
+
+    # perf profiling support (bug 2031822)
+    include ::roles_profiles::profiles::linux_perf_profiling
 }


### PR DESCRIPTION
Adds a linux_perf_profiling profile to the 1804 and 2404 talos roles
that installs linux-tools-generic and grants cltbld NOPASSWD sudo on
/usr/bin/perf, to support Speedometer3 bimodality profiling.

See https://bugzilla.mozilla.org/show_bug.cgi?id=2031822 and https://mozilla-hub.atlassian.net/browse/RELOPS-2363.