### PR TITLE
roles: role-owned taskcluster_version on mac PROD pools (Phase 2, control-move)

### DIFF
--- a/data/roles/gecko_t_osx_1015_r8.yaml
+++ b/data/roles/gecko_t_osx_1015_r8.yaml
@@ -7,6 +7,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current running version -- this is a no-op control move.
+taskcluster_version: '60.3.4'
+
 worker:
   taskcluster_version: 60.3.4
   provider_type: standalone

--- a/data/roles/gecko_t_osx_1400_r8.yaml
+++ b/data/roles/gecko_t_osx_1400_r8.yaml
@@ -8,6 +8,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current running version -- this is a no-op control move.
+taskcluster_version: '60.3.4'
+
 worker:
   taskcluster_version: 60.3.4
   provider_type: standalone

--- a/data/roles/gecko_t_osx_1500_m4.yaml
+++ b/data/roles/gecko_t_osx_1500_m4.yaml
@@ -8,6 +8,11 @@ worker_metadata:
   workerType: "%{lookup('gw.worker_type')}"
   provisionerId: "%{lookup('gw.provisioner_id')}"
 
+# Role-owned Taskcluster worker version (read by profiles::worker; takes
+# precedence over the legacy vault-sourced worker.taskcluster_version below).
+# Pinned to the current running version -- this is a no-op control move.
+taskcluster_version: '91.0.2'
+
 worker:
   taskcluster_version: 91.0.2
   provider_type: standalone


### PR DESCRIPTION
Completes **Phase 2** (after staging #1246). Adds the top-level `taskcluster_version` key — which `profiles::worker` (#1243) reads first — to the three **prod** roles, pinned to each pool's **current running version** (measured via `generic-worker --version` on a representative host). No-op for the running version; shifts control from vault to role data.

| Prod role | measured on | OS | pinned to |
|---|---|---|---|
| `gecko_t_osx_1500_m4` | m4-88 | 15 | **91.0.2** |
| `gecko_t_osx_1400_r8` | r8-92 | 14.7.5 | **60.3.4** |
| `gecko_t_osx_1015_r8` | r8-80 | 10.15.7 | **60.3.4** |

Prod m4 runs **91.0.2** (vault is *not* overriding it, unlike staging's 100.4.0), so all three pin to value == nested == running — clean, **zero version change**.

Validation: the mechanism was proven end-to-end on staging (m4-111 / r8-375 / r8-126 noop runs for #1243/#1246). The macOS kitchen suites here (`gecko_t_osx_1015_r8`, `_1400_r8`, `_1500_m4`) compile-check these exact prod role catalogs. The nested `worker.taskcluster_version` stays as the legacy fallback (Phase 3 retires the vault key).

After this lands, **all macOS worker versions — staging and prod — are driven by ronin role data.**