### PR TITLE
ci(kitchen-macos): install vault from HashiCorp releases, not brew

### DIFF
--- a/.github/workflows/kitchen-macos.yml
+++ b/.github/workflows/kitchen-macos.yml
@@ -70,9 +70,18 @@ jobs:
         run: ./.github/scripts/install_puppet_mac.sh
 
       - name: Install Vault
-        run: brew install vault
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: 1
+        # vault was moved out of homebrew-core into the hashicorp tap, which
+        # newer Homebrew refuses to install from ("Refusing to load formula
+        # hashicorp/tap/vault from untrusted tap"). Pull the binary straight
+        # from HashiCorp releases instead -- no brew, no tap-trust, both arches.
+        run: |
+          set -euo pipefail
+          ver="$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/vault/latest | python3 -c 'import sys,json;print(json.load(sys.stdin)["version"])')"
+          case "$(uname -m)" in arm64) arch=arm64 ;; *) arch=amd64 ;; esac
+          echo "Installing vault ${ver} (darwin_${arch})"
+          curl -fsSL -o "$RUNNER_TEMP/vault.zip" "https://releases.hashicorp.com/vault/${ver}/vault_${ver}_darwin_${arch}.zip"
+          sudo unzip -o "$RUNNER_TEMP/vault.zip" -d /usr/local/bin
+          vault --version
 
       - name: Start Vault dev server
         run: |


### PR DESCRIPTION
## The real cause of the "1015_r8 flake"

The recurring `gecko_t_osx_1015_r8 (macos-15-intel)` failures this week were **not** a flake — `brew install vault` is now a hard error on that runner:
```
Error: Refusing to load formula hashicorp/tap/vault from untrusted tap hashicorp/tap.
```
Vault was moved out of homebrew-core into `hashicorp/tap`, and newer Homebrew refuses to auto-install from untrusted taps. It surfaced first on `macos-15-intel` (newest Homebrew); it'll spread to the macos-14 / arm runners as their images update. Re-runs only "fixed" it by luck/caching.

## Fix
Skip brew/tap entirely — pull the vault binary straight from `releases.hashicorp.com` (version from the releases API, both darwin arches). No tap-trust dependency. The vault dev-server step is unchanged.

This unblocks the macOS kitchen suites for **all** mac PRs (including the in-flight bot fix #1250). Merge this first; PRs branched before it (e.g. #1250) just need a rebase to pick it up.