### PR TITLE
RELOPS-2402: fleetbench PSU/firmware-throttle detector (hardware fleet)

### DIFF
--- a/data/os/Windows.yaml
+++ b/data/os/Windows.yaml
@@ -48,6 +48,14 @@ windows:
   ext_pkg_src: "https://roninpuppetassets.blob.core.windows.net/binaries"
   ext_gpg_src: "https://roninpuppetassets.blob.core.windows.net/binaries/gpg"
 
+  # Fleetbench - fleet hardware-health benchmarking collector (RELOPS-2402)
+  # Collector binary is pulled from GitHub releases; pin the version here.
+  fleetbench:
+    version: '0.4.0'
+    download_url: "https://github.com/mozilla-platform-ops/fleetbench/releases/download"
+    install_dir: "%{facts.custom_win_systemdrive}\\fleetbench"
+    results_dir: "%{facts.custom_win_systemdrive}\\fleetbench\\results"
+
   # Taskcluster resources
   taskcluster:
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/modules/roles_profiles/manifests/profiles/hardware_observability.pp
+++ b/modules/roles_profiles/manifests/profiles/hardware_observability.pp
@@ -9,6 +9,12 @@ class roles_profiles::profiles::hardware_observability {
             server    => lookup('windows.datacenter.marlin.ip'),
             server_pw => lookup('marlin_pw')
         }
+        class { win_fleetbench::init:
+            version      => lookup('windows.fleetbench.version'),
+            download_url => lookup('windows.fleetbench.download_url'),
+            install_dir  => lookup('windows.fleetbench.install_dir'),
+            results_dir  => lookup('windows.fleetbench.results_dir'),
+        }
     }
     default: {
       fail("${$facts['os']['name']} not supported")

--- a/modules/win_fleetbench/files/fleetbench_baselines.json
+++ b/modules/win_fleetbench/files/fleetbench_baselines.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "_comment": "Known-good fleetbench `cpu` benchmark ranges per hardware type (RELOPS-2402). Deployed alongside the collector by the win_fleetbench module and read by maintainsystem-hw.ps1. To support a NEW hardware type, add an entry keyed by a short type name with a `model_match` glob (matched against Win32_ComputerSystem.Model) and its thresholds. All frequency values are % of the CPU base clock; tput_cv_pct is the prime-sieve throughput coefficient of variation (%). Collected with: fleetbench cpu --mode quick --duration 900s --json.",
+  "hardware_types": {
+    "nuc13": {
+      "model_match": "NUC13*",
+      "source": "healthy NUC13ANHi5 perf-debug nodes (i5-1340P, base 1900 MHz) at 900s, 2026-06-10; see RELOPS-2402",
+      "thresholds": {
+        "min_floor_pct": { "good_min": 75, "bad_below": 50 },
+        "mean_pct":      { "good_min": 100, "bad_below": 95 },
+        "tput_cv_pct":   { "good_max": 25, "bad_above": 40 }
+      },
+      "reference": {
+        "min_floor_pct": 84,
+        "mean_pct": 108,
+        "tput_cv_pct": 17,
+        "iterations": 221600
+      },
+      "drop_off": {
+        "mean_pct_drop": 5,
+        "min_floor_pct_drop": 10,
+        "iterations_drop_pct": 10
+      }
+    }
+  }
+}

--- a/modules/win_fleetbench/files/run_fleetbench.ps1
+++ b/modules/win_fleetbench/files/run_fleetbench.ps1
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+<#
+.SYNOPSIS
+    Wrapper that runs the fleetbench collector and saves its JSON output to a
+    known results location.
+
+.DESCRIPTION
+    Invokes the fleetbench collector binary for the given suite/mode, captures
+    its JSON envelope from stdout, and writes it atomically (via a .partial
+    file + rename) into the results directory using a sortable, host-scoped
+    filename: <UTC-timestamp>_<host>_<suite>.json
+
+    Deployed by the win_fleetbench Puppet module (RELOPS-2402). Intended to be
+    invoked by a scheduled task / worker-startup hook in a later step.
+
+.PARAMETER BinaryPath
+    Full path to the fleetbench collector executable.
+
+.PARAMETER ResultsDir
+    Directory where result envelopes are written.
+
+.PARAMETER Suite
+    Collector subcommand to run (default: cpu).
+
+.PARAMETER Mode
+    Benchmark mode passed to the collector (quick|normal|long; default: normal).
+
+.PARAMETER ExtraArgs
+    Additional arguments forwarded verbatim to the collector (e.g. --duration 10m).
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BinaryPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDir,
+
+    [string]$Suite = 'cpu',
+
+    [string]$Mode = 'normal',
+
+    [string[]]$ExtraArgs = @()
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $BinaryPath)) {
+    Write-Error "fleetbench binary not found: $BinaryPath"
+    exit 1
+}
+
+# Ensure the known results location exists.
+if (-not (Test-Path -LiteralPath $ResultsDir)) {
+    New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
+}
+
+$timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+$hostName  = $env:COMPUTERNAME
+$baseName  = "${timestamp}_${hostName}_${Suite}"
+$finalPath = Join-Path $ResultsDir "$baseName.json"
+$partPath  = "$finalPath.partial"
+$errPath   = Join-Path $ResultsDir "$baseName.stderr.log"
+
+$collectorArgs = @($Suite, '--mode', $Mode, '--json') + $ExtraArgs
+
+Write-Host "Running: $BinaryPath $($collectorArgs -join ' ')"
+
+# Run the collector, capturing stdout to the .partial file and stderr to a log.
+& $BinaryPath @collectorArgs 1> $partPath 2> $errPath
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -eq 0 -and (Test-Path -LiteralPath $partPath) -and (Get-Item -LiteralPath $partPath).Length -gt 0) {
+    Move-Item -LiteralPath $partPath -Destination $finalPath -Force
+    # No stderr content worth keeping on success.
+    if ((Test-Path -LiteralPath $errPath) -and (Get-Item -LiteralPath $errPath).Length -eq 0) {
+        Remove-Item -LiteralPath $errPath -Force
+    }
+    Write-Host "fleetbench result written: $finalPath"
+    exit 0
+}
+else {
+    # Preserve the partial output for diagnostics on failure.
+    if (Test-Path -LiteralPath $partPath) {
+        Move-Item -LiteralPath $partPath -Destination "$finalPath.failed" -Force
+    }
+    Write-Error "fleetbench collector failed (exit $exitCode); see $errPath"
+    exit $exitCode
+}

--- a/modules/win_fleetbench/manifests/init.pp
+++ b/modules/win_fleetbench/manifests/init.pp
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Installs the fleetbench hardware-health benchmarking collector on Windows
+# hardware nodes and deploys a wrapper script that runs it and saves the
+# results to a known location. Wired in via the hardware_observability profile.
+# See https://github.com/mozilla-platform-ops/fleetbench (RELOPS-2402).
+class win_fleetbench::init (
+  String $version,
+  String $download_url,
+  String $install_dir,
+  String $results_dir,
+) {
+  $pkg       = "fleetbench-v${version}-windows-x86_64.exe"
+  $url       = "${download_url}/v${version}/${pkg}"
+  $binary    = "${install_dir}\\fleetbench-${version}.exe"
+  $wrapper   = "${install_dir}\\run_fleetbench.ps1"
+  $baselines = "${install_dir}\\fleetbench_baselines.json"
+
+  file { $install_dir:
+    ensure => directory,
+  }
+
+  # Known location where benchmark result envelopes are written.
+  file { $results_dir:
+    ensure  => directory,
+    require => File[$install_dir],
+  }
+
+  # Pull the pinned collector binary from GitHub releases. The on-disk name is
+  # version-stamped so a hiera version bump triggers a fresh download.
+  archive { 'fleetbench-collector':
+    ensure  => present,
+    source  => $url,
+    path    => $binary,
+    creates => $binary,
+    cleanup => false,
+    extract => false,
+    require => File[$install_dir],
+  }
+
+  # Wrapper that invokes the collector and writes results to $results_dir.
+  file { $wrapper:
+    ensure  => file,
+    content => file('win_fleetbench/run_fleetbench.ps1'),
+    require => File[$install_dir],
+  }
+
+  # Known-good per-hardware-type baselines, co-located with the collector. The
+  # maintain-system fleetbench check reads this for its good/bad determination.
+  file { $baselines:
+    ensure  => file,
+    content => file('win_fleetbench/fleetbench_baselines.json'),
+    require => File[$install_dir],
+  }
+}

--- a/modules/win_nsclient/files/check_fleetbench.ps1
+++ b/modules/win_nsclient/files/check_fleetbench.ps1
@@ -1,0 +1,65 @@
+# scripts\check_fleetbench.ps1
+# NSClient++ external check that surfaces the latest fleetbench hardware-health
+# verdict to Marlin (Icinga2). It does NOT run the benchmark — it reads the status
+# file written by the maintain-system fleetbench check (RELOPS-2402):
+#   C:\fleetbench\results\fleetbench_status.json
+# Nagios contract: print one line "STATE - text | perfdata" and exit 0/1/2/3.
+
+$ErrorActionPreference = 'Stop'
+
+function Exit-With([int]$code, [string]$msg) {
+    Write-Output $msg
+    exit $code
+}
+
+$statusFile  = 'C:\fleetbench\results\fleetbench_status.json'
+$maxAgeHours = 168   # status older than 7 days is considered stale
+
+if (-not (Test-Path -LiteralPath $statusFile)) {
+    Exit-With 3 "UNKNOWN - no fleetbench status yet (no benchmark has run)"
+}
+
+try {
+    $s = Get-Content -LiteralPath $statusFile -Raw | ConvertFrom-Json
+}
+catch {
+    Exit-With 3 "UNKNOWN - cannot read fleetbench status: $($_.Exception.Message)"
+}
+
+# Age of the last run
+$ageH = $null
+try {
+    $ageH = [math]::Round(((Get-Date).ToUniversalTime() - ([datetime]$s.timestamp_utc).ToUniversalTime()).TotalHours, 1)
+}
+catch { }
+
+# Coerce metrics (may be null for UNKNOWN/unparseable)
+$minPct  = if ($null -ne $s.min_pct)    { [double]$s.min_pct }    else { 0 }
+$meanPct = if ($null -ne $s.mean_pct)   { [double]$s.mean_pct }   else { 0 }
+$cv      = if ($null -ne $s.tput_cv)    { [double]$s.tput_cv }    else { 0 }
+$iters   = if ($null -ne $s.iterations) { [int]$s.iterations }    else { 0 }
+
+# Numeric health code for graphing in Grafana/InfluxDB
+$health = switch ($s.verdict) { 'GOOD' { 0 } 'MARGINAL' { 1 } 'BAD' { 2 } default { 3 } }
+
+$ageVal = if ($null -ne $ageH) { $ageH } else { 0 }
+$perf = "health=$health;1;2;0;3 min_pct=$minPct;;;0;200 mean_pct=$meanPct;;;0;200 tput_cv=$cv;;;0;100 iters=$iters age_h=$ageVal"
+
+$summary = "verdict=$($s.verdict) hw=$($s.hw_type) min%base=$([math]::Round($minPct)) mean%base=$([math]::Round($meanPct)) tputCV=$([math]::Round($cv))% iters=$iters"
+if ($s.drift) { $summary += " DROP-OFF($($s.drift_note))" }
+if ($null -ne $ageH) { $summary += " age=${ageH}h" }
+
+# Stale status -> WARN regardless of last verdict
+if ($null -ne $ageH -and $ageH -gt $maxAgeHours) {
+    Exit-With 1 "WARN - fleetbench status stale - $summary | $perf"
+}
+
+switch ($s.verdict) {
+    'GOOD' {
+        if ($s.drift) { Exit-With 1 "WARN - $summary | $perf" }
+        else { Exit-With 0 "OK - $summary | $perf" }
+    }
+    'MARGINAL'    { Exit-With 1 "WARN - $summary | $perf" }
+    'BAD'         { Exit-With 2 "CRITICAL - $summary | $perf" }
+    default       { Exit-With 3 "UNKNOWN - $summary | $perf" }
+}

--- a/modules/win_nsclient/files/check_fleetbench_variance.ps1
+++ b/modules/win_nsclient/files/check_fleetbench_variance.ps1
@@ -1,0 +1,62 @@
+# scripts\check_fleetbench_variance.ps1
+# NSClient++ external check that surfaces fleetbench run-to-run VARIANCE to Marlin:
+# the latest run compared to the node's FIRST recorded run (its initial baseline).
+# Complements check_fleetbench.ps1 (which reports the absolute GOOD/BAD verdict).
+# Reads the status file written by the maintain-system fleetbench check (RELOPS-2402):
+#   C:\fleetbench\results\fleetbench_status.json
+# Nagios contract: print one line "STATE - text | perfdata" and exit 0/1/2/3.
+
+$ErrorActionPreference = 'Stop'
+
+function Exit-With([int]$code, [string]$msg) {
+    Write-Output $msg
+    exit $code
+}
+
+$statusFile  = 'C:\fleetbench\results\fleetbench_status.json'
+$maxAgeHours = 168   # status older than 7 days is considered stale
+
+if (-not (Test-Path -LiteralPath $statusFile)) {
+    Exit-With 3 "UNKNOWN - no fleetbench status yet (no benchmark has run)"
+}
+
+try {
+    $s = Get-Content -LiteralPath $statusFile -Raw | ConvertFrom-Json
+}
+catch {
+    Exit-With 3 "UNKNOWN - cannot read fleetbench status: $($_.Exception.Message)"
+}
+
+# No variance available (first run / unknown hardware / unparseable)
+if ($null -eq $s.var_min_delta) {
+    $why = if ($s.drift_note) { $s.drift_note } else { 'no_baseline' }
+    Exit-With 3 "UNKNOWN - no variance data ($why)"
+}
+
+$dMin  = [double]$s.var_min_delta
+$dMean = [double]$s.var_mean_delta
+$dIter = [double]$s.var_iter_pct
+
+$ageH = $null
+try {
+    $ageH = [math]::Round(((Get-Date).ToUniversalTime() - ([datetime]$s.timestamp_utc).ToUniversalTime()).TotalHours, 1)
+}
+catch { }
+
+$driftCode = if ($s.drift) { 1 } else { 0 }
+$ageVal = if ($null -ne $ageH) { $ageH } else { 0 }
+# Deltas are (last - first); negative = degraded vs first run.
+$perf = "variance_drift=$driftCode;1;;0;1 var_min_delta=$dMin var_mean_delta=$dMean var_iter_pct=$dIter age_h=$ageVal"
+
+$summary = "vs first run ($($s.first_run)): min%base d=$dMin mean%base d=$dMean iters d=$dIter%"
+if ($null -ne $ageH) { $summary += " age=${ageH}h" }
+
+# Stale status -> WARN
+if ($null -ne $ageH -and $ageH -gt $maxAgeHours) {
+    Exit-With 1 "WARN - fleetbench variance status stale - $summary | $perf"
+}
+
+if ($s.drift) {
+    Exit-With 1 "WARN - fleetbench variance drift - $summary | $perf"
+}
+Exit-With 0 "OK - fleetbench variance within range - $summary | $perf"

--- a/modules/win_nsclient/manifests/init.pp
+++ b/modules/win_nsclient/manifests/init.pp
@@ -64,6 +64,20 @@ class win_nsclient::init (
     notify  => Service['nscp'],
   }
 
+  # Surfaces the latest fleetbench hardware-health verdict to Marlin (RELOPS-2402).
+  file { "${scripts_dir}\\check_fleetbench.ps1":
+    content => file('win_nsclient/check_fleetbench.ps1'),
+    require => File[$scripts_dir],
+    notify  => Service['nscp'],
+  }
+
+  # Surfaces fleetbench run-to-run variance (latest vs first run) to Marlin.
+  file { "${scripts_dir}\\check_fleetbench_variance.ps1":
+    content => file('win_nsclient/check_fleetbench_variance.ps1'),
+    require => File[$scripts_dir],
+    notify  => Service['nscp'],
+  }
+
   service { 'nscp':
     ensure  => running,
     enable  => true,

--- a/modules/win_nsclient/templates/nsclient.ini.epp
+++ b/modules/win_nsclient/templates/nsclient.ini.epp
@@ -38,6 +38,8 @@ worker_bootstrap_stage = powershell.exe -ExecutionPolicy RemoteSigned -File scri
 thermal = powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File scripts\check_thermal.ps1
 thermal_hp = powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File scripts\check_thermal_hp.ps1
 worker_pool_id = powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File scripts\worker_pool_id.ps1
+fleetbench = powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File scripts\check_fleetbench.ps1
+fleetbench_variance = powershell.exe -NoProfile -ExecutionPolicy RemoteSigned -File scripts\check_fleetbench_variance.ps1
 
 [/settings/external scripts/alias/cpu_5s]
 alias = cpu_5s

--- a/modules/win_scheduled_tasks/files/gw_exe_check.ps1
+++ b/modules/win_scheduled_tasks/files/gw_exe_check.ps1
@@ -94,6 +94,31 @@ if ($uptimeMinutes -lt 15) {
     exit
 }
 
+# RELOPS-2402: fleetbench runs a ~15-min CPU benchmark BEFORE worker-runner starts
+# (maintainsystem-hw.ps1 :: Invoke-FleetbenchCheck). During that run generic-worker is
+# intentionally not started yet and uptime can pass the 15-min grace above, which would
+# otherwise trip this watchdog into a needless reboot/PXE. Skip while a fresh benchmark
+# marker is present. Read at Machine scope so we get the value live from the registry, not
+# the (possibly stale) process env block. The marker is the run's UTC start time; a marker
+# older than the max expected run is treated as stale so a crashed/rebooted run mid-benchmark
+# cannot silently disable this check forever.
+$fleetbenchMarker = [Environment]::GetEnvironmentVariable('MOZ_FLEETBENCH_RUNNING', 'Machine')
+if ($fleetbenchMarker) {
+    $fleetbenchMaxRunMinutes = 30   # 900s benchmark + warmup/startup slack
+    [datetimeoffset] $fleetbenchStarted = [datetimeoffset]::MinValue
+    if ([datetimeoffset]::TryParse($fleetbenchMarker, [ref] $fleetbenchStarted)) {
+        $fleetbenchRunMinutes = ([datetimeoffset]::UtcNow - $fleetbenchStarted).TotalMinutes
+        if ($fleetbenchRunMinutes -ge 0 -and $fleetbenchRunMinutes -lt $fleetbenchMaxRunMinutes) {
+            Write-Log -message "Fleetbench benchmark in progress (started $($fleetbenchStarted.UtcDateTime.ToString('o')), $([math]::Round($fleetbenchRunMinutes, 1)) min ago). Skipping generic-worker check until it completes." -severity 'DEBUG'
+            exit
+        }
+        Write-Log -message "Fleetbench marker present but stale ($([math]::Round($fleetbenchRunMinutes, 1)) min old, max $fleetbenchMaxRunMinutes). Ignoring and continuing generic-worker check." -severity 'WARN'
+    }
+    else {
+        Write-Log -message "Fleetbench marker present but unparseable ('$fleetbenchMarker'). Ignoring and continuing generic-worker check." -severity 'WARN'
+    }
+}
+
 # Var set by the maintain system script
 # Check gw_initiated env var
 if ($env:gw_initiated -ne 'true') {

--- a/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
+++ b/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
@@ -675,7 +675,21 @@ function Invoke-FleetbenchCheck {
             $statusFile = Join-Path $ResultsDir 'fleetbench_status.json'
             Write-Log -message ('{0} :: running fleetbench cpu --mode {1} --duration {2} ...' -f $($MyInvocation.MyCommand.Name), $Mode, $Duration) -severity 'INFO'
 
-            $json = & $exe.FullName cpu --mode $Mode --duration $Duration --json 2>$null | Out-String
+            # RELOPS-2402: signal gw_exe_check that a benchmark is in progress. This call blocks
+            # ~15 min while worker-runner is intentionally not yet started, which can push uptime
+            # past gw_exe_check's 15-min grace period and trip its watchdog into a needless
+            # reboot/PXE. The marker is the run's UTC start time; gw_exe_check ignores a stale
+            # marker so a crash/reboot mid-run cannot disable the watchdog. Written at Machine
+            # scope (registry) so the separately-scheduled gw_exe_check process reads it live.
+            [Environment]::SetEnvironmentVariable('MOZ_FLEETBENCH_RUNNING', (Get-Date).ToUniversalTime().ToString('o'), 'Machine')
+            Write-Log -message ('{0} :: MOZ_FLEETBENCH_RUNNING set (machine)' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+            try {
+                $json = & $exe.FullName cpu --mode $Mode --duration $Duration --json 2>$null | Out-String
+            }
+            finally {
+                [Environment]::SetEnvironmentVariable('MOZ_FLEETBENCH_RUNNING', $null, 'Machine')
+                Write-Log -message ('{0} :: MOZ_FLEETBENCH_RUNNING cleared (machine)' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+            }
             if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
                 Write-Log -message ('{0} :: fleetbench run failed (exit {1}).' -f $($MyInvocation.MyCommand.Name), $LASTEXITCODE) -severity 'ERROR'
                 return

--- a/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
+++ b/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
@@ -473,6 +473,285 @@ function Wait-ForUserInitReady {
     return $false
 }
 
+function Get-FleetbenchMetrics {
+    # Extract the evaluation metrics from a fleetbench cpu JSON envelope.
+    # Returns Ok=$false if the envelope cannot be parsed / has no data.
+    param (
+        [Parameter(Mandatory)] [string] $Json
+    )
+    try {
+        $d    = $Json | ConvertFrom-Json
+        $base = [double]$d.cpu.frequency_mhz
+        $freqs = @($d.frequency_series | ForEach-Object { [double]$_.mean_mhz } | Where-Object { $_ -gt 0 })
+        $iters = @($d.results.prime_sieve_mt.iterations | ForEach-Object { [double]$_.seconds } | Where-Object { $_ -gt 0 })
+
+        if ($base -le 0 -or $freqs.Count -eq 0 -or $iters.Count -eq 0) {
+            return [pscustomobject]@{ Ok = $false }
+        }
+
+        $minPct  = ($freqs | Measure-Object -Minimum).Minimum / $base * 100
+        $meanPct = ($freqs | Measure-Object -Average).Average / $base * 100
+        $avg = ($iters | Measure-Object -Average).Average
+        $var = ($iters | ForEach-Object { ($_ - $avg) * ($_ - $avg) } | Measure-Object -Average).Average
+        $sd  = [math]::Sqrt($var)
+        $tputCV = if ($avg -gt 0) { ($sd / $avg) * 100 } else { 0 }
+
+        return [pscustomobject]@{
+            Ok = $true; MinPct = $minPct; MeanPct = $meanPct; TputCV = $tputCV; Iterations = $iters.Count
+        }
+    }
+    catch {
+        return [pscustomobject]@{ Ok = $false }
+    }
+}
+
+function Get-FleetbenchHardwareBaseline {
+    # Identify the hardware type by matching $Model against each entry's model_match
+    # glob in the baselines JSON. Returns $null if the file is missing/unparseable or
+    # no hardware type matches (caller logs, does NOT error). Scalable: add new hw
+    # types by adding entries to fleetbench_baselines.json.
+    param (
+        [Parameter(Mandatory)] [string] $Model,
+        [Parameter(Mandatory)] [string] $BaselinePath
+    )
+    if ([string]::IsNullOrWhiteSpace($Model) -or -not (Test-Path -LiteralPath $BaselinePath)) { return $null }
+    try {
+        $cfg = Get-Content -LiteralPath $BaselinePath -Raw | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+    foreach ($name in $cfg.hardware_types.PSObject.Properties.Name) {
+        $entry = $cfg.hardware_types.$name
+        if ($Model -like $entry.model_match) {
+            return [pscustomobject]@{ Type = $name; Config = $entry }
+        }
+    }
+    return $null
+}
+
+function Get-FleetbenchVerdict {
+    # Absolute pass/fail against the matched hardware type's locked known-good range.
+    param (
+        [Parameter(Mandatory)] $Metrics,
+        [Parameter(Mandatory)] $Thresholds
+    )
+    if (-not $Metrics.Ok) { return 'UNKNOWN' }
+    $t = $Thresholds
+    if ($Metrics.MinPct  -lt $t.min_floor_pct.bad_below -or
+        $Metrics.TputCV  -gt $t.tput_cv_pct.bad_above -or
+        $Metrics.MeanPct -lt $t.mean_pct.bad_below) {
+        return 'BAD'
+    }
+    if ($Metrics.MinPct  -ge $t.min_floor_pct.good_min -and
+        $Metrics.TputCV  -le $t.tput_cv_pct.good_max -and
+        $Metrics.MeanPct -ge $t.mean_pct.good_min) {
+        return 'GOOD'
+    }
+    return 'MARGINAL'
+}
+
+function Get-FleetbenchVariance {
+    # Variance / degradation over the node's life: compare the latest run to the FIRST
+    # recorded run for this node (its initial post-bootstrap baseline). Flags drift if the
+    # latest is worse than the first beyond the hw type's drop_off deltas. Catches gradual
+    # decline even when the latest run still passes the absolute GOOD range.
+    param (
+        [Parameter(Mandatory)] $Current,
+        [Parameter(Mandatory)] [string] $ResultsDir,
+        [Parameter(Mandatory)] $DropOff,
+        [string] $ExcludeFile
+    )
+    # Oldest envelope = the node's first run (its reference baseline). Match only fleetbench
+    # cpu envelopes (`<ts>_<host>_cpu.json`) so siblings like fleetbench_status.json /
+    # defender_status.json that share this dir are not picked up as a "first run."
+    $first = Get-ChildItem -Path (Join-Path $ResultsDir '*_cpu.json') -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -ne $ExcludeFile } |
+        Sort-Object LastWriteTime | Select-Object -First 1
+    if (-not $first) {
+        return [pscustomobject]@{ Drift = $false; Note = 'no_baseline'; FirstRun = $null }
+    }
+    $fm = Get-FleetbenchMetrics -Json (Get-Content -LiteralPath $first.FullName -Raw)
+    if (-not $fm.Ok) {
+        return [pscustomobject]@{ Drift = $false; Note = 'baseline_unparseable'; FirstRun = $first.Name }
+    }
+
+    # Deltas (last - first); negative = worse than the node's first run.
+    $dMin  = [math]::Round($Current.MinPct - $fm.MinPct, 1)
+    $dMean = [math]::Round($Current.MeanPct - $fm.MeanPct, 1)
+    $dIterPct = if ($fm.Iterations -gt 0) { [math]::Round((($Current.Iterations - $fm.Iterations) / $fm.Iterations) * 100, 1) } else { 0 }
+
+    # Always-populated variance summary (so it is logged every run, not only on drift).
+    $note = ('min%base {0:N0}->{1:N0} ({2:+0.0;-0.0;0}) mean%base {3:N0}->{4:N0} ({5:+0.0;-0.0;0}) iters {6}->{7} ({8:+0.0;-0.0;0}%)' -f `
+        $fm.MinPct, $Current.MinPct, $dMin, $fm.MeanPct, $Current.MeanPct, $dMean, $fm.Iterations, $Current.Iterations, $dIterPct)
+
+    $drift = ( (-$dMin) -ge $DropOff.min_floor_pct_drop -or
+               (-$dMean) -ge $DropOff.mean_pct_drop -or
+               (-$dIterPct) -ge $DropOff.iterations_drop_pct )
+
+    return [pscustomobject]@{
+        Drift = $drift; Note = $note; FirstRun = $first.Name
+        DeltaMin = $dMin; DeltaMean = $dMean; DeltaIterPct = $dIterPct
+    }
+}
+
+function Write-FleetbenchStatus {
+    # Persist the latest evaluation to a small status file that NSClient++ surfaces
+    # to Marlin (read by scripts\check_fleetbench.ps1). Best-effort; never throws.
+    param (
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] $Status
+    )
+    try {
+        $Status | ConvertTo-Json -Compress | Out-File -FilePath $Path -Encoding utf8
+    }
+    catch {
+        Write-Log -message ('Write-FleetbenchStatus :: failed: {0}' -f $_.Exception.Message) -severity 'WARN'
+    }
+}
+
+function Invoke-FleetbenchCheck {
+    # Hardware-health / PSU-degradation benchmark + evaluation (RELOPS-2402). Runs the
+    # fleetbench collector to completion and saves the JSON result, BEFORE worker-runner
+    # starts. Evaluates against the locked known-good range for this hardware type
+    # (fleetbench_baselines.json, deployed next to this script) and against the node's
+    # own recent history (drop-off detection). Hardware identification is done here in
+    # the maintain script (Win32_ComputerSystem.Model). Never throws / never blocks
+    # worker-runner. Cadence: once after bootstrap (no prior result), then at most once
+    # per $IntervalHours. Paths match the win_fleetbench module (windows.fleetbench.*).
+    param (
+        [string] $Model        = '',
+        [string] $InstallDir   = 'C:\fleetbench',
+        [string] $ResultsDir   = 'C:\fleetbench\results',
+        # Baselines are installed alongside the collector by the win_fleetbench module.
+        [string] $BaselinePath = $(Join-Path $InstallDir 'fleetbench_baselines.json'),
+        [int]    $IntervalHours = 72,       # production: run at most once per 72h (every 3 days).
+        [string] $Mode         = 'quick',
+        # 900s (15 min): a 120s run at cold boot can pass a degrading node because the
+        # PSU/thermal throttle only engages after sustained load. The longer run self-warms
+        # the machine into that regime (prior stress work: 180s missed nodes that 900s caught).
+        # NOTE: the known-good baselines were measured at 120s; re-baseline at 900s if needed.
+        [string] $Duration     = '900s'
+    )
+    begin {
+        Write-Log -message ('{0} :: begin - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
+    }
+    process {
+        try {
+            # Resolve the version-stamped collector binary installed by win_fleetbench.
+            $exe = Get-ChildItem -Path (Join-Path $InstallDir 'fleetbench*.exe') -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if (-not $exe) {
+                Write-Log -message ('{0} :: fleetbench binary not found in {1}; skipping benchmark.' -f $($MyInvocation.MyCommand.Name), $InstallDir) -severity 'WARN'
+                return
+            }
+
+            if (-not (Test-Path $ResultsDir)) {
+                New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
+            }
+
+            # Cadence gate: run if there is no prior result (first run post-bootstrap),
+            # otherwise only when the newest result is older than $IntervalHours. Match only
+            # fleetbench cpu envelopes (`<ts>_<host>_cpu.json`); the Defender guard and
+            # Write-FleetbenchStatus share this dir with `*_status.json` siblings that must
+            # not be mistaken for a prior benchmark run.
+            $newest = Get-ChildItem -Path (Join-Path $ResultsDir '*_cpu.json') -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if ($newest) {
+                $ageHours = ((Get-Date).ToUniversalTime() - $newest.LastWriteTimeUtc).TotalHours
+                if ($ageHours -lt $IntervalHours) {
+                    Write-Log -message ('{0} :: last benchmark {1:N1}h ago (< {2}h); skipping.' -f $($MyInvocation.MyCommand.Name), $ageHours, $IntervalHours) -severity 'INFO'
+                    return
+                }
+            }
+            else {
+                Write-Log -message ('{0} :: no prior result; running first post-bootstrap benchmark.' -f $($MyInvocation.MyCommand.Name)) -severity 'INFO'
+            }
+
+            # Run the benchmark to completion (blocks ~duration) BEFORE worker-runner starts.
+            $stamp      = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+            $stampIso   = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+            $outFile    = Join-Path $ResultsDir ('{0}_{1}_cpu.json' -f $stamp, $env:COMPUTERNAME)
+            $statusFile = Join-Path $ResultsDir 'fleetbench_status.json'
+            Write-Log -message ('{0} :: running fleetbench cpu --mode {1} --duration {2} ...' -f $($MyInvocation.MyCommand.Name), $Mode, $Duration) -severity 'INFO'
+
+            $json = & $exe.FullName cpu --mode $Mode --duration $Duration --json 2>$null | Out-String
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
+                Write-Log -message ('{0} :: fleetbench run failed (exit {1}).' -f $($MyInvocation.MyCommand.Name), $LASTEXITCODE) -severity 'ERROR'
+                return
+            }
+
+            $json | Out-File -FilePath $outFile -Encoding utf8
+            Write-Log -message ('{0} :: result saved to {1}' -f $($MyInvocation.MyCommand.Name), $outFile) -severity 'INFO'
+
+            # ---- Evaluation ----
+            $metrics = Get-FleetbenchMetrics -Json $json
+            if (-not $metrics.Ok) {
+                Write-Log -message ('{0} :: result saved but metrics could not be parsed; skipping evaluation.' -f $($MyInvocation.MyCommand.Name)) -severity 'WARN'
+                Write-FleetbenchStatus -Path $statusFile -Status ([pscustomobject]@{
+                    timestamp_utc = $stampIso; host = $env:COMPUTERNAME; model = $Model
+                    hw_type = 'unknown'; verdict = 'UNKNOWN'; min_pct = $null; mean_pct = $null
+                    tput_cv = $null; iterations = $null; drift = $false; drift_note = 'unparseable'
+                    var_min_delta = $null; var_mean_delta = $null; var_iter_pct = $null; first_run = $null
+                })
+                return
+            }
+
+            # Hardware identification (done here in the maintain script).
+            if ([string]::IsNullOrWhiteSpace($Model)) {
+                try { $Model = (Get-CimInstance -ClassName Win32_ComputerSystem).Model } catch { $Model = '' }
+            }
+
+            $hw = Get-FleetbenchHardwareBaseline -Model $Model -BaselinePath $BaselinePath
+            if (-not $hw) {
+                # Unknown / unlisted hardware type: log metrics, do NOT error and do NOT block.
+                Write-Log -message ('{0} :: hardware type for model "{1}" not found in baselines ({2}); logging metrics only (min%base={3:N0} mean%base={4:N0} tputCV={5:N0}% iters={6}). No pass/fail evaluation.' -f $($MyInvocation.MyCommand.Name), $Model, $BaselinePath, $metrics.MinPct, $metrics.MeanPct, $metrics.TputCV, $metrics.Iterations) -severity 'WARN'
+                Write-FleetbenchStatus -Path $statusFile -Status ([pscustomobject]@{
+                    timestamp_utc = $stampIso; host = $env:COMPUTERNAME; model = $Model
+                    hw_type = 'unknown'; verdict = 'UNEVALUATED'
+                    min_pct = [math]::Round($metrics.MinPct, 1); mean_pct = [math]::Round($metrics.MeanPct, 1)
+                    tput_cv = [math]::Round($metrics.TputCV, 1); iterations = $metrics.Iterations
+                    drift = $false; drift_note = 'hardware_type_not_in_baselines'
+                    var_min_delta = $null; var_mean_delta = $null; var_iter_pct = $null; first_run = $null
+                })
+                return
+            }
+
+            # Absolute pass/fail against the locked known-good range for this hardware type.
+            $verdict = Get-FleetbenchVerdict -Metrics $metrics -Thresholds $hw.Config.thresholds
+            $sev = switch ($verdict) { 'BAD' { 'ERROR' } 'GOOD' { 'INFO' } default { 'WARN' } }
+            Write-Log -message ('{0} :: hw={1} model={2} verdict={3} min%base={4:N0} mean%base={5:N0} tputCV={6:N0}% iters={7}' -f $($MyInvocation.MyCommand.Name), $hw.Type, $Model, $verdict, $metrics.MinPct, $metrics.MeanPct, $metrics.TputCV, $metrics.Iterations) -severity $sev
+
+            # Variance vs this node's FIRST run (its initial baseline) - catches gradual decline.
+            $variance = Get-FleetbenchVariance -Current $metrics -ResultsDir $ResultsDir -DropOff $hw.Config.drop_off -ExcludeFile $outFile
+            if ($variance.Drift) {
+                Write-Log -message ('{0} :: VARIANCE vs first run ({1}): {2}' -f $($MyInvocation.MyCommand.Name), $variance.FirstRun, $variance.Note) -severity 'WARN'
+            }
+            else {
+                Write-Log -message ('{0} :: variance ok ({1})' -f $($MyInvocation.MyCommand.Name), $variance.Note) -severity 'INFO'
+            }
+
+            # Persist the latest status for NSClient++ -> Marlin reporting.
+            Write-FleetbenchStatus -Path $statusFile -Status ([pscustomobject]@{
+                timestamp_utc = $stampIso; host = $env:COMPUTERNAME; model = $Model
+                hw_type = $hw.Type; verdict = $verdict
+                min_pct = [math]::Round($metrics.MinPct, 1); mean_pct = [math]::Round($metrics.MeanPct, 1)
+                tput_cv = [math]::Round($metrics.TputCV, 1); iterations = $metrics.Iterations
+                drift = $variance.Drift; drift_note = $variance.Note
+                var_min_delta = $variance.DeltaMin; var_mean_delta = $variance.DeltaMean
+                var_iter_pct = $variance.DeltaIterPct; first_run = $variance.FirstRun
+            })
+        }
+        catch {
+            # Health check must never block worker-runner from starting.
+            Write-Log -message ('{0} :: error: {1}' -f $($MyInvocation.MyCommand.Name), $_.Exception.Message) -severity 'WARN'
+        }
+    }
+    end {
+        Write-Log -message ('{0} :: end - {1:o}' -f $($MyInvocation.MyCommand.Name), (Get-Date).ToUniversalTime()) -severity 'DEBUG'
+    }
+}
+
 Write-Log -message ('{0} :: maintained system started' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
 if (-not (Get-Process explorer -ErrorAction SilentlyContinue)) {
     Write-Log -message ('{0} :: No user logged in (no explorer.exe); sleeping 60s' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
@@ -527,6 +806,10 @@ If ($bootstrap_stage -eq 'complete') {
         # If you prefer fail-closed (PXE) instead, change this behavior.
         Write-Log -message "MOZ_GW_UI_READY :: proceeding despite timeout" -severity 'WARN'
     }
+    # RELOPS-2402: run the fleetbench hardware-health benchmark to completion BEFORE
+    # starting worker-runner. Hardware-only (this maintainsystem script is datacenter).
+    # $model is identified above from Win32_ComputerSystem.Model.
+    Invoke-FleetbenchCheck -Model $model
     StartWorkerRunner
     Exit-PSSession
 }


### PR DESCRIPTION
## Summary

Fleetbench-based PSU / firmware-throttle detector for the NUC13 hardware fleet.
**Split out of #1235**, which combined this with the Windows Defender hardening
(RELOPS-2396); that half is now in a separate PR.

Hardware-only: gated to the datacenter maintain-system path + the `hardware_observability`
profile, so cloud/VM workers are unaffected.

## What it does (per hardware node)

1. **Install** — new `win_fleetbench` module installs the version-pinned collector to
   `C:\fleetbench` plus per-hardware baselines (`fleetbench_baselines.json`), wired via
   `hardware_observability`. Version pinned in `data/os/Windows.yaml`.
2. **Benchmark** — `maintainsystem-hw.ps1` runs `fleetbench cpu --mode quick --duration 900s --json`
   **before worker-runner starts** (once post-bootstrap, then at most once per 72h). 900s
   self-warms the node so PSU/thermal throttling actually surfaces — a short cold-boot run
   can false-pass.
3. **Evaluate** — GOOD / BAD / MARGINAL / UNKNOWN vs the locked per-hardware baseline
   (nuc13: min-floor ≥75 / mean ≥100 / tputCV ≤25 = GOOD; min<50 OR cv>40 OR mean<95 = BAD).
   Hardware type identified in-script from `Win32_ComputerSystem.Model`; unknown hardware
   logs and does not error/block.
4. **Variance** — compares the latest run to the node's first recorded run (drift over time).
5. **Report** — NSClient++ external checks `fleetbench` and `fleetbench_variance` surface
   verdict + metrics to Marlin (matching Marlin services live in mozilla-it/marlin).

## Files

**New:** `modules/win_fleetbench/{manifests/init.pp,files/run_fleetbench.ps1,files/fleetbench_baselines.json}`,
`modules/win_nsclient/files/check_fleetbench.ps1`, `modules/win_nsclient/files/check_fleetbench_variance.ps1`

**Modified:** `data/os/Windows.yaml`, `hardware_observability.pp`, `win_nsclient/manifests/init.pp`,
`win_nsclient/templates/nsclient.ini.epp`, `win_scheduled_tasks/files/maintainsystem-hw.ps1`
(fleetbench functions + the `Invoke-FleetbenchCheck` call before `StartWorkerRunner`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)