### PR TITLE
worker_runner: purge stale gw cache-state on version change (+ m4 prod bump to exercise it)

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4.yaml
+++ b/data/roles/gecko_t_osx_1500_m4.yaml
@@ -10,8 +10,10 @@ worker_metadata:
 
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
-# Pinned to the current running version -- this is a no-op control move.
-taskcluster_version: '91.0.2'
+# Bumped 91.0.2 -> 100.5.0 to validate end-to-end that the role-owned value
+# drives the worker version with no per-host vault edit (vault's nested
+# worker.taskcluster_version is never read once this top-level key is set).
+taskcluster_version: '100.5.0'
 
 worker:
   taskcluster_version: 91.0.2

--- a/modules/worker_runner/manifests/init.pp
+++ b/modules/worker_runner/manifests/init.pp
@@ -128,6 +128,27 @@ class worker_runner (
                 }
             }
 
+            # Purge generic-worker's persisted cache-state on a version change.
+            # Across some version boundaries the on-disk cache-state schema
+            # changes (e.g. the ownerUsername/mounterUID fields dropped in
+            # v100.5.0), and the new binary aborts at Mounts/Caches init with
+            # `json: unknown field ...` when it loads state written by the old
+            # binary. These workers reboot themselves between tasks, so there is
+            # no reliable manual window to clear this after a bump -- it must
+            # land in the same catalog that swaps the binary, before the worker
+            # next starts. Fires only when a binary actually changes
+            # (refreshonly + subscribe). rm -f is idempotent and engine-agnostic:
+            # multiuser* runs from ${gw_root_dir}, the simple engine from
+            # ${data_dir}. The files regenerate on the next clean start.
+            exec { 'purge-stale-gw-cache-state-on-version-change':
+                command     => "/bin/rm -f ${gw_root_dir}/file-caches.json ${gw_root_dir}/directory-caches.json ${data_dir}/file-caches.json ${data_dir}/directory-caches.json",
+                refreshonly => true,
+                subscribe   => [
+                    File['/usr/local/bin/generic-worker-multiuser'],
+                    File['/usr/local/bin/generic-worker-simple'],
+                ],
+            }
+
             # Create worker data dir
             file { $data_dir:
                 ensure => 'directory',


### PR DESCRIPTION
## What
Two commits on this branch:

1. **`worker_runner`: purge stale generic-worker cache-state on version change** — the real fix.
2. **roles(m4 prod): bump `taskcluster_version` 91.0.2 -> 100.5.0** — a test vehicle to trigger #1 and to validate role-driven version control end-to-end.

## Background / why
`profiles::worker` now drives the worker version from the **role-owned top-level `taskcluster_version`** (vault's nested `worker.taskcluster_version` is only a fallback and isn't read once the role sets the key). Confirmed on **m4-214**: role edit alone bumps the version with **no per-host vault change and no revert**.

But a version bump isn't self-contained when it crosses a **worker-state schema boundary**. generic-worker persists cache-state (`file-caches.json` / `directory-caches.json`); **v100.5.0 dropped the `ownerUsername`/`mounterUID` fields**, so the new binary aborts at `Mounts/Caches` init with `json: unknown field "ownerUsername"` when it loads state written by the old binary — and crash-loops (exit 69).

**Observed live on prod m4-219** (multiuser-static): `run-puppet.sh` staged 100.5.0, the host **self-rebooted before any manual cleanup**, and the worker crash-looped. Lesson: these workers reboot themselves between tasks, so there's no reliable manual window to clear state after a bump — **the purge must land in the same catalog that swaps the binary.**

## The fix (commit 1)
A `refreshonly` exec that `rm -f`s the cache-state files, triggered only when a generic-worker binary actually changes (`subscribe` to the binary `File` resources). Idempotent and engine-agnostic: multiuser* keeps state in `/var/root`, the simple engine in the data dir. Files regenerate on the next clean worker start.

## Retest plan (validates the fix end-to-end)
m4-219 can't re-prove the fix (its binary is already swapped, so the exec won't fire again — it needs one manual clear to recover). Instead use a **different quarantined m4 still at 91.0.2 with accumulated cache-state**:

1. Point it at this branch, `sudo /usr/local/bin/run-puppet.sh`.
2. Confirm in the puppet output: `Notice: .../Exec[purge-stale-gw-cache-state-on-version-change]` fires in the **same run** as the binary download.
3. Reboot -> confirm `stderr.log` gets past `Mounts/Caches` to `worker ready` with **no PANIC / no ownerUsername**, worker at 100.5.0, reconnects to TC, runs a smoke task.

## Merge guidance
The `worker_runner` fix is mergeable on its own and should probably land as its own PR. The prod m4 role bump belongs in the normal staging->prod canary flow (or drop it from this branch before merge). Keep both here only for the combined test.

## Rollback
Revert the PR. Old 91.0.2 binary stays cached (`/usr/local/lib/taskcluster-binaries/`), so rollback is instant on next puppet.