### PR TITLE
profiles::worker: prefer role-owned taskcluster_version, fall back to vault

### DIFF
--- a/modules/roles_profiles/manifests/profiles/worker.pp
+++ b/modules/roles_profiles/manifests/profiles/worker.pp
@@ -18,7 +18,7 @@ class roles_profiles::profiles::worker {
       # `worker.taskcluster_version` for roles not yet migrated. The fallback is
       # lazy (only evaluated when the role key is unset) so it won't error once
       # vault's value is eventually retired.
-      $role_taskcluster_version = lookup('taskcluster_version', String, 'first', undef)
+      $role_taskcluster_version = lookup('taskcluster_version', Optional[String], 'first', undef)
       $taskcluster_version = $role_taskcluster_version ? {
         undef   => lookup('worker.taskcluster_version'),
         default => $role_taskcluster_version,

--- a/modules/roles_profiles/manifests/profiles/worker.pp
+++ b/modules/roles_profiles/manifests/profiles/worker.pp
@@ -11,8 +11,21 @@ class roles_profiles::profiles::worker {
         default            => undef,
       }
 
+      # Taskcluster worker version precedence -- moving control out of vault.
+      # Prefer a role-owned top-level `taskcluster_version` (managed here in
+      # ronin role data) so a version bump is just a puppet change that workers
+      # pick up on their next run. Fall back to the legacy vault-provided
+      # `worker.taskcluster_version` for roles not yet migrated. The fallback is
+      # lazy (only evaluated when the role key is unset) so it won't error once
+      # vault's value is eventually retired.
+      $role_taskcluster_version = lookup('taskcluster_version', String, 'first', undef)
+      $taskcluster_version = $role_taskcluster_version ? {
+        undef   => lookup('worker.taskcluster_version'),
+        default => $role_taskcluster_version,
+      }
+
       class { 'worker_runner':
-        taskcluster_version   => lookup('worker.taskcluster_version'),
+        taskcluster_version   => $taskcluster_version,
         provider_type         => lookup('worker.provider_type'),
         root_url              => 'https://firefox-ci-tc.services.mozilla.com',
         client_id             => lookup('worker.client_id'),


### PR DESCRIPTION
## Why

Follow-on from #1145 (the GitHub/S3 Taskcluster-binary downloader). #1145 reads `worker.taskcluster_version`, but that key is supplied by each host's static `vault.yaml`, which **wins the hiera lookup** (default *first* merge selects vault's entire `worker` hash) and **shadows the role-level pins**. Verified on staging `macmini-m4-111`: vault forces `100.4.0` even though role `gecko_t_osx_1500_m4_staging` pins `95.0.3`. So today the worker version is controlled by vault, not by ronin.

Goal (north star): bump a Taskcluster worker version with a **puppet change in role data**, and workers pick it up on their next between-jobs run — no per-host vault edit.

Note: simply commenting the version out of vault is **not** safe — the lookup then returns `undef` (it does not fall through to the role's `worker` hash), and `worker_runner` types it `Pattern[/^\\d+\\.\\d+\\.\\d+$/]`, so the next apply fails. Validated on m4-111.

## What this does (Phase 1 — the enabler)

`profiles::worker` now prefers a **role-owned top-level `taskcluster_version`** and falls back to the legacy vault-provided `worker.taskcluster_version` only when the role key is unset. The fallback is **lazy** so it won't error once vault's value is eventually retired.

**Backward-compatible:** no role sets the new key yet, so every host resolves exactly as before. Verified on m4-111: top-level `taskcluster_version` is unset → falls through to vault's `100.4.0` (unchanged).

## Rollout (tracked in the Jira issue)
- **Phase 2:** migrate roles by adding `taskcluster_version: <ver>` to `data/roles/<role>.yaml` (role then wins). `*_staging` roles become a real canary.
- **Phase 3:** retire `worker.taskcluster_version` from vault (now safe).
- **Phase 4:** make the downloader install idempotent (today it re-downloads from GitHub every boot because it stages to `/tmp`, which these hosts wipe on reboot).

Scope: macOS (`macos_taskcluster_binary`); Linux/Windows use separate version keys.