### PR TITLE
roles: bump macOS staging taskcluster_version toward 100.5.0

### DIFF
--- a/data/roles/gecko_t_osx_1015_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1015_r8_staging.yaml
@@ -10,7 +10,7 @@ worker_metadata:
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
 # Pinned to the current effective version -- this is a no-op control move.
-taskcluster_version: '60.3.4'
+taskcluster_version: '67.1.0'
 
 worker:
   taskcluster_version: 60.3.4

--- a/data/roles/gecko_t_osx_1400_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_staging.yaml
@@ -11,7 +11,7 @@ worker_metadata:
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
 # Pinned to the current effective version -- this is a no-op control move.
-taskcluster_version: '60.3.4'
+taskcluster_version: '100.5.0'
 
 worker:
   taskcluster_version: 60.3.4

--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -11,7 +11,7 @@ worker_metadata:
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
 # Pinned to the current effective version -- this is a no-op control move.
-taskcluster_version: '100.4.0'
+taskcluster_version: '100.5.0'
 
 worker:
   taskcluster_version: 95.0.3


### PR DESCRIPTION
Automated monthly Taskcluster worker-version bump for the **macOS staging** pools.

Latest stable taskcluster: **100.5.0**

Proposed staging bumps (capped per each pool's macOS/Go-toolchain ceiling):
- `gecko_t_osx_1400_r8_staging`: 60.3.4 → **100.5.0**
- `gecko_t_osx_1015_r8_staging`: 60.3.4 → **67.1.0** (capped at OS ceiling)
- `gecko_t_osx_1500_m4_staging`: 100.4.0 → **100.5.0**

### Validate before merging
Push a try run routing test tasks to the staging pools (they aren't in normal try routing):
```
./mach try fuzzy \
  --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging \
  --worker-override t-osx-1400-r8=releng-hardware/gecko-t-osx-1400-r8-staging \
  --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1015-r8-staging \
  -q "'test"
```
Staging hosts pick up the new binary on their next reboot (cached). After staging is green, bump the **prod** roles in a separate PR.

_Opened by `.github/workflows/taskcluster-binary-bump.yml`. Do not auto-merge._