### PR TITLE
tcc_perms: add sqlite busy timeout to survive TCC.db lock race on boot

### DIFF
--- a/modules/macos_tcc_perms/files/tcc_perms.sh
+++ b/modules/macos_tcc_perms/files/tcc_perms.sh
@@ -10,11 +10,22 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
-# Function to execute the sqlite3 queries
+# Function to execute the sqlite3 queries.
+#
+# A 5s busy timeout makes sqlite wait out a transiently-locked TCC.db instead
+# of failing immediately with "database is locked (5)". This happens when
+# puppet runs at boot while cltbld's autologin session is still initializing
+# and the system briefly holds a write lock on the user TCC.db — without the
+# timeout that race fails the whole puppet apply (and fires a failure email),
+# even though a retry 60s later succeeds. The timeout is a cap, not a fixed
+# delay: sqlite returns the instant the lock frees, so the normal unlocked path
+# is not slowed. 5s comfortably covers the brief session-startup lock while
+# keeping the worst-case wait bounded on these CI hosts; a genuinely stuck lock
+# still fails (after 5s) so real problems are surfaced.
 execute_query() {
     local db_path=$1
     local query=$2
-    sudo sqlite3 "$db_path" "$query"
+    sudo sqlite3 -cmd ".timeout 5000" "$db_path" "$query"
 }
 
 # Build a TCC csreq blob (cdhash-anchored code requirement) for a given binary.


### PR DESCRIPTION
## Problem

CI macs reboot between jobs and run puppet at boot. Occasionally puppet runs while cltbld's autologin session is still initializing and the system holds a brief write lock on the user `TCC.db`. `sqlite3` then returns `SQLITE_BUSY` immediately:

```
Macos_tcc_perms/Exec[execute tcc perms script]/returns: Error: stepping, database is locked (5)
'/usr/local/bin/tcc_perms.sh' returned 5 instead of one of [0]
```

`set -e` aborts `tcc_perms.sh` (exit 5), the apply is marked failed, and `run-puppet.sh` fires a "Puppet apply failed" email — even though the automatic 60s retry succeeds once the session settles. Result: recurring spurious failure emails across the M4 fleet.

Note this is a *lock* race, not a *missing-file* race — the TCC.db exists, so the `cltbld_tcc_db_present` fact approach (#1211) does not address it.

## Fix

Give sqlite a 30s busy timeout so it waits out the transient lock instead of failing:

```bash
sudo sqlite3 -cmd ".timeout 30000" "$db_path" "$query"
```

The session-startup lock clears in well under 30s, so the write succeeds and no email is sent. A genuinely persistent lock still fails after 30s, so real problems are still surfaced. One-line change to the script's `execute_query()`; no manifest changes, so no conflict with the other in-flight tcc PRs.