### PR TITLE
ci: fix staging smoke try commands + add /try-mac 1015

### DIFF
--- a/.github/workflows/mac-staging-test.yml
+++ b/.github/workflows/mac-staging-test.yml
@@ -14,7 +14,8 @@ jobs:
     if: |
       github.event.issue.pull_request != null &&
       (startsWith(github.event.comment.body, '/try-mac 1400') ||
-       startsWith(github.event.comment.body, '/try-mac 1500'))
+       startsWith(github.event.comment.body, '/try-mac 1500') ||
+       startsWith(github.event.comment.body, '/try-mac 1015'))
     runs-on: ubuntu-latest
 
     steps:
@@ -39,6 +40,9 @@ jobs:
           elif [[ "$COMMENT" == "/try-mac 1500"* ]]; then
             echo "pool=1500" >> "$GITHUB_OUTPUT"
             echo "group_id=151249" >> "$GITHUB_OUTPUT"
+          elif [[ "$COMMENT" == "/try-mac 1015"* ]]; then
+            echo "pool=1015" >> "$GITHUB_OUTPUT"
+            echo "group_id=127888" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get PR branch and repo
@@ -105,9 +109,11 @@ jobs:
           BRANCH="${{ steps.pr.outputs.branch }}"
 
           if [ "$POOL" = "1400" ]; then
-            TRY_CMD="./mach try fuzzy --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1400-r8-staging --tag os_integration -q 'test-macosx1400'"
+            TRY_CMD="./mach try fuzzy --all-tasks --worker-override t-osx-1400-r8=releng-hardware/gecko-t-osx-1400-r8-staging -q \"'test-macosx1470-64/opt 'cppunittest\""
+          elif [ "$POOL" = "1015" ]; then
+            TRY_CMD="./mach try fuzzy --all-tasks --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1015-r8-staging -q \"'test-macosx1015-64-qr/opt 'xpcshell\""
           else
-            TRY_CMD="./mach try fuzzy --all-tasks --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging -q 'test-macosx1500'"
+            TRY_CMD="./mach try fuzzy --all-tasks --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging -q \"'test-macosx1500-aarch64/opt 'xpcshell !vms\""
           fi
 
           printf 'Puppet triggered on `gecko-t-osx-%s-staging` with branch `%s`. Allow ~5 min for puppet to complete, then from your gecko checkout:\n\n```\n%s\n```' \

--- a/.github/workflows/taskcluster-binary-bump.yml
+++ b/.github/workflows/taskcluster-binary-bump.yml
@@ -152,15 +152,22 @@ jobs:
           $(echo -e "${SUMMARY}")
 
           ### Validate before merging
-          Push a try run routing test tasks to the staging pools (they aren't in normal try routing):
+          Push one try run per staging pool (these pools aren't in normal try routing). Each is a
+          minimal smoke that just exercises the worker binary (claim -> run -> upload); use the
+          suite that actually generates on each platform post-migration:
           \`\`\`
-          ./mach try fuzzy \\
-            --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging \\
-            --worker-override t-osx-1400-r8=releng-hardware/gecko-t-osx-1400-r8-staging \\
-            --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1015-r8-staging \\
-            -q "'test"
+          # 1500 / m4
+          ./mach try fuzzy --all-tasks --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging -q "'test-macosx1500-aarch64/opt 'xpcshell !vms"
+
+          # 1400 / Sonoma  (macosx1470-64 only generates cppunittest/gtest now; mochitests moved to m4)
+          ./mach try fuzzy --all-tasks --worker-override t-osx-1400-r8=releng-hardware/gecko-t-osx-1400-r8-staging -q "'test-macosx1470-64/opt 'cppunittest"
+
+          # 1015 / Catalina
+          ./mach try fuzzy --all-tasks --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1015-r8-staging -q "'test-macosx1015-64-qr/opt 'xpcshell"
           \`\`\`
-          Staging hosts pick up the new binary on their next reboot (cached). After staging is green, bump the **prod** roles in a separate PR.
+          (Or comment \`/try-mac 1500\` | \`/try-mac 1400\` | \`/try-mac 1015\` on this PR to deploy the
+          branch to that staging pool automatically.) Staging hosts pick up the new binary on their
+          next reboot (cached). After staging is green, bump the **prod** roles in a separate PR.
 
           _Opened by \`.github/workflows/taskcluster-binary-bump.yml\`. Do not auto-merge._
           EOF


### PR DESCRIPTION
## Why
While smoke-testing a taskcluster-binary change on the staging pools, the try commands our automation emits turned out to be broad and, for the **1400** pool, **broken**.

## What was wrong
**`mac-staging-test.yml`** (`/try-mac` ChatOps completion comment) — the 1400 command:
```
./mach try fuzzy --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1400-r8-staging --tag os_integration -q 'test-macosx1400'
```
- overrides the **wrong alias** (`t-osx-1015-r8` pointed at the 1400 pool — no-op)
- targets a **non-existent platform** (`test-macosx1400`; the 1400 pool is `macosx1470-64`)
- uses `--tag os_integration`, which **isn't a `mach try` flag** (os-integration is cron-only, and those suites no longer generate on `macosx1470` post-migration)

**`taskcluster-binary-bump.yml`** (monthly bot PR body) emitted one broad `-q "'test"` push.

## What this does
- **1400** → `cppunittest` on `macosx1470-64/opt` (the suite that actually generates there now)
- **1500** → `xpcshell` on `macosx1500-aarch64/opt`, excluding `-vms` (those use a different, non-overridden worker)
- **Adds `/try-mac 1015`** (SimpleMDM group `127888`) → `xpcshell` on `macosx1015-64-qr/opt`
- Bump-bot PR body now lists three minimal per-pool smoke commands + the `/try-mac` shortcut, and notes the `macosx1470` cppunittest/gtest-only reality.

## Validation
All three commands pushed green on staging today: try Lando `61921` (m4), `61922` (1400), `61924` (1015).

🤖 Generated with [Claude Code](https://claude.com/claude-code)