### PR TITLE
provisioners/macos: simplemdm bootstrap targets master

### DIFF
--- a/provisioners/macos/simplemdm_bootstrap_sip_safari.sh
+++ b/provisioners/macos/simplemdm_bootstrap_sip_safari.sh
@@ -35,7 +35,7 @@ if [ -f "$SENTINEL" ]; then
   exit 0
 fi
 
-PUPPET_BRANCH=sip-compatible-safari-automation
+PUPPET_BRANCH=master
 PUPPET_REPO=https://github.com/mozilla-platform-ops/ronin_puppet.git
 REPO_DIR=/opt/puppet_environments/mozilla-platform-ops/ronin_puppet
 LD_LABEL=com.mozilla.m4-bootstrap


### PR DESCRIPTION
## Summary

Post-merge follow-up to #1152. Flips the `PUPPET_BRANCH` inside `provisioners/macos/simplemdm_bootstrap_sip_safari.sh` from `sip-compatible-safari-automation` to `master`, now that the feature branch has landed.

```diff
-PUPPET_BRANCH=sip-compatible-safari-automation
+PUPPET_BRANCH=master
```

Rationale: keeping the feature-branch reference in the source-of-truth would pin every future re-provision to a soon-to-be-stale branch. New M4 EACS cycles should pull from `master` alongside the rest of the fleet.

## Operator action required after merge

**The SimpleMDM Script itself is not automatically updated by this PR.** The web UI copy of "Dev - CC- Bootstrap" (script id 14716) still holds the old branch reference until an operator copy-pastes the updated file contents into the SimpleMDM Scripts UI. Sequence when convenient:

1. Merge this PR
2. In SimpleMDM: Scripts → "Dev - CC- Bootstrap" → replace contents with the version now at `provisioners/macos/simplemdm_bootstrap_sip_safari.sh` in master
3. Optionally: rename the SimpleMDM script to drop the "Dev -" prefix if it's no longer dev-only

## Test plan

- [x] Repo file updated
- [ ] SimpleMDM script contents refreshed (manual step above)
- [ ] Next EACS cycle on a fresh M4 host validates the master-targeted bootstrap end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)