### PR TITLE
RELOPS-2449: skip NetFx3 install on ARM64 builders

### DIFF
--- a/modules/roles_profiles/manifests/profiles/microsoft_tools.pp
+++ b/modules/roles_profiles/manifests/profiles/microsoft_tools.pp
@@ -18,7 +18,7 @@ class roles_profiles::profiles::microsoft_tools {
         'builder':{
           ## This class seems to timeout on the first run of a new VM
           ## For now don't look for it after bootstrap.
-          if $facts['custom_win_bootstrap_stage'] != 'complete' {
+          if $facts['custom_win_bootstrap_stage'] != 'complete' and $facts['custom_win_os_arch'] != 'aarch64' {
             include win_packages::dxsdk_jun10
           }
           include win_packages::binscope

--- a/modules/win_packages/manifests/dxsdk_jun10.pp
+++ b/modules/win_packages/manifests/dxsdk_jun10.pp
@@ -3,34 +3,39 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class win_packages::dxsdk_jun10 {
-  $prog86x = $facts['custom_win_programfilesx86']
-  $sdk_dir = 'Microsoft DirectX SDK (June 2010)'
-  $file    = 'DXSDK_Jun10.exe'
+  # The ARM64 builder only runs profile generation and does not need the
+  # legacy DirectX SDK. Its NetFx3 payload is not available on Azure ARM64
+  # desktop images, so skip both NetFx3 and DXSDK there.
+  if $facts['custom_win_os_arch'] != 'aarch64' {
+    $prog86x = $facts['custom_win_programfilesx86']
+    $sdk_dir = 'Microsoft DirectX SDK (June 2010)'
+    $file    = 'DXSDK_Jun10.exe'
 
-  case $facts['az_metadata']['compute']['publisher'] {
-    'microsoftwindowsdesktop': {
-      exec { 'install_net_framework3.5':
-        command   => 'Enable-WindowsOptionalFeature -Online -FeatureName "NetFx3" -All',
-        provider  => powershell,
-        tries     => 3,
-        try_sleep => 10,
-        timeout   => 1200,
+    case $facts['az_metadata']['compute']['publisher'] {
+      'microsoftwindowsdesktop': {
+        exec { 'install_net_framework3.5':
+          command   => 'Enable-WindowsOptionalFeature -Online -FeatureName "NetFx3" -All',
+          provider  => powershell,
+          tries     => 3,
+          try_sleep => 10,
+          timeout   => 1200,
+        }
+      }
+      default: {
+        windowsfeature { 'NET-Framework-Core':
+          ensure => present,
+        }
       }
     }
-    default: {
-      windowsfeature { 'NET-Framework-Core':
-        ensure => present,
-      }
-    }
-  }
 
-  win_packages::win_exe_pkg { 'dxsdk_jun10':
-    pkg                    => 'DXSDK_Jun10.exe',
-    install_options_string => '/U',
-    creates                => "${prog86x}\\${sdk_dir}\\Include\\audiodefs.h",
-    returns                => [0, 1023],
-  }
-  windows::environment { 'DXSDK_DIR':
-    value => "${facts['custom_win_programfilesx86']}\\${sdk_dir}",
+    win_packages::win_exe_pkg { 'dxsdk_jun10':
+      pkg                    => $file,
+      install_options_string => '/U',
+      creates                => "${prog86x}\\${sdk_dir}\\Include\\audiodefs.h",
+      returns                => [0, 1023],
+    }
+    windows::environment { 'DXSDK_DIR':
+      value => "${facts['custom_win_programfilesx86']}\\${sdk_dir}",
+    }
   }
 }

--- a/test/integration/win11a6425h2azurebuilder/serverspec/microsoft_tools_spec.rb
+++ b/test/integration/win11a6425h2azurebuilder/serverspec/microsoft_tools_spec.rb
@@ -42,16 +42,16 @@ end
 if ROLE_NAME == 'win11a6425h2azurebuilder'
   describe powershell_command("(Get-WindowsOptionalFeature -Online -FeatureName 'NetFx3' -ErrorAction Stop).State") do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/^Enabled\s*$/i) }
+    its(:stdout) { should match(/^Disabled(?:WithPayloadRemoved)?\s*$/i) }
   end
 
   describe machine_env_command('DXSDK_DIR') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/^#{Regexp.escape(dxsdk_dir)}\s*$/) }
+    its(:stdout) { should match(/^\s*$/) }
   end
 
   describe file("#{dxsdk_dir}\\Include\\audiodefs.h") do
-    it { should exist }
+    it { should_not exist }
   end
 
   describe software_property_command("$_.DisplayName -eq 'Microsoft BinScope 2014'", 'DisplayVersion') do


### PR DESCRIPTION
## Summary
On ARM64 (`aarch64`) builders, skip the DirectX SDK (June 2010) and the NetFx3 install it requires. `win_packages::dxsdk_jun10` is no longer included for ARM64 builders in `roles_profiles::profiles::microsoft_tools`, and the class body is guarded so it is a no-op on ARM64. x64 desktop images are unchanged (DXSDK + NetFx3); Server images keep `NET-Framework-Core`.

## Why
The NetFx3 SxS enable (`Enable-WindowsOptionalFeature -Online -FeatureName "NetFx3" -All`) is chronically unreliable on ARM64 Azure images: DISM returns 1, the feature stays `DisabledWithPayloadRemoved`, and the packer build fails (error code 6) after ~25 min and 3 retries. This blocked production builds for `win11-a64-25h2-builder` and `trusted-win11-a64-25h2-builder`.

The DirectX SDK June 2010 installer was the only thing pulling NetFx3 (and the VC++ 2008 runtime) onto these builders, and the ARM64 builder only runs profile generation, which does not need the legacy SDK. So DXSDK is dropped on ARM64 along with NetFx3. x64 builds and ARM64 testers are unaffected.

Tracked in RELOPS-2449.

## Validation
Validated end-to-end against a real Firefox ARM64 PGO build.

- Built `win11-a64-25h2-builder-alpha` from this branch: Puppet applied with no NetFx3 error and the in-VM Pester suite passed.
- Ran `generate-profile-win64-aarch64-shippable/opt` on the alpha builder pool `gecko-1/win11-a64-25h2-builder-alpha` — the only task that runs natively on the ARM64 builder (the `win64-aarch64` build itself cross-compiles on `b-win2022`). Result: green — https://treeherder.mozilla.org/jobs?repo=try&revision=9381f2e68646
  - `generate-profile-win64-aarch64-shippable/opt`: success
  - `instrumented-build-win64-aarch64-shippable/opt`: success (one transient retry)

## Companion worker-images changes
DXSDK and the VC++ 2008 runtime were only present on these builders as a side-effect of the DirectX SDK installer, so their Pester checks were removed:
- mozilla-platform-ops/worker-images#812 — remove `directx_sdk.tests.ps1` from the ARM64 builder configs
- mozilla-platform-ops/worker-images#814 — remove `microsoft_vcc_2008_arm64.tests.ps1` from the ARM64 builder configs
