### PR TITLE
RELOPS-2395 add cross-platform ronin SBOM module

### DIFF
--- a/.github/workflows/kitchen-windows.yml
+++ b/.github/workflows/kitchen-windows.yml
@@ -85,7 +85,7 @@ jobs:
           max_attempts=3
           for attempt in $(seq 1 $max_attempts); do
             echo "=== Attempt $attempt of $max_attempts ==="
-            if bundle exec kitchen test ${{ matrix.kitchen_instance }} -l debug; then
+            if bundle exec kitchen test ${{ matrix.kitchen_instance }} --destroy=never -l debug; then
               exit 0
             fi
             echo "::warning::Attempt $attempt failed (likely spot VM eviction)"
@@ -97,6 +97,51 @@ jobs:
           echo "::error::All $max_attempts attempts failed"
           exit 1
 
+      - name: Capture SBOM artifacts
+        if: always()
+        env:
+          KITCHEN_YAML: .kitchen_configs/kitchen.windows.yml
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          KITCHEN_ADMIN_PASSWORD: ${{ env.KITCHEN_ADMIN_PASSWORD }}
+          PUPPET_ROLE: ${{ matrix.role }}
+          WORKER_POOL_ID: ${{ matrix.worker_pool_id }}
+          RONIN_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set +e
+          mkdir -p test-results/sbom
+
+          read -r -d '' ps_script <<'POWERSHELL' || true
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path 'C:\sbom')) {
+              throw 'C:\sbom does not exist.'
+          }
+          Compress-Archive -Path 'C:\sbom\ronin-sbom.*' -DestinationPath 'C:\Windows\Temp\ronin-sbom.zip' -Force
+          Write-Output 'SBOM_ZIP_B64_START'
+          [Convert]::ToBase64String([IO.File]::ReadAllBytes('C:\Windows\Temp\ronin-sbom.zip'))
+          Write-Output 'SBOM_ZIP_B64_END'
+          POWERSHELL
+
+          encoded_script="$(printf '%s' "$ps_script" | iconv -f UTF-8 -t UTF-16LE | base64 -w0)"
+          output="$(bundle exec kitchen exec ${{ matrix.kitchen_instance }} -c "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $encoded_script" 2>&1)"
+          status=$?
+          printf '%s\n' "$output" > "test-results/sbom/kitchen-exec-${{ matrix.role }}.log"
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Unable to capture SBOM artifacts from ${{ matrix.kitchen_instance }}"
+            exit 0
+          fi
+
+          printf '%s\n' "$output" \
+            | awk '/SBOM_ZIP_B64_START/{capture=1;next}/SBOM_ZIP_B64_END/{capture=0}capture' \
+            | tr -d '\r\n' \
+            | base64 --decode > "test-results/sbom/ronin-sbom-${{ matrix.role }}.zip"
+
+          if [ ! -s "test-results/sbom/ronin-sbom-${{ matrix.role }}.zip" ]; then
+            echo "::warning::Captured SBOM artifact zip is empty"
+          fi
+
+          exit 0
+
       - name: Kitchen destroy
         if: always()
         env:
@@ -107,3 +152,11 @@ jobs:
           WORKER_POOL_ID: ${{ matrix.worker_pool_id }}
           RONIN_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: bundle exec kitchen destroy ${{ matrix.kitchen_instance }} -l debug
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-results-${{ matrix.role }}
+          path: test-results/
+          if-no-files-found: ignore

--- a/modules/roles_profiles/manifests/profiles/linux_base.pp
+++ b/modules/roles_profiles/manifests/profiles/linux_base.pp
@@ -27,6 +27,7 @@ class roles_profiles::profiles::linux_base {
 
       # should be requires above, but fight that battle another day
       include linux_snmpd
+      include roles_profiles::profiles::sbom
 
       # TODO:
       # - add auditd

--- a/modules/roles_profiles/manifests/profiles/packages_installed.pp
+++ b/modules/roles_profiles/manifests/profiles/packages_installed.pp
@@ -7,6 +7,7 @@ class roles_profiles::profiles::packages_installed {
     'Darwin': {
       $package_list = lookup('packages_classes', Array[String], 'unique', [])
       map ($package_list) | $package | { "packages::${package}" }.include
+      include roles_profiles::profiles::sbom
     }
     default: {
       fail("${facts['os']['name']} not supported")

--- a/modules/roles_profiles/manifests/profiles/sbom.pp
+++ b/modules/roles_profiles/manifests/profiles/sbom.pp
@@ -2,6 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class roles_profiles::profiles::macos_sbom {
-  include roles_profiles::profiles::sbom
+class roles_profiles::profiles::sbom {
+  stage { 'sbom':
+    require => Stage['main'],
+  }
+
+  class { 'ronin_sbom':
+    stage => 'sbom',
+  }
 }

--- a/modules/roles_profiles/manifests/profiles/worker.pp
+++ b/modules/roles_profiles/manifests/profiles/worker.pp
@@ -27,6 +27,7 @@ class roles_profiles::profiles::worker {
       # TODO: don't assume these are need with all workers. break out into another profile?
       include mercurial::system_hgrc
       include mercurial::ext::robustcheckout
+      include roles_profiles::profiles::sbom
     }
     default: {
       fail("${facts['os']['name']} not supported")

--- a/modules/roles_profiles/manifests/roles/win10642009azure.pp
+++ b/modules/roles_profiles/manifests/roles/win10642009azure.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win10642009azure {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win11642009azure.pp
+++ b/modules/roles_profiles/manifests/roles/win11642009azure.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win11642009azure {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win116424h2azure.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2azure.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win116424h2azure {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win116424h2hw.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hw.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hw {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   ## Install before Widnows Updates is disabled.
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwalpha.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwalpha.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwalpha {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   ## Install before Widnows Updates is disabled.
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwperfdebug.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwperfdebug.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwperfdebug {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   ## Install before Widnows Updates is disabled.
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwperfsheriff.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwperfsheriff.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwperfsheriff {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   ## Install before Widnows Updates is disabled.
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwref.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwref.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwref {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   # Install MS tools earlier
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwrefalpha.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwrefalpha.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwrefalpha {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   # Install MS tools earlier
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116424h2hwrelops1213.pp
+++ b/modules/roles_profiles/manifests/roles/win116424h2hwrelops1213.pp
@@ -1,4 +1,5 @@
 class roles_profiles::roles::win116424h2hwrelops1213 {
+  include roles_profiles::profiles::sbom
   include roles_profiles::profiles::chocolatey
   # Install before Widnows Updates is disabled.
   include roles_profiles::profiles::microsoft_tools

--- a/modules/roles_profiles/manifests/roles/win116425h2azure.pp
+++ b/modules/roles_profiles/manifests/roles/win116425h2azure.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win116425h2azure {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win11a6424h2azurebuilder.pp
+++ b/modules/roles_profiles/manifests/roles/win11a6424h2azurebuilder.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win11a6424h2azurebuilder {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     ## Include only what is needed in the catalog post bootstrap
     ## Saves minutes on workers first boot

--- a/modules/roles_profiles/manifests/roles/win11a6424h2azuretester.pp
+++ b/modules/roles_profiles/manifests/roles/win11a6424h2azuretester.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win11a6424h2azuretester {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win11a6425h2azurebuilder.pp
+++ b/modules/roles_profiles/manifests/roles/win11a6425h2azurebuilder.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win11a6425h2azurebuilder {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     ## Include only what is needed in the catalog post bootstrap
     ## Saves minutes on workers first boot

--- a/modules/roles_profiles/manifests/roles/win11a6425h2azuretester.pp
+++ b/modules/roles_profiles/manifests/roles/win11a6425h2azuretester.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win11a6425h2azuretester {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     'complete': {
       include roles_profiles::profiles::azure_vm_file_system

--- a/modules/roles_profiles/manifests/roles/win2022642009azure.pp
+++ b/modules/roles_profiles/manifests/roles/win2022642009azure.pp
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 class roles_profiles::roles::win2022642009azure {
+  include roles_profiles::profiles::sbom
   case $facts['custom_win_bootstrap_stage'] {
     ## Include only what is needed in the catalog post bootstrap
     ## Saves minutes on workers first boot

--- a/modules/ronin_sbom/files/generate_ronin_sbom.rb
+++ b/modules/ronin_sbom/files/generate_ronin_sbom.rb
@@ -275,12 +275,31 @@ def collect_users_and_groups(inv)
 end
 
 def collect_platform_packages(inv)
-  collect_homebrew(inv) if macos?
-  collect_pkgutil(inv) if macos?
+  collect_macos_applications(inv) if macos?
+  if macos? && ENV['RONIN_SBOM_COLLECT_DEEP_PACKAGES'] == 'true'
+    collect_homebrew(inv)
+    collect_pkgutil(inv)
+  end
   collect_dpkg(inv) if linux?
   collect_rpm(inv) if linux?
   collect_snap(inv) if linux?
   collect_windows_package_extras(inv) if windows?
+end
+
+def collect_macos_applications(inv)
+  [
+    '/Applications/*.app',
+    '/System/Applications/*.app',
+  ].flat_map { |pattern| Dir.glob(pattern) }.each do |path|
+    inv.component(
+      name: File.basename(path, '.app'),
+      type: 'application',
+      source: 'macos-application',
+      properties: {
+        path: path,
+      },
+    )
+  end
 end
 
 def collect_homebrew(inv)
@@ -519,8 +538,10 @@ def collect_configuration(inv)
     )
   end
 
-  collect_services(inv)
-  collect_users_and_groups(inv)
+  unless macos?
+    collect_services(inv)
+    collect_users_and_groups(inv)
+  end
 end
 
 def selected_files

--- a/modules/ronin_sbom/files/generate_ronin_sbom.rb
+++ b/modules/ronin_sbom/files/generate_ronin_sbom.rb
@@ -1,0 +1,831 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'optparse'
+require 'rbconfig'
+require 'securerandom'
+require 'socket'
+require 'time'
+require 'timeout'
+
+begin
+  require 'puppet'
+  require 'facter'
+rescue LoadError => e
+  warn("Puppet/OpenVox Ruby libraries were not available: #{e.message}")
+end
+
+VERSION = '2'
+
+class RoninSbom
+  attr_reader :components, :configuration, :errors
+
+  def initialize
+    @components = []
+    @configuration = []
+    @errors = []
+    @component_keys = {}
+    @configuration_keys = {}
+  end
+
+  def error(collector, message)
+    @errors << {
+      'collector' => collector.to_s,
+      'message' => message.to_s,
+    }
+  end
+
+  def component(name:, version: nil, type: 'application', source: nil, purl: nil, properties: {})
+    return if blank?(name)
+
+    key = [
+      type,
+      name.to_s.downcase,
+      version.to_s.downcase,
+      source.to_s.downcase,
+      properties.fetch('provider', '').to_s.downcase,
+    ].join('|')
+    return if @component_keys[key]
+
+    @component_keys[key] = true
+    record = {
+      'type' => type.to_s,
+      'name' => name.to_s,
+    }
+    record['version'] = version.to_s unless blank?(version)
+    record['purl'] = purl.to_s unless blank?(purl)
+
+    props = normalize_properties(properties)
+    props['source'] = source unless blank?(source)
+    record['properties'] = props.sort.map { |k, v| { 'name' => "ronin:#{k}", 'value' => v.to_s } } unless props.empty?
+    @components << record
+  end
+
+  def config(kind:, name:, source: nil, properties: {})
+    return if blank?(name)
+
+    key = [kind, name, source].map { |item| item.to_s.downcase }.join('|')
+    return if @configuration_keys[key]
+
+    @configuration_keys[key] = true
+    @configuration << {
+      'kind' => kind.to_s,
+      'name' => name.to_s,
+      'source' => source.to_s,
+      'properties' => normalize_properties(properties),
+    }
+  end
+
+  private
+
+  def blank?(value)
+    value.nil? || value.to_s.strip.empty?
+  end
+
+  def normalize_properties(properties)
+    properties.each_with_object({}) do |(key, value), memo|
+      next if value.nil? || value.to_s.empty?
+
+      memo[key.to_s] = value.to_s
+    end
+  end
+end
+
+def puppet_available?
+  defined?(Puppet) && defined?(Facter)
+end
+
+def init_puppet(inv)
+  return unless puppet_available?
+
+  Puppet.initialize_settings
+  Puppet::Util::Log.newdestination(:console)
+rescue StandardError => e
+  inv.error('puppet-init', e.message)
+end
+
+def fact_value(name)
+  return nil unless defined?(Facter)
+
+  value = Facter.value(name)
+  value.respond_to?(:to_h) ? value.to_h : value
+rescue StandardError
+  nil
+end
+
+def host_os
+  RbConfig::CONFIG['host_os']
+end
+
+def windows?
+  host_os =~ /mswin|mingw|cygwin/i
+end
+
+def macos?
+  host_os =~ /darwin/i
+end
+
+def linux?
+  host_os =~ /linux/i
+end
+
+def command(*args, timeout: 60)
+  Timeout.timeout(timeout) do
+    stdout, stderr, status = Open3.capture3(*args)
+    {
+      ok: status.success?,
+      stdout: stdout,
+      stderr: stderr,
+      exitstatus: status.exitstatus,
+    }
+  end
+rescue StandardError => e
+  {
+    ok: false,
+    stdout: '',
+    stderr: e.message,
+    exitstatus: nil,
+  }
+end
+
+def resource_value(resource, attribute)
+  value = resource[attribute]
+  return nil if value.nil?
+
+  value.respond_to?(:join) ? value.join(',') : value.to_s
+rescue StandardError
+  nil
+end
+
+def provider_name(resource)
+  provider = resource.provider
+  return nil unless provider
+
+  if provider.respond_to?(:name)
+    provider.name
+  elsif provider.class.respond_to?(:name)
+    provider.class.name.split('::').last
+  end
+rescue StandardError
+  nil
+end
+
+def collect_puppet_type(inv, type_name)
+  type = Puppet::Type.type(type_name)
+  return [] unless type
+
+  type.instances
+rescue StandardError => e
+  inv.error("puppet-ral-#{type_name}", e.message)
+  []
+end
+
+def collect_packages(inv)
+  collect_puppet_type(inv, :package).each do |package|
+    name = resource_value(package, :name) || package.title
+    ensure_value = resource_value(package, :ensure)
+    version = ensure_value unless %w[present installed latest].include?(ensure_value.to_s)
+    provider = provider_name(package)
+    purl = package_purl(name, version, provider)
+
+    inv.component(
+      name: name,
+      version: version,
+      type: 'application',
+      source: 'puppet-ral-package',
+      purl: purl,
+      properties: {
+        provider: provider,
+        ensure: ensure_value,
+      },
+    )
+  end
+end
+
+def package_purl(name, version, provider)
+  return nil if name.nil? || version.nil?
+
+  case provider.to_s
+  when /apt|dpkg/
+    "pkg:deb/debian/#{name}@#{version}"
+  when /yum|dnf|rpm/
+    "pkg:rpm/#{name}@#{version}"
+  when /gem/
+    "pkg:gem/#{name}@#{version}"
+  when /pip/
+    "pkg:pypi/#{name}@#{version}"
+  else
+    nil
+  end
+end
+
+def collect_services(inv)
+  collect_puppet_type(inv, :service).each do |service|
+    inv.config(
+      kind: 'service',
+      name: resource_value(service, :name) || service.title,
+      source: 'puppet-ral-service',
+      properties: {
+        provider: provider_name(service),
+        ensure: resource_value(service, :ensure),
+        enable: resource_value(service, :enable),
+      },
+    )
+  end
+end
+
+def collect_users_and_groups(inv)
+  collect_puppet_type(inv, :user).each do |user|
+    inv.config(
+      kind: 'user',
+      name: resource_value(user, :name) || user.title,
+      source: 'puppet-ral-user',
+      properties: {
+        uid: resource_value(user, :uid),
+        gid: resource_value(user, :gid),
+        home: resource_value(user, :home),
+        shell: resource_value(user, :shell),
+        provider: provider_name(user),
+      },
+    )
+  end
+
+  collect_puppet_type(inv, :group).each do |group|
+    inv.config(
+      kind: 'group',
+      name: resource_value(group, :name) || group.title,
+      source: 'puppet-ral-group',
+      properties: {
+        gid: resource_value(group, :gid),
+        provider: provider_name(group),
+      },
+    )
+  end
+end
+
+def collect_platform_packages(inv)
+  collect_homebrew(inv) if macos?
+  collect_pkgutil(inv) if macos?
+  collect_snap(inv) if linux?
+  collect_windows_package_extras(inv) if windows?
+end
+
+def collect_homebrew(inv)
+  brew = find_command('brew')
+  return unless brew
+
+  result = command(brew, 'list', '--versions', timeout: 120)
+  unless result[:ok]
+    inv.error('homebrew', result[:stderr])
+    return
+  end
+
+  result[:stdout].each_line do |line|
+    name, *versions = line.split
+    next if name.nil?
+
+    version = versions.join(',')
+    inv.component(
+      name: name,
+      version: version,
+      type: 'application',
+      source: 'homebrew',
+      purl: version.empty? ? nil : "pkg:brew/#{name}@#{version}",
+    )
+  end
+end
+
+def collect_pkgutil(inv)
+  return unless find_command('pkgutil')
+
+  result = command('pkgutil', '--pkgs', timeout: 120)
+  unless result[:ok]
+    inv.error('macos-pkgutil', result[:stderr])
+    return
+  end
+
+  result[:stdout].each_line do |line|
+    package_id = line.strip
+    next if package_id.empty?
+
+    inv.component(
+      name: package_id,
+      type: 'library',
+      source: 'macos-pkgutil',
+    )
+  end
+end
+
+def collect_snap(inv)
+  snap = find_command('snap')
+  return unless snap
+
+  result = command(snap, 'list', timeout: 120)
+  unless result[:ok]
+    inv.error('snap', result[:stderr])
+    return
+  end
+
+  result[:stdout].lines.drop(1).each do |line|
+    name, version, = line.split
+    next if name.nil?
+
+    inv.component(
+      name: name,
+      version: version,
+      type: 'application',
+      source: 'snap',
+    )
+  end
+end
+
+def collect_windows_package_extras(inv)
+  powershell = windows_powershell
+  return unless powershell
+
+  collect_windows_json(inv, powershell, 'windows-hotfix',
+                       'Get-HotFix | Select-Object HotFixID,Description,InstalledOn,InstalledBy | ConvertTo-Json -Depth 4') do |row|
+    inv.component(
+      name: row['HotFixID'],
+      version: row['InstalledOn'],
+      type: 'application',
+      source: 'windows-hotfix',
+      properties: {
+        description: row['Description'],
+        installed_by: row['InstalledBy'],
+      },
+    )
+  end
+
+  collect_windows_json(inv, powershell, 'windows-appx',
+                       'Get-AppxPackage -AllUsers | Select-Object Name,Version,Publisher,PackageFullName | ConvertTo-Json -Depth 4') do |row|
+    inv.component(
+      name: row['Name'],
+      version: row['Version'],
+      type: 'application',
+      source: 'windows-appx',
+      properties: {
+        publisher: row['Publisher'],
+        package_full_name: row['PackageFullName'],
+      },
+    )
+  end
+
+  collect_windows_json(inv, powershell, 'windows-driver',
+                       'Get-WindowsDriver -Online -All | Select-Object Driver,Version,ProviderName,ClassName | ConvertTo-Json -Depth 4') do |row|
+    inv.component(
+      name: row['Driver'],
+      version: row['Version'],
+      type: 'device-driver',
+      source: 'windows-driver',
+      properties: {
+        provider: row['ProviderName'],
+        class: row['ClassName'],
+      },
+    )
+  end
+end
+
+def collect_windows_json(inv, powershell, source, script)
+  result = command(powershell, '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+                   '-Command', script, timeout: 180)
+  unless result[:ok]
+    inv.error(source, result[:stderr])
+    return
+  end
+
+  rows = JSON.parse(result[:stdout])
+  rows = [rows] if rows.is_a?(Hash)
+  rows.each { |row| yield row if row.is_a?(Hash) }
+rescue StandardError => e
+  inv.error(source, e.message)
+end
+
+def windows_powershell
+  candidates = []
+  candidates << File.join(ENV['SystemRoot'], 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe') if ENV['SystemRoot']
+  candidates << 'powershell.exe'
+  candidates.find { |candidate| executable_command?(candidate) }
+end
+
+def collect_configuration(inv)
+  inv.config(
+    kind: 'environment-variable',
+    name: 'PATH',
+    source: 'process-environment',
+    properties: { value: ENV['PATH'] },
+  )
+
+  selected_files.each do |path|
+    next unless File.exist?(path)
+
+    inv.config(
+      kind: File.directory?(path) ? 'directory' : 'file',
+      name: path,
+      source: 'ronin-managed-path',
+      properties: file_evidence(path),
+    )
+  end
+
+  collect_services(inv)
+  collect_users_and_groups(inv)
+end
+
+def selected_files
+  if windows?
+    [
+      'C:/generic-worker/generic-worker.config',
+      'C:/generic-worker/task-user-init.cmd',
+      'C:/worker-runner/runner.yml',
+      'C:/ProgramData/PuppetLabs/ronin',
+      'C:/mozilla-build/python3/pip.conf',
+    ]
+  elsif macos?
+    [
+      '/opt/puppet_environments/last_run_metadata.json',
+      '/opt/puppet_environments/ronin_settings',
+      '/etc/puppet_role',
+      '/Library/LaunchDaemons/org.mozilla.generic-worker.plist',
+      '/Library/LaunchDaemons/org.mozilla.worker-runner.plist',
+      '/usr/local/bin/run-generic-worker.sh',
+      '/usr/local/bin/run-start-worker.sh',
+    ]
+  else
+    [
+      '/etc/puppet/last_run_metadata.json',
+      '/etc/puppet/ronin_settings',
+      '/etc/systemd/system/generic-worker.service',
+      '/etc/systemd/system/worker-runner.service',
+      '/etc/generic-worker/generic-worker.config',
+      '/etc/snmp/snmpd.conf',
+      '/usr/local/bin/run-start-worker.sh',
+      '/usr/local/bin/run-generic-worker.sh',
+    ]
+  end
+end
+
+def file_evidence(path)
+  stat = File.stat(path)
+  evidence = {
+    path: path,
+    mode: format('%o', stat.mode & 0o7777),
+    size: stat.size,
+    mtime: stat.mtime.utc.iso8601,
+  }
+  evidence[:sha256] = Digest::SHA256.file(path).hexdigest if File.file?(path)
+  evidence
+rescue StandardError => e
+  { path: path, error: e.message }
+end
+
+def collect_taskcluster_binaries(inv)
+  taskcluster_binary_paths.each do |path|
+    next unless File.file?(path)
+
+    version = nil
+    ['--short-version', '--version', '-version'].each do |flag|
+      result = command(path, flag, timeout: 10)
+      next unless result[:ok]
+
+      version = first_line(result[:stdout] + result[:stderr])
+      break if version
+    end
+
+    inv.component(
+      name: File.basename(path),
+      version: version,
+      type: 'application',
+      source: 'taskcluster-binary',
+      properties: file_evidence(path),
+    )
+  end
+end
+
+def taskcluster_binary_paths
+  if windows?
+    [
+      'C:/generic-worker/generic-worker.exe',
+      'C:/generic-worker/taskcluster-proxy.exe',
+      'C:/generic-worker/livelog.exe',
+      'C:/worker-runner/start-worker.exe',
+    ]
+  else
+    [
+      '/usr/local/bin/generic-worker',
+      '/usr/local/bin/taskcluster-proxy',
+      '/usr/local/bin/start-worker',
+      '/usr/local/bin/livelog',
+      '/usr/bin/generic-worker',
+      '/usr/bin/taskcluster-proxy',
+      '/opt/worker/bin/generic-worker',
+      '/opt/worker/bin/taskcluster-proxy',
+    ]
+  end
+end
+
+def first_line(text)
+  text.each_line.map(&:strip).find { |line| !line.empty? }
+end
+
+def metadata(inv)
+  facts = {}
+  if defined?(Facter)
+    %w[
+      os kernel architecture networking puppet_role custom_win_worker_pool_id
+      custom_win_gw_workerType custom_win_deployment_id custom_win_bootstrap_stage
+    ].each do |fact|
+      value = fact_value(fact)
+      facts[fact] = value unless value.nil? || value.to_s.empty?
+    end
+  end
+
+  data = {
+    generated_at: Time.now.utc.iso8601,
+    generator: 'ronin_sbom',
+    generator_version: VERSION,
+    hostname: Socket.gethostname,
+    ruby: RUBY_VERSION,
+    ruby_engine: defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby',
+    host_os: host_os,
+    puppet_version: defined?(Puppet) ? Puppet.version : nil,
+    facts: facts,
+  }
+
+  data.merge!(puppet_settings)
+  data.merge!(ronin_git_metadata(inv))
+  data.merge!(last_run_metadata)
+  stringify_keys(data)
+end
+
+def puppet_settings
+  return {} unless defined?(Puppet)
+
+  {
+    puppet_confdir: Puppet[:confdir],
+    puppet_vardir: Puppet[:vardir],
+    puppet_statedir: Puppet[:statedir],
+    puppet_lastrunreport: Puppet[:lastrunreport],
+    puppet_lastrunfile: Puppet[:lastrunfile],
+  }
+rescue StandardError
+  {}
+end
+
+def last_run_metadata
+  paths = if windows?
+            []
+          elsif macos?
+            ['/opt/puppet_environments/last_run_metadata.json']
+          else
+            ['/etc/puppet/last_run_metadata.json']
+          end
+
+  paths.each do |path|
+    next unless File.file?(path)
+
+    data = JSON.parse(File.read(path))
+    return { puppet_run_metadata_file: path, puppet_run_metadata: data }
+  rescue StandardError
+    next
+  end
+  {}
+end
+
+def ronin_git_metadata(inv)
+  repo = ronin_repo_path
+  return {} unless repo && File.directory?(File.join(repo, '.git'))
+
+  values = {}
+  {
+    ronin_git_repo: ['git', '-C', repo, 'config', '--get', 'remote.origin.url'],
+    ronin_git_branch: ['git', '-C', repo, 'rev-parse', '--abbrev-ref', 'HEAD'],
+    ronin_git_sha: ['git', '-C', repo, 'rev-parse', 'HEAD'],
+    ronin_git_status: ['git', '-C', repo, 'status', '--porcelain'],
+  }.each do |key, args|
+    result = command(*args, timeout: 15)
+    if result[:ok]
+      values[key] = result[:stdout].strip
+    else
+      inv.error('ronin-git', result[:stderr])
+    end
+  end
+  values[:ronin_git_dirty] = !values.fetch(:ronin_git_status, '').empty?
+  values.delete(:ronin_git_status)
+  values
+end
+
+def ronin_repo_path
+  return 'C:/ronin' if windows? && File.directory?('C:/ronin')
+
+  candidates = [
+    '/etc/puppet/environments/mozilla-platform-ops/code',
+    '/opt/puppet_environments/*/ronin_puppet',
+  ]
+  candidates.flat_map { |pattern| Dir.glob(pattern) }.find { |path| File.directory?(File.join(path, '.git')) }
+end
+
+def build_cyclonedx(meta, inv)
+  {
+    'bomFormat' => 'CycloneDX',
+    'specVersion' => '1.5',
+    'serialNumber' => "urn:uuid:#{SecureRandom.uuid}",
+    'version' => 1,
+    'metadata' => {
+      'timestamp' => meta['generated_at'],
+      'tools' => {
+        'components' => [
+          {
+            'type' => 'application',
+            'name' => 'ronin_sbom',
+            'version' => VERSION,
+          },
+        ],
+      },
+      'component' => {
+        'type' => 'operating-system',
+        'name' => platform_name(meta),
+      },
+      'properties' => metadata_properties(meta, inv),
+    },
+    'components' => inv.components.sort_by { |component| [component['name'].downcase, component['version'].to_s] },
+  }
+end
+
+def platform_name(meta)
+  os = meta.dig('facts', 'os')
+  if os.is_a?(Hash)
+    [os.dig('name'), os.dig('release', 'full')].compact.join(' ')
+  else
+    meta['host_os']
+  end
+end
+
+def metadata_properties(meta, inv)
+  flat_metadata(meta).map { |key, value| { 'name' => "ronin:#{key}", 'value' => value.to_s } } + [
+    { 'name' => 'ronin:component_count', 'value' => inv.components.length.to_s },
+    { 'name' => 'ronin:configuration_count', 'value' => inv.configuration.length.to_s },
+    { 'name' => 'ronin:collector_error_count', 'value' => inv.errors.length.to_s },
+  ]
+end
+
+def flat_metadata(meta, prefix = nil)
+  meta.each_with_object({}) do |(key, value), memo|
+    name = [prefix, key].compact.join('.')
+    if value.is_a?(Hash)
+      memo.merge!(flat_metadata(value, name))
+    elsif value.is_a?(Array)
+      memo[name] = value.join(',')
+    elsif !value.nil? && !value.to_s.empty?
+      memo[name] = value
+    end
+  end
+end
+
+def build_inventory(meta, inv)
+  {
+    'schema_version' => 2,
+    'generated_at' => meta['generated_at'],
+    'metadata' => meta,
+    'components' => inv.components,
+    'configuration' => inv.configuration,
+    'collector_errors' => inv.errors,
+  }
+end
+
+def build_markdown(meta, inv)
+  lines = []
+  lines << '# Ronin Puppet SBOM'
+  lines << ''
+  lines << "Generated: `#{escape_md(meta['generated_at'])}`"
+  lines << ''
+  lines << '## Summary'
+  lines << ''
+  lines << '| Item | Count |'
+  lines << '|------|-------|'
+  lines << "| Components | #{inv.components.length} |"
+  lines << "| Configuration records | #{inv.configuration.length} |"
+  lines << "| Collector errors | #{inv.errors.length} |"
+  lines << ''
+  lines << '## Metadata'
+  lines << ''
+  lines << '| Name | Value |'
+  lines << '|------|-------|'
+  flat_metadata(meta).sort.each do |key, value|
+    lines << "| #{escape_md(key)} | #{escape_md(value)} |"
+  end
+  lines << ''
+
+  inv.components.group_by { |component| source_for(component) }.sort.each do |source, components|
+    lines << "## Components: #{escape_md(source)}"
+    lines << ''
+    lines << '| Name | Version | Type |'
+    lines << '|------|---------|------|'
+    components.sort_by { |component| component['name'].downcase }.each do |component|
+      lines << "| #{escape_md(component['name'])} | #{escape_md(component['version'])} | #{escape_md(component['type'])} |"
+    end
+    lines << ''
+  end
+
+  unless inv.configuration.empty?
+    lines << '## Configuration Evidence'
+    lines << ''
+    lines << '| Kind | Name | Source |'
+    lines << '|------|------|--------|'
+    inv.configuration.sort_by { |record| [record['kind'], record['name']] }.each do |record|
+      lines << "| #{escape_md(record['kind'])} | #{escape_md(record['name'])} | #{escape_md(record['source'])} |"
+    end
+    lines << ''
+  end
+
+  unless inv.errors.empty?
+    lines << '## Collector Errors'
+    lines << ''
+    lines << '| Collector | Message |'
+    lines << '|-----------|---------|'
+    inv.errors.each do |error|
+      lines << "| #{escape_md(error['collector'])} | #{escape_md(error['message'])} |"
+    end
+    lines << ''
+  end
+
+  lines.join("\n") + "\n"
+end
+
+def source_for(component)
+  prop = Array(component['properties']).find { |item| item['name'] == 'ronin:source' }
+  prop ? prop['value'] : 'unknown'
+end
+
+def escape_md(value)
+  value.to_s.gsub('|', '\\|').gsub(/\r?\n/, ' ')
+end
+
+def write_json(path, data)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(data) + "\n", mode: 'w:UTF-8')
+  FileUtils.mv(tmp, path)
+end
+
+def write_text(path, data)
+  tmp = "#{path}.tmp"
+  File.write(tmp, data, mode: 'w:UTF-8')
+  FileUtils.mv(tmp, path)
+end
+
+def find_command(name)
+  ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |dir|
+    path = File.join(dir, name)
+    return path if executable_command?(path)
+  end
+  nil
+end
+
+def executable_command?(path)
+  File.executable?(path) || (windows? && File.file?(path))
+end
+
+def stringify_keys(value)
+  case value
+  when Hash
+    value.each_with_object({}) { |(k, v), memo| memo[k.to_s] = stringify_keys(v) }
+  when Array
+    value.map { |item| stringify_keys(item) }
+  else
+    value
+  end
+end
+
+options = {
+  output_directory: windows? ? 'C:/sbom' : '/var/sbom',
+  base_name: 'ronin-sbom',
+}
+
+OptionParser.new do |parser|
+  parser.on('--output-directory PATH') { |value| options[:output_directory] = value }
+  parser.on('--base-name NAME') { |value| options[:base_name] = value }
+end.parse!
+
+inv = RoninSbom.new
+init_puppet(inv)
+collect_packages(inv)
+collect_platform_packages(inv)
+collect_taskcluster_binaries(inv)
+collect_configuration(inv)
+
+meta = metadata(inv)
+FileUtils.mkdir_p(options[:output_directory])
+
+base = File.join(options[:output_directory], options[:base_name])
+write_json("#{base}.cdx.json", build_cyclonedx(meta, inv))
+write_json("#{base}.inventory.json", build_inventory(meta, inv))
+write_text("#{base}.md", build_markdown(meta, inv))
+
+puts "Wrote #{base}.cdx.json"
+puts "Wrote #{base}.inventory.json"
+puts "Wrote #{base}.md"

--- a/modules/ronin_sbom/files/generate_ronin_sbom.rb
+++ b/modules/ronin_sbom/files/generate_ronin_sbom.rb
@@ -135,6 +135,10 @@ def linux?
   host_os =~ /linux/i
 end
 
+def env_true?(name)
+  %w[1 true yes].include?(ENV[name].to_s.downcase)
+end
+
 def command(*args, timeout: 60)
   Timeout.timeout(timeout) do
     stdout, stderr, status = Open3.capture3(*args)
@@ -190,7 +194,7 @@ rescue StandardError => e
 end
 
 def collect_packages(inv)
-  return unless ENV['RONIN_SBOM_COLLECT_PUPPET_PACKAGES'] == 'true'
+  return unless env_true?('RONIN_SBOM_COLLECT_PUPPET_PACKAGES')
 
   collect_puppet_type(inv, :package, timeout: 120).each do |package|
     name = resource_value(package, :name) || package.title
@@ -276,13 +280,13 @@ end
 
 def collect_platform_packages(inv)
   collect_macos_applications(inv) if macos?
-  if macos? && ENV['RONIN_SBOM_COLLECT_DEEP_PACKAGES'] == 'true'
+  if macos? && env_true?('RONIN_SBOM_COLLECT_DEEP_PACKAGES')
     collect_homebrew(inv)
     collect_pkgutil(inv)
   end
   collect_dpkg(inv) if linux?
   collect_rpm(inv) if linux?
-  collect_snap(inv) if linux?
+  collect_snap(inv) if linux? && env_true?('RONIN_SBOM_COLLECT_SNAP_PACKAGES')
   collect_windows_package_extras(inv) if windows?
 end
 
@@ -538,7 +542,7 @@ def collect_configuration(inv)
     )
   end
 
-  unless macos?
+  if windows? || env_true?('RONIN_SBOM_COLLECT_PUPPET_CONFIG')
     collect_services(inv)
     collect_users_and_groups(inv)
   end
@@ -596,7 +600,7 @@ def collect_taskcluster_binaries(inv)
     next unless File.file?(path)
 
     version = nil
-    unless macos?
+    if env_true?('RONIN_SBOM_COLLECT_BINARY_VERSIONS')
       ['--short-version', '--version', '-version'].each do |flag|
         result = command(path, flag, timeout: 10)
         next unless result[:ok]

--- a/modules/ronin_sbom/files/generate_ronin_sbom.rb
+++ b/modules/ronin_sbom/files/generate_ronin_sbom.rb
@@ -596,12 +596,14 @@ def collect_taskcluster_binaries(inv)
     next unless File.file?(path)
 
     version = nil
-    ['--short-version', '--version', '-version'].each do |flag|
-      result = command(path, flag, timeout: 10)
-      next unless result[:ok]
+    unless macos?
+      ['--short-version', '--version', '-version'].each do |flag|
+        result = command(path, flag, timeout: 10)
+        next unless result[:ok]
 
-      version = first_line(result[:stdout] + result[:stderr])
-      break if version
+        version = first_line(result[:stdout] + result[:stderr])
+        break if version
+      end
     end
 
     inv.component(

--- a/modules/ronin_sbom/files/generate_ronin_sbom.rb
+++ b/modules/ronin_sbom/files/generate_ronin_sbom.rb
@@ -176,18 +176,23 @@ rescue StandardError
   nil
 end
 
-def collect_puppet_type(inv, type_name)
+def collect_puppet_type(inv, type_name, timeout: 120)
   type = Puppet::Type.type(type_name)
   return [] unless type
 
-  type.instances
+  Timeout.timeout(timeout) { type.instances }
+rescue Timeout::Error
+  inv.error("puppet-ral-#{type_name}", "collector exceeded #{timeout}s")
+  []
 rescue StandardError => e
   inv.error("puppet-ral-#{type_name}", e.message)
   []
 end
 
 def collect_packages(inv)
-  collect_puppet_type(inv, :package).each do |package|
+  return unless ENV['RONIN_SBOM_COLLECT_PUPPET_PACKAGES'] == 'true'
+
+  collect_puppet_type(inv, :package, timeout: 120).each do |package|
     name = resource_value(package, :name) || package.title
     ensure_value = resource_value(package, :ensure)
     version = ensure_value unless %w[present installed latest].include?(ensure_value.to_s)
@@ -226,7 +231,7 @@ def package_purl(name, version, provider)
 end
 
 def collect_services(inv)
-  collect_puppet_type(inv, :service).each do |service|
+  collect_puppet_type(inv, :service, timeout: 60).each do |service|
     inv.config(
       kind: 'service',
       name: resource_value(service, :name) || service.title,
@@ -241,7 +246,7 @@ def collect_services(inv)
 end
 
 def collect_users_and_groups(inv)
-  collect_puppet_type(inv, :user).each do |user|
+  collect_puppet_type(inv, :user, timeout: 60).each do |user|
     inv.config(
       kind: 'user',
       name: resource_value(user, :name) || user.title,
@@ -256,7 +261,7 @@ def collect_users_and_groups(inv)
     )
   end
 
-  collect_puppet_type(inv, :group).each do |group|
+  collect_puppet_type(inv, :group, timeout: 60).each do |group|
     inv.config(
       kind: 'group',
       name: resource_value(group, :name) || group.title,
@@ -272,6 +277,8 @@ end
 def collect_platform_packages(inv)
   collect_homebrew(inv) if macos?
   collect_pkgutil(inv) if macos?
+  collect_dpkg(inv) if linux?
+  collect_rpm(inv) if linux?
   collect_snap(inv) if linux?
   collect_windows_package_extras(inv) if windows?
 end
@@ -322,6 +329,62 @@ def collect_pkgutil(inv)
   end
 end
 
+def collect_dpkg(inv)
+  dpkg_query = find_command('dpkg-query')
+  return unless dpkg_query
+
+  result = command(dpkg_query, '-W', '-f=${binary:Package}\t${Version}\t${Architecture}\n', timeout: 60)
+  unless result[:ok]
+    inv.error('dpkg', result[:stderr])
+    return
+  end
+
+  result[:stdout].each_line do |line|
+    name, version, architecture = line.chomp.split("\t", 3)
+    next if name.nil? || name.empty?
+
+    inv.component(
+      name: name,
+      version: version,
+      type: 'application',
+      source: 'dpkg',
+      purl: version.to_s.empty? ? nil : "pkg:deb/debian/#{name}@#{version}",
+      properties: {
+        provider: 'dpkg',
+        architecture: architecture,
+      },
+    )
+  end
+end
+
+def collect_rpm(inv)
+  rpm = find_command('rpm')
+  return unless rpm
+
+  result = command(rpm, '-qa', '--qf', "%{NAME}\t%{VERSION}-%{RELEASE}\t%{ARCH}\n", timeout: 60)
+  unless result[:ok]
+    inv.error('rpm', result[:stderr])
+    return
+  end
+
+  result[:stdout].each_line do |line|
+    name, version, architecture = line.chomp.split("\t", 3)
+    next if name.nil? || name.empty?
+
+    inv.component(
+      name: name,
+      version: version,
+      type: 'application',
+      source: 'rpm',
+      purl: version.to_s.empty? ? nil : "pkg:rpm/#{name}@#{version}",
+      properties: {
+        provider: 'rpm',
+        architecture: architecture,
+      },
+    )
+  end
+end
+
 def collect_snap(inv)
   snap = find_command('snap')
   return unless snap
@@ -348,6 +411,29 @@ end
 def collect_windows_package_extras(inv)
   powershell = windows_powershell
   return unless powershell
+
+  collect_windows_json(inv, powershell, 'windows-installed-program', <<~'POWERSHELL') do |row|
+    $paths = @(
+      'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+      'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    Get-ItemProperty -Path $paths -ErrorAction SilentlyContinue |
+      Where-Object { $_.DisplayName } |
+      Select-Object DisplayName,DisplayVersion,Publisher,InstallDate,PSChildName |
+      ConvertTo-Json -Depth 4
+  POWERSHELL
+    inv.component(
+      name: row['DisplayName'],
+      version: row['DisplayVersion'],
+      type: 'application',
+      source: 'windows-installed-program',
+      properties: {
+        publisher: row['Publisher'],
+        install_date: row['InstallDate'],
+        registry_key: row['PSChildName'],
+      },
+    )
+  end
 
   collect_windows_json(inv, powershell, 'windows-hotfix',
                        'Get-HotFix | Select-Object HotFixID,Description,InstalledOn,InstalledBy | ConvertTo-Json -Depth 4') do |row|

--- a/modules/ronin_sbom/manifests/init.pp
+++ b/modules/ronin_sbom/manifests/init.pp
@@ -1,0 +1,150 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class ronin_sbom (
+  Boolean $enabled                 = true,
+  Boolean $run_on_every_puppet_run = true,
+  String[1] $output_basename       = 'ronin-sbom',
+  Integer[1] $timeout              = 900,
+) {
+  if $enabled {
+    case $facts['os']['name'] {
+      'Windows': {
+        $ronin_dir = $facts['custom_win_roninprogramdata'] ? {
+          undef   => 'C:\ProgramData\PuppetLabs\ronin',
+          default => $facts['custom_win_roninprogramdata'],
+        }
+        $programfiles = $facts['custom_win_programfiles'] ? {
+          undef   => 'C:\Program Files',
+          default => $facts['custom_win_programfiles'],
+        }
+        $ruby_exe    = "${programfiles}\\Puppet Labs\\Puppet\\puppet\\bin\\ruby.exe"
+        $script_dir  = "${ronin_dir}\\sbom"
+        $script_path = "${script_dir}\\generate_ronin_sbom.rb"
+        $output_dir  = 'C:\sbom'
+        $command     = "& '${ruby_exe}' '${script_path}' --output-directory '${output_dir}' --base-name '${output_basename}'"
+        $unless      = "Test-Path '${output_dir}\\${output_basename}.cdx.json'"
+
+        file { [$ronin_dir, $script_dir, $output_dir]:
+          ensure => directory,
+        }
+
+        file { $script_path:
+          ensure  => file,
+          source  => 'puppet:///modules/ronin_sbom/generate_ronin_sbom.rb',
+          require => File[$script_dir],
+        }
+
+        if $run_on_every_puppet_run {
+          exec { 'generate_ronin_sbom_windows':
+            command   => $command,
+            provider  => powershell,
+            require   => [File[$script_path], File[$output_dir]],
+            timeout   => $timeout,
+            logoutput => true,
+          }
+        } else {
+          exec { 'generate_ronin_sbom_windows':
+            command   => $command,
+            provider  => powershell,
+            require   => [File[$script_path], File[$output_dir]],
+            timeout   => $timeout,
+            logoutput => true,
+            unless    => $unless,
+          }
+        }
+      }
+      'Darwin': {
+        $ruby_exe    = '/opt/puppetlabs/puppet/bin/ruby'
+        $script_path = '/usr/local/bin/generate_ronin_sbom.rb'
+        $output_dir  = '/var/sbom'
+        $command     = "${ruby_exe} ${script_path} --output-directory ${output_dir} --base-name ${output_basename}"
+        $unless      = "test -s '${output_dir}/${output_basename}.cdx.json'"
+        $exec_path   = ['/opt/puppetlabs/puppet/bin', '/opt/puppetlabs/bin',
+          '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
+
+        file { $script_path:
+          ensure => file,
+          owner  => 'root',
+          group  => 'wheel',
+          mode   => '0755',
+          source => 'puppet:///modules/ronin_sbom/generate_ronin_sbom.rb',
+        }
+
+        file { $output_dir:
+          ensure => directory,
+          owner  => 'root',
+          group  => 'wheel',
+          mode   => '0755',
+        }
+
+        if $run_on_every_puppet_run {
+          exec { 'generate_ronin_sbom_darwin':
+            command   => $command,
+            path      => $exec_path,
+            require   => [File[$script_path], File[$output_dir]],
+            timeout   => $timeout,
+            logoutput => true,
+          }
+        } else {
+          exec { 'generate_ronin_sbom_darwin':
+            command   => $command,
+            path      => $exec_path,
+            require   => [File[$script_path], File[$output_dir]],
+            timeout   => $timeout,
+            logoutput => true,
+            unless    => $unless,
+          }
+        }
+      }
+      default: {
+        if $facts['kernel'] == 'Linux' {
+          $ruby_exe    = '/opt/puppetlabs/puppet/bin/ruby'
+          $script_path = '/usr/local/bin/generate_ronin_sbom.rb'
+          $output_dir  = '/var/sbom'
+          $command     = "${ruby_exe} ${script_path} --output-directory ${output_dir} --base-name ${output_basename}"
+          $unless      = "test -s '${output_dir}/${output_basename}.cdx.json'"
+          $exec_path   = ['/opt/puppetlabs/puppet/bin', '/opt/puppetlabs/bin',
+            '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']
+
+          file { $script_path:
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0755',
+            source => 'puppet:///modules/ronin_sbom/generate_ronin_sbom.rb',
+          }
+
+          file { $output_dir:
+            ensure => directory,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0755',
+          }
+
+          if $run_on_every_puppet_run {
+            exec { 'generate_ronin_sbom_linux':
+              command   => $command,
+              path      => $exec_path,
+              require   => [File[$script_path], File[$output_dir]],
+              timeout   => $timeout,
+              logoutput => true,
+            }
+          } else {
+            exec { 'generate_ronin_sbom_linux':
+              command   => $command,
+              path      => $exec_path,
+              require   => [File[$script_path], File[$output_dir]],
+              timeout   => $timeout,
+              logoutput => true,
+              unless    => $unless,
+            }
+          }
+        } else {
+          fail("${facts['os']['name']} not supported")
+        }
+      }
+    }
+  }
+}

--- a/modules/ronin_sbom/manifests/init.pp
+++ b/modules/ronin_sbom/manifests/init.pp
@@ -11,29 +11,24 @@ class ronin_sbom (
   if $enabled {
     case $facts['os']['name'] {
       'Windows': {
-        $ronin_dir = $facts['custom_win_roninprogramdata'] ? {
-          undef   => 'C:\ProgramData\PuppetLabs\ronin',
-          default => $facts['custom_win_roninprogramdata'],
-        }
         $programfiles = $facts['custom_win_programfiles'] ? {
           undef   => 'C:\Program Files',
           default => $facts['custom_win_programfiles'],
         }
         $ruby_exe    = "${programfiles}\\Puppet Labs\\Puppet\\puppet\\bin\\ruby.exe"
-        $script_dir  = "${ronin_dir}\\sbom"
-        $script_path = "${script_dir}\\generate_ronin_sbom.rb"
         $output_dir  = 'C:\sbom'
+        $script_path = "${output_dir}\\generate_ronin_sbom.rb"
         $command     = "& '${ruby_exe}' '${script_path}' --output-directory '${output_dir}' --base-name '${output_basename}'"
         $unless      = "Test-Path '${output_dir}\\${output_basename}.cdx.json'"
 
-        file { [$ronin_dir, $script_dir, $output_dir]:
+        file { $output_dir:
           ensure => directory,
         }
 
         file { $script_path:
           ensure  => file,
           source  => 'puppet:///modules/ronin_sbom/generate_ronin_sbom.rb',
-          require => File[$script_dir],
+          require => File[$output_dir],
         }
 
         if $run_on_every_puppet_run {

--- a/test/integration/common_test/serverspec/sbom_windows_shared.rb
+++ b/test/integration/common_test/serverspec/sbom_windows_shared.rb
@@ -32,7 +32,7 @@ describe powershell_command(<<~POWERSHELL) do
     }
   )
 
-  foreach ($source in @('puppet-ral-package', 'puppet-ral-service', 'windows-driver')) {
+  foreach ($source in @('windows-installed-program', 'puppet-ral-service', 'windows-driver')) {
     if ($sources -notcontains $source) { exit 1 }
   }
 
@@ -58,7 +58,7 @@ end
 
 describe powershell_command(<<~POWERSHELL) do
   $markdown = Get-Content -Raw -Path '#{sbom_paths[:markdown]}'
-  foreach ($needle in @('# Ronin Puppet SBOM', '## Summary', '## Components: puppet-ral-package', '## Components: windows-driver')) {
+  foreach ($needle in @('# Ronin Puppet SBOM', '## Summary', '## Components: windows-installed-program', '## Components: windows-driver')) {
     if (-not $markdown.Contains($needle)) { exit 1 }
   }
 POWERSHELL

--- a/test/integration/common_test/serverspec/sbom_windows_shared.rb
+++ b/test/integration/common_test/serverspec/sbom_windows_shared.rb
@@ -1,0 +1,66 @@
+sbom_dir = 'C:\\sbom'
+sbom_base = "#{sbom_dir}\\ronin-sbom"
+sbom_paths = {
+  cyclonedx: "#{sbom_base}.cdx.json",
+  inventory: "#{sbom_base}.inventory.json",
+  markdown: "#{sbom_base}.md",
+}
+
+sbom_paths.each_value do |path|
+  describe file(path) do
+    it { should exist }
+  end
+
+  describe powershell_command("if ((Get-Item '#{path}' -ErrorAction Stop).Length -gt 0) { exit 0 } else { exit 1 }") do
+    its(:exit_status) { should eq 0 }
+  end
+end
+
+describe powershell_command(<<~POWERSHELL) do
+  $bom = Get-Content -Raw -Path '#{sbom_paths[:cyclonedx]}' | ConvertFrom-Json
+  if ($bom.bomFormat -ne 'CycloneDX') { exit 1 }
+  if ($bom.specVersion -ne '1.5') { exit 1 }
+  if (@($bom.components).Count -lt 1) { exit 1 }
+
+  $sources = @(
+    foreach ($component in @($bom.components)) {
+      foreach ($property in @($component.properties)) {
+        if ($property.name -eq 'ronin:source') {
+          $property.value
+        }
+      }
+    }
+  )
+
+  foreach ($source in @('puppet-ral-package', 'puppet-ral-service', 'windows-driver')) {
+    if ($sources -notcontains $source) { exit 1 }
+  }
+
+  '{0} {1} {2}' -f $bom.bomFormat, $bom.specVersion, @($bom.components).Count
+POWERSHELL
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^CycloneDX 1\.5 \d+\s*$/) }
+end
+
+describe powershell_command(<<~POWERSHELL) do
+  $inventory = Get-Content -Raw -Path '#{sbom_paths[:inventory]}' | ConvertFrom-Json
+  if ($inventory.schema_version -ne 2) { exit 1 }
+  if (@($inventory.components).Count -lt 1) { exit 1 }
+  if ($inventory.metadata.generator -ne 'ronin_sbom') { exit 1 }
+  if ($inventory.metadata.host_os -notmatch '(?i)(mswin|mingw|windows)') { exit 1 }
+  if ($inventory.metadata.puppet_version -notmatch '^8\\.') { exit 1 }
+
+  '{0} {1} {2}' -f $inventory.schema_version, $inventory.metadata.generator, @($inventory.components).Count
+POWERSHELL
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^2 ronin_sbom \d+\s*$/) }
+end
+
+describe powershell_command(<<~POWERSHELL) do
+  $markdown = Get-Content -Raw -Path '#{sbom_paths[:markdown]}'
+  foreach ($needle in @('# Ronin Puppet SBOM', '## Summary', '## Components: puppet-ral-package', '## Components: windows-driver')) {
+    if (-not $markdown.Contains($needle)) { exit 1 }
+  }
+POWERSHELL
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/win10642009azure/serverspec/sbom_spec.rb
+++ b/test/integration/win10642009azure/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win116424h2azure/serverspec/sbom_spec.rb
+++ b/test/integration/win116424h2azure/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win116425h2azure/serverspec/sbom_spec.rb
+++ b/test/integration/win116425h2azure/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win11a6424h2azurebuilder/serverspec/sbom_spec.rb
+++ b/test/integration/win11a6424h2azurebuilder/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win11a6424h2azuretester/serverspec/sbom_spec.rb
+++ b/test/integration/win11a6424h2azuretester/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win11a6425h2azurebuilder/serverspec/sbom_spec.rb
+++ b/test/integration/win11a6425h2azurebuilder/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win11a6425h2azuretester/serverspec/sbom_spec.rb
+++ b/test/integration/win11a6425h2azuretester/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)

--- a/test/integration/win2022642009azure/serverspec/sbom_spec.rb
+++ b/test/integration/win2022642009azure/serverspec/sbom_spec.rb
@@ -1,0 +1,2 @@
+require_relative 'spec_helper'
+require File.expand_path('../../common_test/serverspec/sbom_windows_shared', __dir__)


### PR DESCRIPTION
## Summary

- adds a new `ronin_sbom` Puppet module for Windows, macOS, and Linux
- runs the collector with Puppet/OpenVox's bundled Ruby instead of separate Python and PowerShell collectors
- generates three files from the same inventory data:
  - `ronin-sbom.cdx.json` for canonical CycloneDX SBOM output
  - `ronin-sbom.inventory.json` for ronin-specific installed/configured evidence
  - `ronin-sbom.md` for human-readable review
- runs SBOM generation in a late Puppet stage after the normal `main` stage
- replaces the old macOS-only SBOM profile with a compatibility shim to the shared profile
- wires the profile into Linux, macOS worker/package profiles, and all Windows role files
- adds Windows Kitchen Serverspec coverage for the generated SBOM artifacts and uploads the captured `C:\sbom\ronin-sbom.*` files from Kitchen runs

## Notes

This follows the useful `actions/runner-images` pattern: collect late in provisioning, use native collectors, and emit both structured JSON and Markdown from the same source data.

The collector runs under Puppet/OpenVox Ruby and uses native platform inventory paths that avoid the earlier long-running Python/PowerShell split:

- Puppet/Facter metadata
- Windows uninstall registry, hotfixes, Appx packages, drivers, and Puppet RAL service/user/group evidence
- macOS lightweight application inventory by default; Homebrew and `pkgutil` remain opt-in with `RONIN_SBOM_COLLECT_DEEP_PACKAGES=true`
- Linux `dpkg-query` and `rpm` packages by default; snap remains opt-in with `RONIN_SBOM_COLLECT_SNAP_PACKAGES=true`
- selected ronin-managed file/path hashes and Taskcluster binary hashes

Potentially blocking collectors remain opt-in:

- Puppet package RAL collection: `RONIN_SBOM_COLLECT_PUPPET_PACKAGES=true`
- non-Windows Puppet RAL service/user/group collection: `RONIN_SBOM_COLLECT_PUPPET_CONFIG=true`
- executing worker binaries for version probes: `RONIN_SBOM_COLLECT_BINARY_VERSIONS=true`

## Validation

- `ruby -c modules/ronin_sbom/files/generate_ronin_sbom.rb`
- Ruby syntax check for the shared Windows SBOM Serverspec
- Generated local macOS Ruby test artifacts under `/tmp/ronin-sbom-macos-light-test`
- Generated OpenVox Ruby test artifacts under `/tmp/ronin-sbom-openvox` using `voxpupuli/openvoxagent:latest`
- OpenVox parser validation in `voxpupuli/openvoxagent:latest` (`8.27.0`)
- Full Linux container `puppet apply` of `roles_profiles::profiles::sbom` in `voxpupuli/openvoxagent:latest`, generating `/var/sbom/ronin-sbom.{cdx.json,inventory.json,md}`
- Fake hanging Taskcluster binary smoke in `voxpupuli/openvoxagent:latest`, confirming default collection hashes the binary without executing it
- Added Windows Kitchen coverage in `fc36c9e3`; pushed CI failure fixes in `645e50e8`, `77ea40fe`, `6d5a9d26`, and `23edb9d4`

Jira: https://mozilla-hub.atlassian.net/browse/RELOPS-2395
