### PR TITLE
Linux workers: automated vault.yaml fetch via mTLS

### DIFF
--- a/provisioners/linux/bootstrap_linux.sh
+++ b/provisioners/linux/bootstrap_linux.sh
@@ -131,6 +131,62 @@ function run_puppet {
     esac
 }
 
+# Fetch /root/vault.yaml from the relops-bootstrap vault-broker via mTLS,
+# using a step-ca-issued client cert that the operator's deliver_linux.sh
+# script staged at /etc/relops-bootstrap/. No-op if /root/vault.yaml is
+# already present (e.g. legacy hand-drop or already-fetched).
+#
+# See https://github.com/mozilla-platform-ops/relops-bootstrap for the
+# broker architecture. Per-role SCEP provisioners on step-ca issue certs
+# with the worker's puppet_role bound into the SPIFFE URI of the cert SAN;
+# the broker enforces that role matches the URL path.
+function fetch_vault_yaml_via_mtls {
+    local cert_dir=/etc/relops-bootstrap
+    local cert=$cert_dir/cert.pem
+    local key=$cert_dir/key.pem
+    local broker_host=forge.relops.mozilla.com
+    local role_file=/etc/puppet_role
+
+    if [ -f /root/vault.yaml ]; then
+        echo "/root/vault.yaml already present, skipping mTLS fetch"
+        return 0
+    fi
+
+    if [ ! -r "$cert" ] || [ ! -r "$key" ]; then
+        echo "no client cert at $cert_dir; skipping mTLS fetch (legacy hand-drop expected)"
+        return 0
+    fi
+
+    if [ ! -r "$role_file" ]; then
+        fail "/etc/puppet_role not set; can't determine role to fetch from broker"
+    fi
+    local role
+    role=$(tr -d '[:space:]' < "$role_file")
+    echo "fetching vault.yaml for role=$role via mTLS from $broker_host"
+
+    local tmp
+    tmp=$(mktemp /root/.vault-yaml.XXXXXX)
+    local http
+    if ! http=$(curl -sS --fail-with-body --max-time 30 \
+                --cert "$cert" --key "$key" \
+                -w '%{http_code}' \
+                -o "$tmp" \
+                "https://${broker_host}/secret/${role}"); then
+        rm -f "$tmp"
+        fail "broker fetch failed: curl exited non-zero"
+    fi
+    if [ "$http" != "200" ]; then
+        cat "$tmp" >&2 || true
+        rm -f "$tmp"
+        fail "broker returned HTTP $http"
+    fi
+
+    chmod 0640 "$tmp"
+    chown root:root "$tmp"
+    mv "$tmp" /root/vault.yaml
+    echo "vault.yaml fetched ($(wc -c < /root/vault.yaml) bytes)"
+}
+
 # If something fails hard, either exit for interactive or hang for non-interactive
 function fail {
     # TODO: emit an critical error event so provisioner knows this node needs to be handled
@@ -176,9 +232,17 @@ if [ "$(uname -s)" != "Linux" ]; then
     exit 1
 fi
 
+# If deliver_linux.sh staged a step-ca client cert at /etc/relops-bootstrap/,
+# fetch /root/vault.yaml from the broker via mTLS. If the cert isn't staged,
+# we fall through to the legacy "vault.yaml must be hand-dropped" check.
+fetch_vault_yaml_via_mtls
+
 # check for /root/vault.yaml
 if [ ! -f /root/vault.yaml ]; then
     echo "Missing /root/vault.yaml, this file is required for the bootstrap script to run."
+    echo "Either operator drops it directly (legacy flow) or operator stages"
+    echo "/etc/relops-bootstrap/{cert,key}.pem so this script can fetch it via mTLS"
+    echo "from forge.relops.mozilla.com."
     exit 1
 fi
 

--- a/provisioners/linux/deliver_linux.sh
+++ b/provisioners/linux/deliver_linux.sh
@@ -45,8 +45,23 @@ RONIN_SETTINGS="ronin_settings"
 # remote files
 ROLE_FILE_REMOTE="/etc/puppet_role"
 SECRETS_FILE_REMOTE="/root/vault.yaml"
+RELOPS_BOOTSTRAP_CERT_DIR_REMOTE="/etc/relops-bootstrap"
 RONIN_SETTINGS_REMOTE="/etc/puppet/ronin_settings"
 BOOTSTRAP_FILE_REMOTE="/tmp/bootstrap.sh"
+
+# RELOPS_BOOTSTRAP_REPO env var: path to a local checkout of
+# mozilla-platform-ops/relops-bootstrap. When set, this script mints a
+# step-ca-issued client cert via $RELOPS_BOOTSTRAP_REPO/scripts/mint-scep-cert.sh
+# and SCPs it to /etc/relops-bootstrap/ on the worker, instead of SCP'ing a
+# local vault.yaml file. bootstrap_linux.sh on the worker then fetches
+# vault.yaml from forge.relops.mozilla.com via mTLS using that cert.
+#
+# Unset RELOPS_BOOTSTRAP_REPO to keep the legacy flow (local vault.yaml SCP).
+USE_MTLS_FLOW=0
+if [ -n "${RELOPS_BOOTSTRAP_REPO:-}" ]; then
+  USE_MTLS_FLOW=1
+  MINT_HELPER="${RELOPS_BOOTSTRAP_REPO}/scripts/mint-scep-cert.sh"
+fi
 
 
 # ensure critical scripts/files exist
@@ -56,9 +71,20 @@ if [ ! -e "$BOOTSTRAP_FILE" ]; then
   exit 1
 fi
 
-if [ ! -e "$SECRETS_FILE" ]; then
-  echo "Couldn't find secrets ('$SECRETS_FILE')"
-  exit 1
+if [ "$USE_MTLS_FLOW" -eq 1 ]; then
+  if [ ! -x "$MINT_HELPER" ]; then
+    echo "ERROR: RELOPS_BOOTSTRAP_REPO is set but mint helper not executable at $MINT_HELPER"
+    exit 1
+  fi
+else
+  if [ ! -e "$SECRETS_FILE" ]; then
+    echo "Couldn't find secrets ('$SECRETS_FILE') and RELOPS_BOOTSTRAP_REPO not set."
+    echo "Either:"
+    echo "  - Drop a vault.yaml in CWD for the legacy flow, OR"
+    echo "  - export RELOPS_BOOTSTRAP_REPO=/path/to/relops-bootstrap to mint a cert and"
+    echo "    have bootstrap_linux.sh fetch vault.yaml via mTLS on the worker."
+    exit 1
+  fi
 fi
 
 
@@ -125,12 +151,38 @@ scp "$BOOTSTRAP_FILE" "$REMOTE_SSH_USER"@"$THE_HOST":$BOOTSTRAP_FILE_REMOTE
 ssh "$REMOTE_SSH_USER"@"$THE_HOST" "sudo chmod 755 $BOOTSTRAP_FILE_REMOTE"
 
 # place secrets
-# TODO: generate vault.yml with vault data
-scp "$SECRETS_FILE" "$REMOTE_SSH_USER"@"$THE_HOST":/tmp/vault.yaml
-# shellcheck disable=SC2029
-ssh "$REMOTE_SSH_USER"@"$THE_HOST" "sudo mv /tmp/vault.yaml $SECRETS_FILE_REMOTE"
-# shellcheck disable=SC2029
-ssh "$REMOTE_SSH_USER"@"$THE_HOST" "sudo chmod 640 $SECRETS_FILE_REMOTE"
+if [ "$USE_MTLS_FLOW" -eq 1 ]; then
+  # New flow: mint a step-ca cert + key locally via the relops-bootstrap helper,
+  # scp them to /etc/relops-bootstrap/ on the worker. bootstrap_linux.sh will
+  # then mTLS-fetch /root/vault.yaml from forge.relops.mozilla.com.
+  CERT_OUT=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$CERT_OUT'" EXIT
+
+  echo "Minting step-ca client cert for $THE_HOST (role=$THE_ROLE)..."
+  "$MINT_HELPER" "$THE_HOST" "$THE_ROLE" "$CERT_OUT"
+
+  # Stage cert + key under /tmp first, then sudo-move into the privileged dir.
+  scp "$CERT_OUT/cert.pem" "$REMOTE_SSH_USER"@"$THE_HOST":/tmp/relops-cert.pem
+  scp "$CERT_OUT/key.pem"  "$REMOTE_SSH_USER"@"$THE_HOST":/tmp/relops-key.pem
+
+  # shellcheck disable=SC2029
+  ssh "$REMOTE_SSH_USER"@"$THE_HOST" "
+    sudo mkdir -p $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE &&
+    sudo chmod 0700 $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE &&
+    sudo mv /tmp/relops-cert.pem $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE/cert.pem &&
+    sudo mv /tmp/relops-key.pem  $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE/key.pem &&
+    sudo chmod 0600 $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE/cert.pem $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE/key.pem &&
+    sudo chown -R root:root $RELOPS_BOOTSTRAP_CERT_DIR_REMOTE
+  "
+else
+  # Legacy flow: SCP a locally-staged vault.yaml directly.
+  scp "$SECRETS_FILE" "$REMOTE_SSH_USER"@"$THE_HOST":/tmp/vault.yaml
+  # shellcheck disable=SC2029
+  ssh "$REMOTE_SSH_USER"@"$THE_HOST" "sudo mv /tmp/vault.yaml $SECRETS_FILE_REMOTE"
+  # shellcheck disable=SC2029
+  ssh "$REMOTE_SSH_USER"@"$THE_HOST" "sudo chmod 640 $SECRETS_FILE_REMOTE"
+fi
 
 # finally, place role
 # shellcheck disable=SC2029


### PR DESCRIPTION
Replaces the operator's manual `vault.yaml` SCP step with a step-ca-issued client cert + mTLS fetch from a brokered Secret Manager. Companion to [mozilla-platform-ops/relops-bootstrap](https://github.com/mozilla-platform-ops/relops-bootstrap).

Same mechanism as the macOS Path C work that landed on m4-81 last week — adapted for Linux (no MDM equivalent, so cert minting moves to the operator's laptop instead of via SimpleMDM SCEP profile).

## What changes

### `provisioners/linux/bootstrap_linux.sh` (worker-side)
Adds a `fetch_vault_yaml_via_mtls` function that:
- Looks for a client cert at `/etc/relops-bootstrap/{cert,key}.pem`
- If present, `curl --cert ... --key ...` to `https://forge.relops.mozilla.com/secret/<role>`
- Atomic-writes the response to `/root/vault.yaml`
- Hands off to the existing puppet flow unchanged

If the cert isn't staged, the function is a no-op and falls through to the existing "vault.yaml must be hand-dropped" check. **Existing workers being provisioned today via the legacy flow continue to work unchanged.**

### `provisioners/linux/deliver_linux.sh` (operator-side)
Adds opt-in mTLS path gated on `RELOPS_BOOTSTRAP_REPO` env var:
- When set, runs `$RELOPS_BOOTSTRAP_REPO/scripts/mint-scep-cert.sh` to mint a fresh cert+key for the target host+role via SCEP against step-ca (using the operator's gcloud auth as the gate on the SCEP challenge)
- SCPs cert+key to `/etc/relops-bootstrap/` on the worker (root:root 0600)
- Operator no longer needs a local `vault.yaml` file

When `RELOPS_BOOTSTRAP_REPO` is unset, the original flow is preserved.

## Architecture

Full design doc in [mozilla-platform-ops/relops-bootstrap](https://github.com/mozilla-platform-ops/relops-bootstrap). Quick version:

- step-ca (GCE VM) has per-role SCEP provisioners (`scep-gecko-t-linux-2404-talos`, etc.). Each provisioner's x509 template hardcodes the puppet role into the cert's SPIFFE URI SAN (`spiffe://relops.mozilla/host/<CN>/role/<role>`).
- GCP HTTPS LB at `forge.relops.mozilla.com` does mTLS termination against a Trust Config containing the step-ca root + intermediate, forwards `X-Client-Cert-Leaf` (+ presence/chain-verified flags) to the broker.
- Broker (Cloud Run, FastAPI) parses the leaf cert, URL-decodes the SPIFFE URI from the SAN, role-binds against the URL path, returns `vault-<role>` from Secret Manager. Per-cert-serial rate limit + Cloud Audit logging.

## Testing — @aerickson would you mind taking this for a spin?

Validated end-to-end on macOS hardware already (m4-81 post-EACS). The Linux side hasn't been tested against a real worker yet. Want a second pair of eyes + a real-host run before we merge.

**Steps**:

```bash
# 1. Install prerequisites on your laptop
brew install sscep                # or apt install sscep on Linux
gcloud auth login                  # for Secret Manager access
gcloud config set project relops-bootstrap

# 2. Clone relops-bootstrap (the operator-side helpers live there)
git clone git@github.com:mozilla-platform-ops/relops-bootstrap.git ~/git/relops-bootstrap

# 3. Populate the vault secret for the role you want to test (one-time, from 1P)
op read "op://RelOps Vault/vault-gecko_t_linux_2404_talos/notesPlain" \
  | gcloud secrets versions add vault-gecko_t_linux_2404_talos --data-file=- \
    --project=relops-bootstrap

# 4. Check out this PR branch
cd ~/git/ronin_puppet
git fetch && git checkout rcurran/relops-bootstrap-mtls-vault-fetch

# 5. Run deliver_linux with the new flow against a TEST host
export RELOPS_BOOTSTRAP_REPO=~/git/relops-bootstrap
cd provisioners/linux
./deliver_linux.sh <test-linux-host> gecko_t_linux_2404_talos

# 6. SSH to the worker and kick the bootstrap (with -l to capture log to a file)
ssh root@<test-linux-host> "bash /tmp/bootstrap.sh -l /var/log/bootstrap.log"
```

**What you should see**:
- `deliver_linux.sh` mints a cert via sscep and SCPs it to `/etc/relops-bootstrap/{cert,key}.pem` on the worker
- `bootstrap_linux.sh` runs `fetch_vault_yaml_via_mtls` first, finds the cert, curls to `https://forge.relops.mozilla.com/secret/gecko_t_linux_2404_talos`, gets HTTP 200 with the vault.yaml content
- File lands at `/root/vault.yaml` and the rest of the bootstrap proceeds normally

**Available Linux roles** (per-role step-ca SCEP provisioners are already set up):
- `gecko_t_linux_talos`
- `gecko_t_linux_2204_talos`
- `gecko_t_linux_2404_talos`
- `gecko_t_linux_2404_talos_wayland`
- `gecko_t_linux_netperf`
- `gecko_t_linux_2404_netperf`

(Each role's `vault-<role>` secret in Secret Manager needs to be populated once before the first worker of that role can fetch — step 3 above. Currently all 6 secret containers exist but have no version data yet.)

**If anything goes wrong**, the diagnostic trail is:
- `bootstrap_linux.sh` output: wherever you pointed `-l` (or stdout if interactive)
- `mint-scep-cert.sh` errors print to stderr on your laptop
- Broker logs: `gcloud logging read 'resource.type=cloud_run_revision AND resource.labels.service_name=vault-broker' --project relops-bootstrap --freshness 5m`