### PR TITLE
macos_screenshot_helper: fix empty/blank failure screenshots via WatchPaths

### DIFF
--- a/modules/macos_screenshot_helper/files/capture-on-demand.sh
+++ b/modules/macos_screenshot_helper/files/capture-on-demand.sh
@@ -6,14 +6,24 @@ TRIGGER_FILE="/Users/cltbld/.trigger_screenshot"
 
 OUTPUT_PATH=$(cat "${TRIGGER_FILE}")
 
+# Clear the trigger file up front. The truncation itself fires a WatchPaths
+# event, but that re-run sees an empty trigger and exits, so a single request
+# can never be captured twice.
+: > "${TRIGGER_FILE}"
+
 # Ensure output directory exists
 mkdir -p "$(dirname "${OUTPUT_PATH}")"
 
-# Take screenshot
-/usr/sbin/screencapture -C -x -t png "${OUTPUT_PATH}"
+# Capture to a temp file, then atomically move it into place. The harness
+# polls for OUTPUT_PATH to become non-empty, so it must only ever appear once
+# fully written -- never as a partial or zero-byte frame.
+TMP_PATH="${OUTPUT_PATH}.tmp.$$"
+/usr/sbin/screencapture -C -x -t png "${TMP_PATH}"
 
-# Log the capture
-echo "$(date): Screenshot saved to ${OUTPUT_PATH}" >> /tmp/screenshot-capture.log
-
-# Clear the trigger file
-: > "${TRIGGER_FILE}"
+if [ -s "${TMP_PATH}" ]; then
+  mv -f "${TMP_PATH}" "${OUTPUT_PATH}"
+  echo "$(date): Screenshot saved to ${OUTPUT_PATH}" >> /tmp/screenshot-capture.log
+else
+  rm -f "${TMP_PATH}"
+  echo "$(date): screencapture produced no output for ${OUTPUT_PATH}" >> /tmp/screenshot-capture.log
+fi

--- a/modules/macos_screenshot_helper/files/com.mozilla.screencapture.plist
+++ b/modules/macos_screenshot_helper/files/com.mozilla.screencapture.plist
@@ -9,8 +9,18 @@
   <array>
     <string>/Users/cltbld/bin/capture-on-demand.sh</string>
   </array>
-  <key>StartInterval</key>
-  <integer>1</integer>
+  <!--
+    Fire the moment the harness writes the trigger file. Previously this used
+    StartInterval=1, but because the helper exits almost instantly launchd
+    throttled respawns to its ~10s minimum-runtime floor, while the test
+    harness only waits 5s for the screenshot. That race produced empty /
+    blank-desktop screenshots on Apple Silicon workers. WatchPaths reacts on
+    write with sub-second latency and is not subject to the respawn throttle.
+  -->
+  <key>WatchPaths</key>
+  <array>
+    <string>/Users/cltbld/.trigger_screenshot</string>
+  </array>
   <key>RunAtLoad</key>
   <true/>
 </dict>

--- a/modules/macos_screenshot_helper/manifests/init.pp
+++ b/modules/macos_screenshot_helper/manifests/init.pp
@@ -36,12 +36,23 @@ class macos_screenshot_helper (
       source => 'puppet:///modules/macos_screenshot_helper/com.mozilla.screencapture.plist',
     }
 
+    # The agent watches this file (WatchPaths), so it must exist for the watch
+    # to be armed before the first task runs. replace => false so we create it
+    # when absent but never clobber the path the harness writes into it.
+    file { $trigger_file:
+      ensure  => present,
+      owner   => 'cltbld',
+      group   => 'staff',
+      mode    => '0644',
+      replace => false,
+    }
+
+    # bootout then bootstrap so a changed plist (e.g. StartInterval -> WatchPaths)
+    # is actually re-read. launchctl kickstart only restarts the already-loaded
+    # job definition and would not pick up plist edits.
     exec { 'load or restart screenshot agent':
-      command     => "/bin/bash -c 'if /bin/launchctl print gui/${cltbld_uid}/com.mozilla.screencapture 2>/dev/null; then \
-                    /bin/launchctl kickstart -k gui/${cltbld_uid}/com.mozilla.screencapture; \
-                  else \
-                    /bin/launchctl bootstrap gui/${cltbld_uid} \"${launchagent_path}\" 2>/dev/null; \
-                  fi; exit 0'",
+      command     => "/bin/bash -c '/bin/launchctl bootout gui/${cltbld_uid}/com.mozilla.screencapture 2>/dev/null; \
+                    /bin/launchctl bootstrap gui/${cltbld_uid} \"${launchagent_path}\" 2>/dev/null; exit 0'",
       path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
       refreshonly => true,
       subscribe   => File[$launchagent_path],


### PR DESCRIPTION
## Problem

Failure screenshots on the `gecko-t-osx-1500-m4` pool are frequently empty (zero-byte) or show a **blank desktop** instead of the browser. RELOPS-1438's trigger/LaunchAgent mechanism is correctly wired (tasks run as `cltbld`, `cltbld` owns `/dev/console`, trigger paths match), so this is not the original empty-on-ARM TCC problem — it's a **timing race**.

### Root cause (observed on `macmini-m4-102`)
`com.mozilla.screencapture.plist` used `StartInterval=1`, but `capture-on-demand.sh` exits almost instantly when the trigger file is empty. launchd therefore throttles respawns to its ~10s minimum-runtime floor:

```
launchctl print gui/555/com.mozilla.screencapture
    runs = 94          # over 16 min uptime ≈ one run / ~10s, NOT 1s
    minimum runtime = 10
    last exit code = 0
```

`/tmp/screenshot-capture.log` was absent despite 94 runs — every run found the trigger empty and bailed before capturing. The mochitest/reftest harness only waits **5s** (`10 × 0.5s`) for the screenshot, so the agent often doesn't read the trigger before the harness gives up → zero-byte upload; when it fires ~10s late onto an idle screen → blank-desktop capture. (Sampling recent failed tasks: ~58% real content, ~38% blank, plus a band of 0-byte files.)

## Fix

- **`WatchPaths`** on the trigger file instead of `StartInterval` — launchd fires on write with sub-second latency and is not subject to the respawn throttle.
- `capture-on-demand.sh`: capture to a temp file then **atomic `mv`** so the harness never observes a partial/zero-byte frame; clear the trigger up front to prevent double capture.
- Ensure the trigger file exists so the watch is armed before the first task.
- Reload via **bootout + bootstrap** (`kickstart -k` restarts the loaded job but does not re-read an edited plist, so already-provisioned hosts would otherwise keep the old config).

## Testing

- `pre-commit` (puppet-lint, puppet-validate, shellcheck, templated-script checker) passes; `plutil -lint` OK on the plist.
- The race only manifests on real hardware, so this needs validation on a worker: apply, then confirm `WatchPaths` fires (`/tmp/screenshot-capture.log` grows on task failures) and that recent `mozilla-test-fail-screenshot_*.png` artifacts show the browser rather than a blank desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)