### PR TITLE
roles: role-owned taskcluster_version on mac staging pools (Phase 2, control-move)

### DIFF
--- a/data/roles/gecko_t_osx_1015_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1015_r8_staging.yaml
@@ -7,6 +7,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current effective version -- this is a no-op control move.
+taskcluster_version: '60.3.4'
+
 worker:
   taskcluster_version: 60.3.4
   provider_type: standalone

--- a/data/roles/gecko_t_osx_1400_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_staging.yaml
@@ -8,6 +8,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current effective version -- this is a no-op control move.
+taskcluster_version: '60.3.4'
+
 worker:
   taskcluster_version: 60.3.4
   provider_type: standalone

--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -8,6 +8,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current effective version -- this is a no-op control move.
+taskcluster_version: '100.4.0'
+
 worker:
   taskcluster_version: 95.0.3
   provider_type: standalone


### PR DESCRIPTION
## Phase 2 of moving the macOS worker version from vault → ronin role data

Builds on #1243 (`profiles::worker` now reads a top-level `taskcluster_version`, falling back to the legacy vault-sourced `worker.taskcluster_version`). This adds that top-level key to the **three staging roles**, pinned to **each pool's current effective version** — so it's a **no-op for the running version** and only shifts *control* from vault to role data:

| Role | Pinned to | Note |
|---|---|---|
| `gecko_t_osx_1500_m4_staging` | `100.4.0` | already running it (= latest stable) |
| `gecko_t_osx_1400_r8_staging` | `60.3.4` | unchanged |
| `gecko_t_osx_1015_r8_staging` | `60.3.4` | unchanged |

**Staging-only canary.** Prod roles migrate in a separate PR once this validates. The nested `worker.taskcluster_version` stays as the legacy fallback (retired in Phase 3).

Validated non-breaking via `puppet apply --noop` on m4-111 / r8-375 / r8-126 (#1243 testing) — each resolves to the same version it runs today.

After this, bumping a staging pool's worker version is a one-line change to this key; the worker installs it on its next reboot (cached per #1245).