### PR TITLE
tcc: fail-safe SIP detection for hosts in Custom Configuration

### DIFF
--- a/modules/macos_safaridriver/files/add_tcc_perms.sh
+++ b/modules/macos_safaridriver/files/add_tcc_perms.sh
@@ -25,9 +25,16 @@ os_version=$(sw_vers -productVersion)
 # the legacy fleet has always relied on. On SIP-on hosts the equivalent
 # grants come from the org.mozilla.ci-tcc-pppc MDM profile deployed via
 # SimpleMDM; the sqlite3 writes would silently fail or abort there.
-SIP_DISABLED=false
-if csrutil status 2>/dev/null | grep -qi "disabled"; then
-    SIP_DISABLED=true
+#
+# Default to SIP-off (legacy behavior). Only treat the host as SIP-on when
+# csrutil status clearly says "enabled". Some hosts return output like
+# "unknown (Custom Configuration)" when SIP is in a partial/custom state;
+# a naive `grep "disabled"` misses those and silently skips the system-DB
+# writes that the legacy fleet relies on. Fail-safe to preserving legacy
+# behavior for anything ambiguous.
+SIP_DISABLED=true
+if csrutil status 2>/dev/null | grep -qiE "status:[[:space:]]*enabled\.?$"; then
+    SIP_DISABLED=false
 fi
 
 # Function to run SQLite queries

--- a/modules/macos_tcc_perms/files/tcc_perms.sh
+++ b/modules/macos_tcc_perms/files/tcc_perms.sh
@@ -56,9 +56,16 @@ csreq_for_binary() {
 # SIP-compatible fleet) those writes silently fail; the equivalent
 # system-level grants come from the org.mozilla.ci-tcc-pppc MDM profile
 # deployed via SimpleMDM instead.
-SIP_DISABLED=false
-if csrutil status 2>/dev/null | grep -qi "disabled"; then
-    SIP_DISABLED=true
+#
+# Default to SIP-off (legacy behavior). Only treat the host as SIP-on when
+# csrutil status clearly says "enabled". Some hosts return output like
+# "unknown (Custom Configuration)" when SIP is in a partial/custom state;
+# a naive `grep "disabled"` misses those and silently skips the system-DB
+# writes that the legacy fleet relies on. Fail-safe to preserving legacy
+# behavior for anything ambiguous.
+SIP_DISABLED=true
+if csrutil status 2>/dev/null | grep -qiE "status:[[:space:]]*enabled\.?$"; then
+    SIP_DISABLED=false
 fi
 
 # Get the macOS version


### PR DESCRIPTION
## Summary

Follow-up to #1152. Inverts the default in the SIP detection block of `tcc_perms.sh` and `add_tcc_perms.sh` so anything other than a clean `System Integrity Protection status: enabled.` is treated as SIP-off (legacy behavior).

The current logic:

```bash
SIP_DISABLED=false
if csrutil status 2>/dev/null | grep -qi "disabled"; then
    SIP_DISABLED=true
fi
```

misses hosts whose `csrutil status` returns `"unknown (Custom Configuration)"`. Those hosts silently fall through to the SIP-on code path and the legacy system-DB writes they rely on get skipped.

## Where this was observed

During validation of #1152, two production staging r8 hosts (`macmini-r8-109`, `macmini-r8-154`) reported this state:

```
% csrutil status
System Integrity Protection status: unknown (Custom Configuration).
```

Neither is actively broken today — the entries from previous master-branch puppet runs persist. But if either loses its system TCC.db (EACS, OS reinstall, sqlite reset), the next puppet run wouldn't re-apply them.

## The fix

Invert the default so ambiguity falls through to the legacy path:

```bash
SIP_DISABLED=true
if csrutil status 2>/dev/null | grep -qiE "status:[[:space:]]*enabled\.?$"; then
    SIP_DISABLED=false
fi
```

Clean SIP-off (`disabled.`) and clean SIP-on (`enabled.`) hosts behave the same as before. Only ambiguous / edge-case output changes behavior — and it changes to the safer (write the legacy entries) direction.

## Test plan

- [x] Regex hand-checked against the three real `csrutil status` outputs observed in the fleet:
  * `System Integrity Protection status: enabled.` → matches → SIP_DISABLED=false ✓
  * `System Integrity Protection status: disabled.` → doesn't match → SIP_DISABLED=true ✓
  * `System Integrity Protection status: unknown (Custom Configuration).` → doesn't match → SIP_DISABLED=true ✓ (fail-safe to legacy)
- [ ] Puppet apply on `macmini-r8-109` or `macmini-r8-154` (Custom Configuration) — expect the system-DB writes to happen this time.
- [ ] Puppet apply on a cleanly-SIP-disabled host (any m4-{111,112,113}, r8-{246,361,375}, r8-1015) — should behave identically to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)