### PR TITLE
linux: run `apt autoremove` when boot partition is full

### DIFF
--- a/modules/linux_cltbld_and_apt_cleaner/files/cltbld-and-apt-cleaner.sh
+++ b/modules/linux_cltbld_and_apt_cleaner/files/cltbld-and-apt-cleaner.sh
@@ -12,9 +12,21 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
+disk_usage_percent() {
+  local path="$1"
+  local usage
+
+  usage=$(df --output=pcent "$path" 2>/dev/null | tail -1 | tr -dc "0-9")
+  if [[ "$usage" =~ ^[0-9]+$ ]]; then
+    echo "$usage"
+  else
+    echo 0
+  fi
+}
+
 SECONDS=0
-root_usage=$(df --output=pcent / | tail -1 | tr -dc "0-9")
-boot_usage=$(df --output=pcent /boot | tail -1 | tr -dc "0-9")
+root_usage=$(disk_usage_percent /)
+boot_usage=$(disk_usage_percent /boot)
 
 echo "Root disk usage is ${root_usage}%"
 echo "Boot disk usage is ${boot_usage}%"

--- a/modules/linux_cltbld_and_apt_cleaner/files/cltbld-and-apt-cleaner.sh
+++ b/modules/linux_cltbld_and_apt_cleaner/files/cltbld-and-apt-cleaner.sh
@@ -13,28 +13,36 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 SECONDS=0
-usage=$(df --output=pcent / | tail -1 | tr -dc "0-9")
-echo "Disk usage is ${usage}%"
-if [ "$usage" -le 70 ]; then
-  echo "Disk usage below threshold, skipping cleanup. Elapsed: ${SECONDS}s"
+root_usage=$(df --output=pcent / | tail -1 | tr -dc "0-9")
+boot_usage=$(df --output=pcent /boot | tail -1 | tr -dc "0-9")
+
+echo "Root disk usage is ${root_usage}%"
+echo "Boot disk usage is ${boot_usage}%"
+
+if [ "$root_usage" -le 70 ] && [ "$boot_usage" -le 70 ]; then
+  echo "Disk usage below thresholds, skipping cleanup. Elapsed: ${SECONDS}s"
   exit 0
 fi
 
-echo "Disk usage above 70%, performing cleanup..."
+echo "Disk usage above threshold, performing cleanup..."
 
-echo "Cleaning up build caches..."
-for target in /home/cltbld/.mozbuild \
-              /home/cltbld/caches \
-              /home/cltbld/file-caches.json \
-              /home/cltbld/directory-caches.json; do
-    if [ -e "$target" ]; then
-        size=$(du -sh "$target" 2>/dev/null | cut -f1)
-        echo "  removing $target ($size)"
-        rm -rf "$target"
-    else
-        echo "  skipping $target (not present)"
-    fi
-done
+if [ "$root_usage" -gt 70 ]; then
+  echo "Cleaning up build caches..."
+  for target in /home/cltbld/.mozbuild \
+                /home/cltbld/caches \
+                /home/cltbld/file-caches.json \
+                /home/cltbld/directory-caches.json; do
+      if [ -e "$target" ]; then
+          size=$(du -sh "$target" 2>/dev/null | cut -f1)
+          echo "  removing $target ($size)"
+          rm -rf "$target"
+      else
+          echo "  skipping $target (not present)"
+      fi
+  done
+else
+  echo "Root disk usage below threshold; skipping build cache cleanup"
+fi
 
 echo "Cleaning up apt/deb..."
 apt-get autoremove -y

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2204_talos_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2204_talos_generic_worker.pp
@@ -35,6 +35,7 @@ class roles_profiles::profiles::gecko_t_linux_2204_talos_generic_worker {
       require linux_talos
 
       require linux_directory_cleaner
+      require linux_cltbld_and_apt_cleaner
 
       class { 'puppet::atboot':
         telegraf_user     => lookup('telegraf.user'),

--- a/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_t_linux_2404_talos_generic_worker_wayland.pp
@@ -37,6 +37,7 @@ class roles_profiles::profiles::gecko_t_linux_2404_talos_generic_worker_wayland 
       require linux_talos
 
       require linux_directory_cleaner
+      require linux_cltbld_and_apt_cleaner
 
       class { 'puppet::atboot':
         telegraf_user     => lookup('telegraf.user'),


### PR DESCRIPTION
We previously would only `autoremove` when / was over 70%, now we check /boot also.

Also, adds the cleaner to all linux roles.