### PR TITLE
ci(tc-bump): fix Open PR push auth

### DIFF
--- a/.github/workflows/taskcluster-binary-bump.yml
+++ b/.github/workflows/taskcluster-binary-bump.yml
@@ -126,16 +126,22 @@ jobs:
         if: steps.bump.outputs.changed == '1' && (github.event_name != 'workflow_dispatch' || inputs.dry_run == false)
         env:
           GH_TOKEN: ${{ secrets.AUTO_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           LATEST: ${{ steps.bump.outputs.latest }}
           SUMMARY: ${{ steps.bump.outputs.summary }}
         run: |
           set -euo pipefail
-          branch="auto/tc-staging-bump-$(date +%Y%m%d)"
+          # Unique per run so same-day/re-runs don't collide on the branch name.
+          branch="auto/tc-staging-bump-$(date +%Y%m%d)-${RUN_ID}"
           git config user.name  "relops-bot"
           git config user.email "ci-worker@mozilla.com"
           git checkout -b "$branch"
           git commit -am "roles: bump macOS staging taskcluster_version toward ${LATEST}"
-          git push -u origin "$branch"
+          # Checkout uses persist-credentials:false, so push with the token
+          # explicitly. Using AUTO_PR_TOKEN (not GITHUB_TOKEN) is also what lets
+          # the resulting PR trigger CI. GH masks the secret in logs.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${branch}"
 
           body="$(cat <<EOF
           Automated monthly Taskcluster worker-version bump for the **macOS staging** pools.


### PR DESCRIPTION
First real run of the bump-bot (#1247) failed at `git push`:
```
fatal: could not read Username for 'https://github.com': No such device or address
```
Cause: the Checkout step uses `persist-credentials: false` (copied from pre-commit.yml, which never pushes), so the git remote had no auth.

Fix: push via `AUTO_PR_TOKEN` explicitly (`https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git`). Using the PAT (not GITHUB_TOKEN) for the push is also what lets the resulting PR **trigger CI**. Branch name now includes `run_id` so re-runs don't collide. Secret is masked in Action logs.

The compute/ceiling logic itself already ran correctly in the failed run (1400→100.4.0, 1015→67.1.0 capped, m4 skip) — only the push step broke.