### PR TITLE
mozillavpn osx workers: install CoreSimulator RuntimeMap override (iOS 26.2 -> 26.3.1 runtime)

### DIFF
--- a/modules/macos_coresimulator_runtime_map/files/RuntimeMap.plist
+++ b/modules/macos_coresimulator_runtime_map/files/RuntimeMap.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>preferredRuntimes</key>
+    <dict/>
+    <key>userOverrides</key>
+    <dict>
+        <key>iphoneos26.2</key>
+        <dict>
+            <key>23C57</key>
+            <string>23D8133</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/modules/macos_coresimulator_runtime_map/files/com.mozilla.coresim-runtimemap-sync.plist
+++ b/modules/macos_coresimulator_runtime_map/files/com.mozilla.coresim-runtimemap-sync.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.coresim-runtimemap-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/coresim_runtimemap_sync.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WatchPaths</key>
+    <array>
+        <string>/Users</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/var/log/coresim-runtimemap-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/coresim-runtimemap-sync.log</string>
+    <key>ThrottleInterval</key>
+    <integer>1</integer>
+</dict>
+</plist>

--- a/modules/macos_coresimulator_runtime_map/files/coresim_runtimemap_sync.sh
+++ b/modules/macos_coresimulator_runtime_map/files/coresim_runtimemap_sync.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Apple's CoreSimulator framework reads its SDK->runtime override map
+# strictly from ~/Library/Developer/CoreSimulator/RuntimeMap.plist; the
+# system path /Library/Developer/CoreSimulator/RuntimeMap.plist is not
+# honored. generic-worker-multiuser spawns a fresh task_<id> user per
+# task whose home has no RuntimeMap.plist, so the override does not
+# apply and ibtool fails with "iOS 26.2 Platform Not Installed".
+#
+# This script copies the canonical RuntimeMap.plist from /Library/...
+# into each existing task_* user's home, fixing ownership/mode. It is
+# invoked by a LaunchDaemon whose WatchPaths is /Users, so it runs
+# within ~1s of generic-worker creating a new task user.
+#
+# Removable once Apple ships an Xcode/runtime pair without the
+# 23C57 (unavailable) <-> 23D8133 (available) mismatch.
+
+set -eu
+
+SRC="/Library/Developer/CoreSimulator/RuntimeMap.plist"
+
+if [ ! -f "$SRC" ]; then
+  exit 0
+fi
+
+for home in /Users/task_*; do
+  [ -d "$home" ] || continue
+  user="$(basename "$home")"
+
+  if ! dscl . -read "/Users/${user}" >/dev/null 2>&1; then
+    continue
+  fi
+
+  dst="${home}/Library/Developer/CoreSimulator/RuntimeMap.plist"
+  if [ -f "$dst" ] && cmp -s "$SRC" "$dst"; then
+    continue
+  fi
+
+  install -d -o "$user" -g staff -m 0755 "${home}/Library/Developer/CoreSimulator"
+  install -m 0644 -o "$user" -g staff "$SRC" "$dst"
+done

--- a/modules/macos_coresimulator_runtime_map/manifests/init.pp
+++ b/modules/macos_coresimulator_runtime_map/manifests/init.pp
@@ -3,19 +3,25 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # @summary
-#   Drops /Library/Developer/CoreSimulator/RuntimeMap.plist with an iOS SDK
-#   build -> simulator runtime build override.
+#   Ensures Apple's CoreSimulator RuntimeMap override (iphoneos26.2 ->
+#   runtime build 23D8133) is in every generic-worker task user's home
+#   directory.
 #
-#   Xcode 26.2/26.3 ships with the iphoneos26.2 SDK whose paired runtime build
-#   (23C57) Apple no longer serves; only the newer 23D8133 (iOS 26.3.1) runtime
-#   is downloadable via `xcodebuild -downloadPlatform iOS`. Without the
-#   override, ibtool refuses to compile storyboards with
-#   "iOS 26.2 Platform Not Installed".
+#   Xcode 26.2 / 26.3 ships the iphoneos26.2 SDK paired with iOS
+#   simulator runtime build 23C57, which Apple no longer serves. Only
+#   23D8133 (iOS 26.3.1) is downloadable via `xcodebuild
+#   -downloadPlatform iOS`. Without an override, ibtool refuses to
+#   compile the LaunchScreen storyboard during build-ios-arm64/debug:
 #
-#   This file is the equivalent of running:
-#     xcrun simctl runtime match set iphoneos26.2 23D8133
-#   ...but placed at the system path so it applies to the ephemeral per-task
-#   users that generic-worker-multiuser spawns for builds.
+#     error: iOS 26.2 Platform Not Installed.
+#
+#   CoreSimulator reads its override map strictly from
+#   ~/Library/Developer/CoreSimulator/RuntimeMap.plist; the
+#   /Library/Developer/CoreSimulator/... path is ignored. Because
+#   generic-worker-multiuser creates a fresh task_<id> user per task,
+#   we keep the canonical file under /Library/... and use a LaunchDaemon
+#   triggered on /Users/ changes to copy it into each new task user's
+#   home before the build runs.
 #
 class macos_coresimulator_runtime_map (
   Boolean $enabled = true,
@@ -23,6 +29,9 @@ class macos_coresimulator_runtime_map (
   if $enabled {
     case $facts['os']['name'] {
       'Darwin': {
+        $sync_script        = '/usr/local/bin/coresim_runtimemap_sync.sh'
+        $launchdaemon_plist = '/Library/LaunchDaemons/com.mozilla.coresim-runtimemap-sync.plist'
+
         file { '/Library/Developer/CoreSimulator':
           ensure => 'directory',
           owner  => 'root',
@@ -37,6 +46,35 @@ class macos_coresimulator_runtime_map (
           group   => 'wheel',
           mode    => '0644',
           require => File['/Library/Developer/CoreSimulator'],
+        }
+
+        file { $sync_script:
+          ensure => 'file',
+          source => 'puppet:///modules/macos_coresimulator_runtime_map/coresim_runtimemap_sync.sh',
+          owner  => 'root',
+          group  => 'wheel',
+          mode   => '0755',
+        }
+
+        file { $launchdaemon_plist:
+          ensure  => 'file',
+          source  => 'puppet:///modules/macos_coresimulator_runtime_map/com.mozilla.coresim-runtimemap-sync.plist',
+          owner   => 'root',
+          group   => 'wheel',
+          mode    => '0644',
+          require => [
+            File[$sync_script],
+            File['/Library/Developer/CoreSimulator/RuntimeMap.plist'],
+          ],
+          notify  => Exec['load coresim-runtimemap-sync launchdaemon'],
+        }
+
+        exec { 'load coresim-runtimemap-sync launchdaemon':
+          command     => "/bin/launchctl bootstrap system ${launchdaemon_plist}",
+          unless      => '/bin/launchctl print system/com.mozilla.coresim-runtimemap-sync',
+          path        => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
+          require     => File[$launchdaemon_plist],
+          refreshonly => false,
         }
       }
       default: {

--- a/modules/macos_coresimulator_runtime_map/manifests/init.pp
+++ b/modules/macos_coresimulator_runtime_map/manifests/init.pp
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# @summary
+#   Drops /Library/Developer/CoreSimulator/RuntimeMap.plist with an iOS SDK
+#   build -> simulator runtime build override.
+#
+#   Xcode 26.2/26.3 ships with the iphoneos26.2 SDK whose paired runtime build
+#   (23C57) Apple no longer serves; only the newer 23D8133 (iOS 26.3.1) runtime
+#   is downloadable via `xcodebuild -downloadPlatform iOS`. Without the
+#   override, ibtool refuses to compile storyboards with
+#   "iOS 26.2 Platform Not Installed".
+#
+#   This file is the equivalent of running:
+#     xcrun simctl runtime match set iphoneos26.2 23D8133
+#   ...but placed at the system path so it applies to the ephemeral per-task
+#   users that generic-worker-multiuser spawns for builds.
+#
+class macos_coresimulator_runtime_map (
+  Boolean $enabled = true,
+) {
+  if $enabled {
+    case $facts['os']['name'] {
+      'Darwin': {
+        file { '/Library/Developer/CoreSimulator':
+          ensure => 'directory',
+          owner  => 'root',
+          group  => 'wheel',
+          mode   => '0755',
+        }
+
+        file { '/Library/Developer/CoreSimulator/RuntimeMap.plist':
+          ensure  => 'file',
+          content => file('macos_coresimulator_runtime_map/RuntimeMap.plist'),
+          owner   => 'root',
+          group   => 'wheel',
+          mode    => '0644',
+          require => File['/Library/Developer/CoreSimulator'],
+        }
+      }
+      default: {
+        fail("${module_name} does not support ${facts['os']['name']}")
+      }
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/macos_coresimulator_runtime_map.pp
+++ b/modules/roles_profiles/manifests/profiles/macos_coresimulator_runtime_map.pp
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class roles_profiles::profiles::macos_coresimulator_runtime_map {
+  class { 'macos_coresimulator_runtime_map':
+    enabled => true,
+  }
+}

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_1_osx.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::mozillavpn_b_1_osx {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_coresimulator_runtime_map
   include roles_profiles::profiles::macos_disable_firewall
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_run_puppet

--- a/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
+++ b/modules/roles_profiles/manifests/roles/mozillavpn_b_3_osx.pp
@@ -6,6 +6,7 @@ class roles_profiles::roles::mozillavpn_b_3_osx {
   include macos_utils::disable_bluetooth_setup
   include roles_profiles::profiles::gui
   include roles_profiles::profiles::hardware
+  include roles_profiles::profiles::macos_coresimulator_runtime_map
   include roles_profiles::profiles::macos_disable_firewall
   include roles_profiles::profiles::macos_people_remover
   include roles_profiles::profiles::macos_run_puppet


### PR DESCRIPTION
## Summary

Installs an iOS SDK→simulator-runtime override for the `iphoneos26.2` SDK on `mozillavpn_b_1_osx` and `mozillavpn_b_3_osx` workers so storyboard compilation succeeds during `build-ios-arm64/debug` under Xcode 26.2 / 26.3.

## Background

- Xcode 26.2 and 26.3 both ship the `iphoneos26.2` SDK.
- The SDK is paired with iOS simulator runtime build `23C57`.
- Apple no longer serves `23C57`; only `23D8133` (iOS 26.3.1) is available via `xcodebuild -downloadPlatform iOS`.
- Without an override, `ibtool` fails the build with:
  ```
  error: iOS 26.2 Platform Not Installed.
  ```

## Override mechanism

The override is the file form of:
```sh
xcrun simctl runtime match set iphoneos26.2 23D8133
```
which writes `~/Library/Developer/CoreSimulator/RuntimeMap.plist`.

**Key constraint**: Apple's CoreSimulator reads the override map **strictly per-user**. Verified on `macmini-r8-362` (Xcode 26.3, file dropped at `/Library/Developer/CoreSimulator/RuntimeMap.plist`):
- `aerickson` (no per-user file): `Chosen Runtime: 23C57` ← system file ignored
- `relops` (per-user file present): `Chosen Runtime: 23D8133` ← override applied

So a single system-wide file is not enough. `generic-worker-multiuser` creates a fresh `task_<id>` user per build, and that user starts with no `~/Library/Developer/CoreSimulator/RuntimeMap.plist`.

## Approach

1. Drop the canonical override at `/Library/Developer/CoreSimulator/RuntimeMap.plist` (single source of truth, root-owned).
2. Install `/usr/local/bin/coresim_runtimemap_sync.sh` that copies the canonical file into every `/Users/task_*/Library/Developer/CoreSimulator/RuntimeMap.plist`, owned by the task user.
3. Install `com.mozilla.coresim-runtimemap-sync` LaunchDaemon with `WatchPaths=/Users` and `RunAtLoad=true`. It fires within ~1s of generic-worker creating a task user, well before the build reaches ibtool. `ThrottleInterval=1` keeps it cheap if multiple users appear at once. Logs to `/var/log/coresim-runtimemap-sync.log`.

## Verification

End-to-end at the tool level on r8-362 (Xcode 26.3 + per-user override active):
- Real `ios/app/MozillaVPNLaunchScreen.storyboard` from `mozilla-mobile/mozilla-vpn-client` compiles with `ibtool` returning exit 0 and producing a valid `.storyboardc` + `Info.plist`. Same invocation that the failing CI builds use.

System-path-only verification on r8-362 confirmed `/Library/...` alone is insufficient — that's why this PR adds the LaunchDaemon to populate per-task-user homes.

## Scope

- `mozillavpn_b_1_osx` (workers r8-362, r8-373, r8-374)
- `mozillavpn_b_3_osx`

Only r8-362 currently has the Xcode/macOS combination this override targets. r8-373 / r8-374 are pinned to an older Xcode and fail for an unrelated reason (`LocalizedStringResource` Swift API mismatch). The override is a no-op on workers without the affected SDK — it only takes effect when an `iphoneos26.2` SDK whose default runtime is `23C57` is in use.

## Files added

- `modules/macos_coresimulator_runtime_map/manifests/init.pp`
- `modules/macos_coresimulator_runtime_map/files/RuntimeMap.plist`
- `modules/macos_coresimulator_runtime_map/files/coresim_runtimemap_sync.sh`
- `modules/macos_coresimulator_runtime_map/files/com.mozilla.coresim-runtimemap-sync.plist`
- `modules/roles_profiles/manifests/profiles/macos_coresimulator_runtime_map.pp`
- role includes in `mozillavpn_b_1_osx.pp` and `mozillavpn_b_3_osx.pp`

## Removal criteria

Once Apple ships an Xcode whose iOS SDK matches a runtime build that is still served (or the matching runtime is bundled with Xcode), this entire module can be removed.