### PR TITLE
packages: restore legacy openssl@1.1 Cellar layout on Catalina build workers

### DIFF
--- a/data/roles/gecko_3_b_osx_1015.yaml
+++ b/data/roles/gecko_3_b_osx_1015.yaml
@@ -20,12 +20,15 @@ worker:
 
 packages_classes:
   - mercurial
+  - openssl_legacy_cellar
   - python3
   - python3_zstandard
   - zstandard
 
 # Package class parameters
 packages::mercurial::version: 6.4.5
+packages::openssl_legacy_cellar::version: 1.1.1h
+packages::openssl_legacy_cellar::checksum: 366f359fa6d5c397ce7c7860511080faf9c36537fc8747438d1b5d238cbf598c
 packages::python3::version: 3.11.0
 packages::python3_zstandard::version: 0.22.0
 

--- a/modules/packages/manifests/openssl_legacy_cellar.pp
+++ b/modules/packages/manifests/openssl_legacy_cellar.pp
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Restores the legacy Homebrew openssl@1.1 Cellar layout on Catalina build
+# workers so newly-provisioned hosts match the ones provisioned before the
+# current base image.
+#
+# Background: the macosx64-python-3.11 toolchain build (build-cpython.sh) has a
+# post-build dylib fixup that hardcodes
+#   /usr/local/Cellar/openssl@1.1/1.1.1h/lib/libcrypto.1.1.dylib
+# in an `install_name_tool -change` followed by an `otool -L | grep` check.
+# Workers provisioned long ago carry a real Homebrew Cellar 1.1.1h and match.
+# Recently-provisioned workers ship openssl 1.1.1w laid directly under
+# /usr/local/opt/openssl@1.1 (a real dir, no Cellar), so libssl references the
+# opt path, the -change no-ops, the grep finds nothing and exits 1. That fails
+# the toolchain build, which blocks every dependent task and PR.
+#
+# This class converges the newer layout back to the legacy Cellar layout so the
+# hardcoded path resolves. It is a no-op on hosts that already match.
+class packages::openssl_legacy_cellar (
+  String $version  = '1.1.1h',
+  String $checksum = '366f359fa6d5c397ce7c7860511080faf9c36537fc8747438d1b5d238cbf598c',
+) {
+  include packages::setup
+
+  $tarball = "openssl-${version}-cellar.tar.gz"
+  $tmp_tar = "/tmp/${tarball}"
+  $url     = "https://${packages::setup::default_s3_domain}/${packages::setup::default_bucket}/macos/public/10.15/${tarball}"
+
+  # Short-circuit once libssl already references the Cellar libcrypto path the
+  # toolchain expects (true on the older fleet -> whole class no-ops there).
+  $already_ok = "/bin/sh -c 'otool -L /usr/local/opt/openssl/lib/libssl.1.1.dylib 2>/dev/null | grep -qF \"Cellar/openssl@1.1/${version}/lib/libcrypto.1.1.dylib\"'"
+
+  exec { 'fetch_openssl_legacy_cellar':
+    command => "/usr/bin/curl -fL -o ${tmp_tar} ${url}",
+    path    => ['/usr/bin', '/bin'],
+    unless  => $already_ok,
+    timeout => 120,
+  }
+
+  exec { 'verify_openssl_legacy_cellar':
+    command => "/bin/sh -c 'echo \"${checksum}  ${tmp_tar}\" | /usr/bin/shasum -a 256 -c -'",
+    path    => ['/usr/bin', '/bin'],
+    unless  => $already_ok,
+    require => Exec['fetch_openssl_legacy_cellar'],
+  }
+
+  # Extract to the Cellar, preserve any pre-existing opt tree as a .bak, then
+  # point the opt symlinks at the restored Cellar version (matching the older
+  # fleet). The .bak / symlink guards keep this safe to re-run.
+  exec { 'install_openssl_legacy_cellar':
+    command => "/bin/sh -c 'mkdir -p /usr/local/Cellar/openssl@1.1 && tar -xzf ${tmp_tar} -C /usr/local/Cellar/openssl@1.1 && { [ -L /usr/local/opt/openssl@1.1 ] || [ -e /usr/local/opt/openssl@1.1.bak ] || mv /usr/local/opt/openssl@1.1 /usr/local/opt/openssl@1.1.bak; } && ln -sfn ../Cellar/openssl@1.1/${version} /usr/local/opt/openssl@1.1 && ln -sfn openssl@1.1 /usr/local/opt/openssl'",
+    path    => ['/usr/bin', '/bin'],
+    unless  => $already_ok,
+    require => Exec['verify_openssl_legacy_cellar'],
+  }
+}


### PR DESCRIPTION
## Problem

`python-3.11` toolchain builds fail on `gecko-3-b-osx-1015` (enterprise-main), blocking every dependent task and PR. CPython compiles fine; the build dies in the post-build dylib fixup in `taskcluster/scripts/misc/build-cpython.sh:108-109`, which hardcodes:

```
install_name_tool -change /usr/local/Cellar/openssl@1.1/1.1.1h/lib/libcrypto.1.1.dylib @rpath/libcrypto.1.1.dylib .../libssl.1.1.dylib
otool -L .../libssl.1.1.dylib | grep @rpath/libcrypto.1.1.dylib   # exits 1
```

## Root cause — provisioning-era divergence

| Fleet | openssl | layout | `libssl` → libcrypto ref | build |
|---|---|---|---|---|
| Provisioned long ago (139/198/199/200) | 1.1.1h | Homebrew **Cellar** | `/usr/local/Cellar/openssl@1.1/1.1.1h/lib/…` | ✅ |
| Provisioned recently (241/242) | **1.1.1w** | real dir under `/usr/local/opt` (no Cellar) | `/usr/local/opt/openssl@1.1/lib/…` | ❌ |

On the newer layout the hardcoded Cellar path matches nothing, `install_name_tool -change` no-ops, and the verifying `grep` exits 1. openssl parity was reportedly ronin-managed historically; the current base image supersedes it.

## Fix

`packages::openssl_legacy_cellar` — guarded `curl` + `shasum -c` + `tar -x` + symlink-relink that restores the legacy Cellar `1.1.1h` layout. It is a **no-op** on hosts that already reference the Cellar path (`unless` = `otool | grep`), so it only acts on the divergent workers. Enabled on the `gecko_3_b_osx_1015` role via `packages_classes`.

## Prerequisite (done)

Tarball staged at `s3://ronin-puppet-package-repo/macos/public/10.15/openssl-1.1.1h-cellar.tar.gz` (snapshot of `199:/usr/local/Cellar/openssl@1.1/1.1.1h`), sha256 `366f359fa6d5c397ce7c7860511080faf9c36537fc8747438d1b5d238cbf598c` (matches the class/hiera checksum).

## Validation

Applied manually on the quarantined **macmini-r8-242**: afterward `libssl` references `Cellar/openssl@1.1/1.1.1h/lib/libcrypto.1.1.dylib` and a faithful replay of `build-cpython.sh:108-109` exits 0. Its prior `1.1.1w` tree is preserved at `/usr/local/opt/openssl@1.1.bak`.

## Rollout notes

- `puppet_run_strategy: never` on this role — puppet applies **at reboot**, so 241 converges on next reboot, or force with `bolt plan run deploy::apply -t macmini-r8-241 noop=false -v`.
- 242 is already converged (manual), so puppet no-ops there.
- **Follow-up:** the same one-liner likely belongs on sibling Catalina build roles that draw from the same r8 pool (`gecko_1_b_osx_1015`, `*_staging`, `nss_*_b_osx_1015`, `applicationservices_*_b_osx_1015`) — not included here to keep the diff scoped to the broken pool; confirm before widening.