### PR TITLE
revert scriptworker-scripts upgrade

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -198,7 +198,7 @@ scriptworker_config:
         sign_chain_of_trust: true
         verify_chain_of_trust: true
         verify_cot_signature: true
-        scriptworker_scripts_revision: "61c332b4773378540bb673cd3c3b4d3ce9833e13"
+        scriptworker_scripts_revision: "bc7b9496cb677ef1dae5b76ac069027119ca45e5"
 
     ff-prod:
         <<: *defaults


### PR DESCRIPTION
This caused a scriptworker bump, which caused this exception:
```
Traceback (most recent call last):
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/worker.py", line 254, in main
    context.event_loop.run_until_complete(async_main(context, credentials))
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 650, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/worker.py", line 214, in async_main
    await run_tasks(context)
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/worker.py", line 197, in run_tasks
    status = await running_tasks.invoke(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/worker.py", line 134, in invoke
    prepare_to_run_task(context, task_defn)
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/task.py", line 648, in prepare_to_run_task
    context.claim_task = claim_task
    ^^^^^^^^^^^^^^^^^^  
  File "/usr/local/builds/dep1/.venv/lib/python3.11/site-packages/scriptworker/context.py", line 103, in claim_task
    self.credentials_fd = os.memfd_create("scriptworker_temp_creds", flags=0)
                          ^^^^^^^^^^^^^^^ 
AttributeError: module 'os' has no attribute 'memfd_create'

```

(This is new as of https://github.com/mozilla-releng/scriptworker/commit/876d622b8c0bc023f9ed092186f1b40376f4631a)