### PR TITLE
RELOPS-2464: comment out HW AppX removal + task-user logon cleanup (deployment/startup overhead)

### DIFF
--- a/modules/roles_profiles/manifests/profiles/disable_services.pp
+++ b/modules/roles_profiles/manifests/profiles/disable_services.pp
@@ -71,7 +71,11 @@ class roles_profiles::profiles::disable_services {
         if ($facts['custom_win_location'] == 'datacenter') {
           include win_disable_services::disable_ms_edge
           include win_disable_services::disable_defender_smartscreen
-          include win_disable_services::extended_uninstall_appx_packages
+          # RELOPS-2464: Commented out for evaluation. This works correctly, but the
+          # AppX package removal on HW (datacenter) workers adds an incredible amount of
+          # overhead/time to deployment and to startup after every reboot / new task-user
+          # logon. Kept in place (not removed) while we evaluate removing it.
+          # include win_disable_services::extended_uninstall_appx_packages
           ## Can't disable appxsvc on ref hardware as it will affect the task
           ## user's ability to use codecs
           ## Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=2013985

--- a/modules/win_scheduled_tasks/files/at_task_user_logon.ps1
+++ b/modules/win_scheduled_tasks/files/at_task_user_logon.ps1
@@ -46,6 +46,10 @@ function Write-Log {
     }
 }
 
+# RELOPS-2464: Commented out for evaluation. This works correctly, but adds an
+# incredible amount of overhead/time on every reboot / new task-user logon.
+# Kept in place (not removed) while we evaluate removing it.
+<#
 function Remove-OneDriveScheduledTasks {
     [CmdletBinding()]
     param(
@@ -167,7 +171,12 @@ function Remove-OneDriveScheduledTasks {
         Write-Log -message "OneDriveTasks :: end (success at timeout boundary)" -severity 'INFO'
     }
 }
+#>
 
+# RELOPS-2464: Commented out for evaluation. This works correctly, but adds an
+# incredible amount of overhead/time on every reboot / new task-user logon.
+# Kept in place (not removed) while we evaluate removing it.
+<#
 function Disable-OneDriveBackupPopup {
     [CmdletBinding()]
     param()
@@ -241,7 +250,12 @@ function Disable-OneDriveBackupPopup {
 
     Write-Log -message "Disable-OneDriveBackupPopup :: complete (recommend reboot)" -severity 'INFO'
 }
+#>
 
+# RELOPS-2464: Commented out for evaluation. This works correctly, but adds an
+# incredible amount of overhead/time on every reboot / new task-user logon.
+# Kept in place (not removed) while we evaluate removing it.
+<#
 function Disable-PerUserUwpServices {
     [CmdletBinding()]
     param (
@@ -284,7 +298,12 @@ function Disable-PerUserUwpServices {
         }
     }
 }
+#>
 
+# RELOPS-2464: Commented out for evaluation. This works correctly, but adds an
+# incredible amount of overhead/time on every reboot / new task-user logon.
+# Kept in place (not removed) while we evaluate removing it.
+<#
 function Remove-EdgeScheduledTasks {
     [CmdletBinding()]
     param(
@@ -419,6 +438,7 @@ function Remove-EdgeScheduledTasks {
         Write-Log -message "EdgeTasks :: end (success at timeout boundary)" -severity 'INFO'
     }
 }
+#>
 
 function Disable-SyncFromCloud {
     [CmdletBinding()]
@@ -619,10 +639,15 @@ switch ($os_version) {
             if ($env:USERNAME -match 'administrator') {
                 exit
             } else {
-                Disable-PerUserUwpServices
-                Remove-OneDriveScheduledTasks
-                Disable-OneDriveBackupPopup
-                Remove-EdgeScheduledTasks
+                # RELOPS-2464: Commented out for evaluation. These functions work
+                # correctly, but they run on every reboot / new task-user logon and add
+                # an incredible amount of overhead/time to startup. Kept in place (not
+                # removed) while we evaluate removing them. See the wrapped function
+                # definitions above.
+                # Disable-PerUserUwpServices
+                # Remove-OneDriveScheduledTasks
+                # Disable-OneDriveBackupPopup
+                # Remove-EdgeScheduledTasks
                 ## Not currently functioning
                 #Disable-SyncFromCloud
                 #Disable-SmartScreenStoreApps

--- a/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
+++ b/modules/win_scheduled_tasks/files/maintainsystem-hw.ps1
@@ -516,12 +516,18 @@ If ($bootstrap_stage -eq 'complete') {
     $ready = Wait-ForUserInitReady -TimeoutSeconds 1200 -PollSeconds 3
 
     # Delete the env var either way to avoid it sticking around forever
+    # RELOPS-2464: Commented out for evaluation. This works correctly, but is tied to
+    # the task-user-init UI-hardening gating that adds an incredible amount of
+    # overhead/time on every reboot / new task-user logon. Kept in place (not removed)
+    # while we evaluate removing it.
+    <#
     try {
         [Environment]::SetEnvironmentVariable('MOZ_GW_UI_READY', $null, 'Machine')
         Write-Log -message "MOZ_GW_UI_READY :: cleared (machine)" -severity 'DEBUG'
     } catch {
         Write-Log -message ("MOZ_GW_UI_READY :: failed to clear: {0}" -f $_.Exception.Message) -severity 'WARN'
     }
+    #>
 
     if (-not $ready) {
         # If you prefer fail-closed (PXE) instead, change this behavior.


### PR DESCRIPTION
## Summary

Comments out (does **not** remove) code that works correctly but adds significant overhead to deployment and to startup after every reboot / new task-user logon on HW (datacenter) workers. This lets us A/B measure the time impact and evaluate permanent removal.

Jira: [RELOPS-2464](https://mozilla-hub.atlassian.net/browse/RELOPS-2464)

## Changes

- **`modules/roles_profiles/manifests/profiles/disable_services.pp`** — commented out `include win_disable_services::extended_uninstall_appx_packages` (AppX package removal on datacenter/HW workers).
- **`modules/win_scheduled_tasks/files/at_task_user_logon.ps1`** — commented out the four cleanup functions (definitions wrapped in `<# #>` and their call sites in the `MDC1 hardware` block): `Disable-PerUserUwpServices`, `Remove-OneDriveScheduledTasks`, `Disable-OneDriveBackupPopup`, `Remove-EdgeScheduledTasks`.
- **`modules/win_scheduled_tasks/files/maintainsystem-hw.ps1`** — commented out the `MOZ_GW_UI_READY` machine env-var clearing block.

Each block carries a `RELOPS-2464` comment noting the code works but adds significant overhead and is retained for evaluation.

## Notes / testing

- Nothing is deleted; this is intentionally reversible.
- `puppet parser validate` / `pwsh` parse were not run locally (neither installed in the dev env). PowerShell block-comment markers were confirmed balanced. Recommend `pre-commit run --all-files` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)