### PR TITLE
Add tart_worker role for gecko-t-osx-1500-m-vms tester VM hosts

### DIFF
--- a/data/roles/tart_worker.yaml
+++ b/data/roles/tart_worker.yaml
@@ -1,0 +1,23 @@
+---
+ntp_server: time.apple.org
+
+# Puppet agent
+puppet_agent:
+  package_version: 7.28.0
+
+puppet_run_strategy: cron
+
+# Tart VM host configuration: runs gecko-t-osx-1500-m-vms tester VMs.
+# Registry/image differ from the gecko-1b builder hosts (which use 10.49.56.83
+# / sequoia-gecko1b-vms). The worker identity is baked into the sequoia-tester
+# image, so no host-side vault secrets are required.
+tart:
+  version: '2.30.0'
+  registry_host: '10.49.56.161'
+  registry_port: 5000
+  oci_image: 'sequoia-tester'
+  oci_tag: 'prod-latest'
+  vm_name_prefix: 'sequoia-tester'
+  worker_count: 2
+  insecure: true
+  user: 'admin'

--- a/data/roles/tart_worker.yaml
+++ b/data/roles/tart_worker.yaml
@@ -11,6 +11,15 @@ puppet_run_strategy: cron
 # Registry/image differ from the gecko-1b builder hosts (which use 10.49.56.83
 # / sequoia-gecko1b-vms). The worker identity is baked into the sequoia-tester
 # image, so no host-side vault secrets are required.
+#
+# manage_image: false  -> puppet does NOT pull/clone. On macOS 15 `tart pull`
+#   only works from the console GUI session (Local Network privacy), so the
+#   image is seeded once by hand (see tart-provision.sh / the on-host vms.sh)
+#   and puppet only manages tart + the launchd unit. This also stops puppet
+#   from retry-looping the doomed headless pull (that caused an email storm).
+# launchd_type: daemon -> system LaunchDaemon (starts at boot headlessly,
+#   survives reboot) instead of a gui-domain LaunchAgent that can't load over
+#   ssh on 15.x.
 tart:
   version: '2.30.0'
   registry_host: '10.49.56.161'
@@ -21,3 +30,5 @@ tart:
   worker_count: 2
   insecure: true
   user: 'admin'
+  manage_image: false
+  launchd_type: 'daemon'

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -23,7 +23,10 @@
 #     daemon - system LaunchDaemon in /Library/LaunchDaemons, runs `tart run`
 #              as the configured user via UserName. Loads headlessly with
 #              `launchctl bootstrap system` and starts at boot, so the VMs
-#              survive reboots without a console session.
+#              survive reboots without a console session. When switching a host
+#              from agent to daemon, any previously-loaded gui-domain agent is
+#              evicted and its plist removed first, so the two don't race to
+#              `tart run` the same VM.
 class roles_profiles::profiles::tart {
   $version        = lookup('tart.version',        String,  'first', '2.30.0')
   $registry_host  = lookup('tart.registry_host',  String,  'first', '10.49.56.83')
@@ -122,7 +125,24 @@ class roles_profiles::profiles::tart {
     $vm_name = "${vm_name_prefix}-${i}"
 
     if $launchd_type == 'daemon' {
-      $plist_path = "/Library/LaunchDaemons/com.mozilla.tartworker-${i}.plist"
+      $plist_path  = "/Library/LaunchDaemons/com.mozilla.tartworker-${i}.plist"
+      $agent_plist = "/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist"
+
+      # Migrate a host off the old gui-domain LaunchAgent. While the agent is
+      # loaded it holds the VM, so the daemon's `tart run` would lose the race
+      # and KeepAlive-flap on "VM already running". Evict the loaded agent
+      # (root can target the user's gui domain) and remove its plist so it
+      # cannot reload at the next autologin/reboot. onlyif keeps it idempotent.
+      exec { "evict_agent_tartworker_${i}":
+        command => "/bin/bash -c 'launchctl bootout gui/\$(id -u ${user})/com.mozilla.tartworker-${i}'",
+        path    => ['/bin', '/usr/bin'],
+        onlyif  => "/bin/bash -c 'launchctl print gui/\$(id -u ${user})/com.mozilla.tartworker-${i} >/dev/null 2>&1'",
+        notify  => Exec["load_tartworker_${i}"],
+      }
+
+      file { $agent_plist:
+        ensure => absent,
+      }
 
       file { $plist_path:
         ensure  => file,
@@ -135,13 +155,15 @@ class roles_profiles::profiles::tart {
         owner   => 'root',
         group   => 'wheel',
         mode    => '0644',
-        require => $image_require + $dir_require,
+        require => $image_require + $dir_require + [Exec["evict_agent_tartworker_${i}"], File[$agent_plist]],
         notify  => Exec["load_tartworker_${i}"],
       }
 
-      # system domain: loads headlessly, no console session required.
+      # system domain: loads headlessly, no console session required. Wrapped in
+      # bash -c because the command uses shell operators (;, ||, redirection)
+      # that Puppet's exec does not pass through a shell on its own.
       exec { "load_tartworker_${i}":
-        command     => "launchctl bootout system ${plist_path} 2>/dev/null || true; launchctl bootstrap system ${plist_path}",
+        command     => "/bin/bash -c 'launchctl bootout system ${plist_path} 2>/dev/null || true; launchctl bootstrap system ${plist_path}'",
         path        => ['/bin', '/usr/bin'],
         refreshonly => true,
         require     => File[$plist_path],

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -2,8 +2,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Installs Tart, pulls an OCI VM image, clones N worker VMs, and manages
-# per-VM LaunchAgents so they start and stay running as the configured user.
+# Installs Tart and manages N worker VMs that start and stay running.
+#
+# Two axes of behaviour, both hiera-driven (defaults preserve the original
+# gecko-1b builder-host behaviour):
+#
+#   tart.manage_image (Boolean, default true)
+#     true  - puppet pulls the OCI image and clones the VMs.
+#     false - puppet does NOT pull/clone. Required on macOS 15+, where
+#             `tart pull` only succeeds from the logged-in console GUI session
+#             (Local Network privacy denies the registry connection from a
+#             headless puppet/ssh context, surfacing as "The Internet
+#             connection appears to be offline"). On those hosts the image is
+#             seeded once by hand from the console and puppet only manages tart
+#             itself + the launchd unit.
+#
+#   tart.launchd_type (Enum['agent','daemon'], default 'agent')
+#     agent  - per-user LaunchAgent in ~/Library/LaunchAgents (gui domain;
+#              only loads from a console session).
+#     daemon - system LaunchDaemon in /Library/LaunchDaemons, runs `tart run`
+#              as the configured user via UserName. Loads headlessly with
+#              `launchctl bootstrap system` and starts at boot, so the VMs
+#              survive reboots without a console session.
 class roles_profiles::profiles::tart {
   $version        = lookup('tart.version',        String,  'first', '2.30.0')
   $registry_host  = lookup('tart.registry_host',  String,  'first', '10.49.56.83')
@@ -14,6 +34,8 @@ class roles_profiles::profiles::tart {
   $worker_count   = lookup('tart.worker_count',   Integer, 'first', 2)
   $insecure       = lookup('tart.insecure',       Boolean, 'first', true)
   $user           = lookup('tart.user',           String,  'first', 'admin')
+  $manage_image   = lookup('tart.manage_image',   Boolean, 'first', true)
+  $launchd_type   = lookup('tart.launchd_type',   Enum['agent', 'daemon'], 'first', 'agent')
 
   $install_dir   = '/Applications'
   $bin_path      = '/usr/local/bin/tart'
@@ -67,44 +89,87 @@ class roles_profiles::profiles::tart {
     require => Exec['install_tart'],
   }
 
-  file { "/Users/${user}/Library/LaunchAgents":
-    ensure => directory,
-    owner  => $user,
-    group  => 'staff',
-    mode   => '0755',
+  # Pull the image + clone the VMs (only when puppet owns the image lifecycle).
+  if $manage_image {
+    exec { 'pull_initial_image':
+      command => "su - ${user} -c '/usr/local/bin/tart-pull-image.sh'",
+      path    => ['/usr/bin', '/bin', '/usr/local/bin'],
+      require => File['/usr/local/bin/tart-pull-image.sh'],
+      timeout => 1800,
+      # tart list is columnar ("local <name> ..."); match the name field ($2),
+      # not $1 (the literal "local"). The old $1 check never matched, so the
+      # pull re-ran on every apply.
+      unless  => "su - ${user} -c '${bin_path} list' | awk '\$1==\"local\"{print \$2}' | grep -Fx '${vm_name_prefix}-1'",
+    }
+    $image_require = [Exec['pull_initial_image']]
+  } else {
+    $image_require = []
   }
 
-  exec { 'pull_initial_image':
-    command => "su - ${user} -c '/usr/local/bin/tart-pull-image.sh'",
-    path    => ['/usr/bin', '/bin', '/usr/local/bin'],
-    require => [File['/usr/local/bin/tart-pull-image.sh']],
-    timeout => 1800,
-    unless  => "su - ${user} -c '${bin_path} list' | awk '{print \$1}' | grep -Fx '${vm_name_prefix}-1'",
+  if $launchd_type == 'agent' {
+    file { "/Users/${user}/Library/LaunchAgents":
+      ensure => directory,
+      owner  => $user,
+      group  => 'staff',
+      mode   => '0755',
+    }
+    $dir_require = [File["/Users/${user}/Library/LaunchAgents"]]
+  } else {
+    $dir_require = []
   }
 
   Integer[1, $worker_count].each |$i| {
     $vm_name = "${vm_name_prefix}-${i}"
 
-    file { "/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist":
-      ensure  => file,
-      content => epp('roles_profiles/tart/com.mozilla.tartworker.plist.epp', {
-        worker_id => $i,
-        vm_name   => $vm_name,
-        bin_path  => $bin_path,
-        user      => $user,
-      }),
-      owner   => $user,
-      group   => 'staff',
-      mode    => '0644',
-      require => [Exec['pull_initial_image'], File["/Users/${user}/Library/LaunchAgents"]],
-      notify  => Exec["load_tartworker_${i}"],
-    }
+    if $launchd_type == 'daemon' {
+      $plist_path = "/Library/LaunchDaemons/com.mozilla.tartworker-${i}.plist"
 
-    exec { "load_tartworker_${i}":
-      command     => "su - ${user} -c 'launchctl unload /Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist 2>/dev/null || true; launchctl load /Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist'",
-      path        => ['/bin', '/usr/bin'],
-      refreshonly => true,
-      require     => File["/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist"],
+      file { $plist_path:
+        ensure  => file,
+        content => epp('roles_profiles/tart/com.mozilla.tartworker.daemon.plist.epp', {
+          worker_id => $i,
+          vm_name   => $vm_name,
+          bin_path  => $bin_path,
+          user      => $user,
+        }),
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0644',
+        require => $image_require + $dir_require,
+        notify  => Exec["load_tartworker_${i}"],
+      }
+
+      # system domain: loads headlessly, no console session required.
+      exec { "load_tartworker_${i}":
+        command     => "launchctl bootout system ${plist_path} 2>/dev/null || true; launchctl bootstrap system ${plist_path}",
+        path        => ['/bin', '/usr/bin'],
+        refreshonly => true,
+        require     => File[$plist_path],
+      }
+    } else {
+      $plist_path = "/Users/${user}/Library/LaunchAgents/com.mozilla.tartworker-${i}.plist"
+
+      file { $plist_path:
+        ensure  => file,
+        content => epp('roles_profiles/tart/com.mozilla.tartworker.plist.epp', {
+          worker_id => $i,
+          vm_name   => $vm_name,
+          bin_path  => $bin_path,
+          user      => $user,
+        }),
+        owner   => $user,
+        group   => 'staff',
+        mode    => '0644',
+        require => $image_require + $dir_require,
+        notify  => Exec["load_tartworker_${i}"],
+      }
+
+      exec { "load_tartworker_${i}":
+        command     => "su - ${user} -c 'launchctl unload ${plist_path} 2>/dev/null || true; launchctl load ${plist_path}'",
+        path        => ['/bin', '/usr/bin'],
+        refreshonly => true,
+        require     => File[$plist_path],
+      }
     }
   }
 }

--- a/modules/roles_profiles/manifests/roles/tart_worker.pp
+++ b/modules/roles_profiles/manifests/roles/tart_worker.pp
@@ -3,12 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Physical macOS host that runs gecko-t-osx-1500-m-vms tester VMs via Tart.
-# Pulls sequoia-tester from the local OCI registry and manages worker VM
-# lifecycle via per-VM LaunchAgents. The Taskcluster worker identity lives
-# inside the VM image, so this host role only manages the Tart layer.
+# Manages worker VM lifecycle via per-VM system LaunchDaemons (launchd_type:
+# daemon in hiera), which load headlessly and survive reboot without a console
+# session. The Taskcluster worker identity lives inside the VM image, so this
+# host role only manages the Tart layer.
 #
-# Admin GUI auto-login (required for the gui-domain tartworker LaunchAgents to
-# run) is set out-of-band, not by puppet: macOS needs both the
+# manage_image is false for this role (see data/roles/tart_worker.yaml): on
+# macOS 15 `tart pull` only succeeds from the console GUI session, so the image
+# is seeded once by hand and puppet only manages tart + the launchd unit. The
+# VMs run under the admin user, so admin auto-login is still set out-of-band
+# (not by puppet) for the manual image-seed step: macOS needs both the
 # com.apple.loginwindow autoLoginUser preference and /etc/kcpassword, and the
 # latter (the obfuscated admin password) cannot be delivered by a config
 # profile. Kept out of this role to avoid the admin password entering vault.

--- a/modules/roles_profiles/manifests/roles/tart_worker.pp
+++ b/modules/roles_profiles/manifests/roles/tart_worker.pp
@@ -13,5 +13,9 @@
 # latter (the obfuscated admin password) cannot be delivered by a config
 # profile. Kept out of this role to avoid the admin password entering vault.
 class roles_profiles::roles::tart_worker {
+  # The macOS application firewall blocks Tart's image-pull connections to the
+  # OCI registry (surfaces as "The Internet connection appears to be offline"),
+  # so it must be disabled — matching the existing tester hosts.
+  include roles_profiles::profiles::macos_disable_firewall
   include roles_profiles::profiles::tart
 }

--- a/modules/roles_profiles/manifests/roles/tart_worker.pp
+++ b/modules/roles_profiles/manifests/roles/tart_worker.pp
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Physical macOS host that runs gecko-t-osx-1500-m-vms tester VMs via Tart.
+# Pulls sequoia-tester from the local OCI registry and manages worker VM
+# lifecycle via per-VM LaunchAgents. The Taskcluster worker identity lives
+# inside the VM image, so this host role only manages the Tart layer.
+#
+# Admin GUI auto-login (required for the gui-domain tartworker LaunchAgents to
+# run) is set out-of-band, not by puppet: macOS needs both the
+# com.apple.loginwindow autoLoginUser preference and /etc/kcpassword, and the
+# latter (the obfuscated admin password) cannot be delivered by a config
+# profile. Kept out of this role to avoid the admin password entering vault.
+class roles_profiles::roles::tart_worker {
+  include macos_utils::disable_bluetooth_setup
+  include roles_profiles::profiles::macos_disable_firewall
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::timezone
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::tart
+}

--- a/modules/roles_profiles/manifests/roles/tart_worker.pp
+++ b/modules/roles_profiles/manifests/roles/tart_worker.pp
@@ -13,16 +13,5 @@
 # latter (the obfuscated admin password) cannot be delivered by a config
 # profile. Kept out of this role to avoid the admin password entering vault.
 class roles_profiles::roles::tart_worker {
-  include macos_utils::disable_bluetooth_setup
-  include roles_profiles::profiles::macos_disable_firewall
-  include roles_profiles::profiles::macos_run_puppet
-  include roles_profiles::profiles::motd
-  include roles_profiles::profiles::network
-  include roles_profiles::profiles::ntp
-  include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::sudo
-  include roles_profiles::profiles::timezone
-  include roles_profiles::profiles::users
-  include roles_profiles::profiles::vnc
   include roles_profiles::profiles::tart
 }

--- a/modules/roles_profiles/templates/tart/com.mozilla.tartworker.daemon.plist.epp
+++ b/modules/roles_profiles/templates/tart/com.mozilla.tartworker.daemon.plist.epp
@@ -1,0 +1,37 @@
+<%- | Integer $worker_id,
+      String  $vm_name,
+      String  $bin_path,
+      String  $user,
+| -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.tartworker-<%= $worker_id %></string>
+    <key>UserName</key>
+    <string><%= $user %></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $bin_path %></string>
+        <string>run</string>
+        <string>--no-graphics</string>
+        <string><%= $vm_name %></string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/<%= $user %></string>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>/Users/<%= $user %></string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/<%= $user %>/Library/Logs/tartworker-<%= $worker_id %>.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/<%= $user %>/Library/Logs/tartworker-<%= $worker_id %>.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## What

Adds the `tart_worker` role + hiera for the macOS Tart **tester** VM hosts
(pool `gecko-t-osx-1500-m-vms`), and reworks the shared `profiles::tart` so
those hosts can be managed on **macOS 15** without the failures we hit during
the m4-235–239 rollout.

## Why

The tester VM hosts ran `tart_worker` off a **private fork branch**
(`rcurranmoz/ronin_puppet@tart_worker_prod`) the hosts can't even re-fetch.
This brings the role onto the canonical repo. While provisioning 5 new hosts on
macOS 15.3 we found two OS-version landmines that the older-built 185–192 never
hit, so the profile needed to flex:

1. **`tart pull` only works from the console GUI session on macOS 15** — Local
   Network privacy denies Tart's connection to the LAN OCI registry from a
   headless puppet/ssh context (`su - admin`), surfacing as the misleading
   `Error: The Internet connection appears to be offline.` (curl from the same
   host pulls fine). So puppet **cannot** own the first pull on 15.x.
2. **gui-domain LaunchAgents can't be loaded over ssh on 15.3** (`bootstrap`
   EIO), so the VMs never start headlessly and don't survive reboot.

## Changes

- **`profiles::tart`** — two new hiera knobs, both defaulting to the current
  gecko-1b builder behaviour (builder hiera untouched → no behaviour change):
  - `tart.manage_image` (default `true`): when `false`, skip pull/clone. Image
    is seeded once by hand from the console; puppet only manages tart + the
    launchd unit. Also stops puppet retry-looping the doomed pull (that caused
    a ~few-hundred-email alert storm from one host over the weekend).
  - `tart.launchd_type` (default `'agent'`): `'daemon'` writes a **system
    LaunchDaemon** (UserName=admin, RunAtLoad, KeepAlive) loaded via
    `launchctl bootstrap system` — starts at boot headlessly, survives reboot.
  - Fixes a latent bug in `pull_initial_image`'s `unless` (awk'd `$1` = literal
    "local" instead of the VM-name field, so it never matched and re-pulled
    every apply).
- **New template** `com.mozilla.tartworker.daemon.plist.epp` (the LaunchDaemon).
- **`data/roles/tart_worker.yaml`** sets `manage_image: false` + `launchd_type: daemon`
  + tester registry/image (`10.49.56.161` / `sequoia-tester`).

## Validation / rollout notes

- `puppet parser validate`, `puppet epp validate`, pre-commit: all pass.
- **Still needs a real-host validation run**: confirm the system LaunchDaemon
  actually boots `tart run` as admin and the worker registers (builder pool
  precedent says daemon-run works, but it should be verified on one tester host).
- Rollout: seed the image once from the console (`vms.sh`), then `run-puppet.sh`
  applies the role → installs tart + writes the LaunchDaemon + bootstraps it.
- Existing m4-235–239 were brought up manually (`tart run &`); after this lands
  + a puppet apply they become reboot-persistent. m4-238/239 have root-owned
  VMs (provisioned via sudo) and must be redone admin-owned for the
  UserName=admin daemon to find them.