### PR TITLE
linux 2404: install openbox and use Intel GPU (bug 2031822)

### DIFF
--- a/modules/linux_gui/files/20-intel-primary.conf
+++ b/modules/linux_gui/files/20-intel-primary.conf
@@ -1,0 +1,6 @@
+Section "Device"
+    Identifier "Intel P580"
+    Driver "modesetting"
+    BusID "PCI:0:2:0"
+    Option "PrimaryGPU" "true"
+EndSection

--- a/modules/linux_gui/manifests/init.pp
+++ b/modules/linux_gui/manifests/init.pp
@@ -269,6 +269,17 @@ class linux_gui (
             '/usr/share/X11/xorg.conf.d/50-display.conf':
               source => "puppet:///modules/${module_name}/50-display.conf";
 
+            '/etc/X11/xorg.conf.d':
+              ensure => directory,
+              owner  => 'root',
+              group  => 'root',
+              mode   => '0755';
+            '/etc/X11/xorg.conf.d/20-intel-primary.conf':
+              owner  => 'root',
+              group  => 'root',
+              mode   => '0644',
+              source => "puppet:///modules/${module_name}/20-intel-primary.conf";
+
             # make sure the builder user doesn't have any funny business
             ["${builder_home}/.xsession",
               "${builder_home}/.xinitrc",

--- a/modules/linux_packages/manifests/openbox.pp
+++ b/modules/linux_packages/manifests/openbox.pp
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class linux_packages::openbox {
+  case $facts['os']['name'] {
+    'Ubuntu': {
+      package {
+        'openbox':
+          ensure => latest;
+      }
+    }
+    default: {
+      fail("Cannot install on ${facts['os']['name']}")
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker.pp
@@ -29,6 +29,7 @@ class roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker {
       require linux_packages::tooltool
       require linux_packages::zstd
       require linux_packages::pulseaudio
+      require linux_packages::openbox
 
       # moved from base to avoid ordering issues with py2/3
       require linux_mercurial

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
@@ -29,6 +29,7 @@ class roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker_wayland 
       require linux_packages::tooltool
       require linux_packages::zstd
       require linux_packages::pulseaudio
+      require linux_packages::openbox
 
       # moved from base to avoid ordering issues with py2/3
       require linux_mercurial

--- a/modules/roles_profiles/manifests/roles/gecko_t_linux_2404_talos_wayland.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_linux_2404_talos_wayland.pp
@@ -18,4 +18,7 @@ class roles_profiles::roles::gecko_t_linux_2404_talos_wayland {
 
   # talos stuff
   include roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker_wayland
+
+  # perf profiling support (bug 2031822)
+  include roles_profiles::profiles::linux_perf_profiling
 }

--- a/test/integration/linux-perf/inspec/linux_gui_spec.rb
+++ b/test/integration/linux-perf/inspec/linux_gui_spec.rb
@@ -116,6 +116,16 @@ elsif os.family == 'debian' && os.release.start_with?('24.04')
     it { should exist }
   end
 
+  if ENV['MOZILLA_WAYLAND'] != '1'
+    describe file('/etc/X11/xorg.conf.d/20-intel-primary.conf') do
+      it { should exist }
+      its('content') { should match(/Identifier "Intel P580"/) }
+      its('content') { should match(/Driver "modesetting"/) }
+      its('content') { should match(/BusID "PCI:0:2:0"/) }
+      its('content') { should match(/Option "PrimaryGPU" "true"/) }
+    end
+  end
+
   describe file('/home/cltbld/.fonts.conf') do
     it { should exist }
   end


### PR DESCRIPTION
- Adds a linux_packages::openbox class and installs openbox on Ubuntu 24.04 Talos X11 and Wayland workers. 
- Forces xorg to use the Intel Iris graphics card.

Also includes the linux_perf_profiling profile on the Ubuntu 24.04 Talos Wayland role (missed in earlier patch).

See https://bugzilla.mozilla.org/show_bug.cgi?id=2031822 and https://mozilla-hub.atlassian.net/browse/RELOPS-2363.