### PR TITLE
worker_runner: purge stale generic-worker cache-state on version change

### DIFF
--- a/modules/worker_runner/manifests/init.pp
+++ b/modules/worker_runner/manifests/init.pp
@@ -128,6 +128,27 @@ class worker_runner (
                 }
             }
 
+            # Purge generic-worker's persisted cache-state on a version change.
+            # Across some version boundaries the on-disk cache-state schema
+            # changes (e.g. the ownerUsername/mounterUID fields dropped in
+            # v100.5.0), and the new binary aborts at Mounts/Caches init with
+            # `json: unknown field ...` when it loads state written by the old
+            # binary. These workers reboot themselves between tasks, so there is
+            # no reliable manual window to clear this after a bump -- it must
+            # land in the same catalog that swaps the binary, before the worker
+            # next starts. Fires only when a binary actually changes
+            # (refreshonly + subscribe). rm -f is idempotent and engine-agnostic:
+            # multiuser* runs from ${gw_root_dir}, the simple engine from
+            # ${data_dir}. The files regenerate on the next clean start.
+            exec { 'purge-stale-gw-cache-state-on-version-change':
+                command     => "/bin/rm -f ${gw_root_dir}/file-caches.json ${gw_root_dir}/directory-caches.json ${data_dir}/file-caches.json ${data_dir}/directory-caches.json",
+                refreshonly => true,
+                subscribe   => [
+                    File['/usr/local/bin/generic-worker-multiuser'],
+                    File['/usr/local/bin/generic-worker-simple'],
+                ],
+            }
+
             # Create worker data dir
             file { $data_dir:
                 ensure => 'directory',


### PR DESCRIPTION
## Problem
A `taskcluster_version` bump swaps the generic-worker binary, but the worker's persisted cache-state (`file-caches.json` / `directory-caches.json`) can be **schema-incompatible across version boundaries**. `v100.5.0` dropped the `ownerUsername`/`mounterUID` fields, so the new binary aborts at `Mounts/Caches` init with:

```
json: unknown field "ownerUsername"
... Exiting worker with exit code 69
```

...when it loads state written by the old binary, and then crash-loops.

## Why a manual clear isn't enough
Observed live on prod **m4-219** (multiuser-static): `run-puppet.sh` staged 100.5.0, the host **self-rebooted before any manual cleanup**, and the worker crash-looped. These workers reboot themselves between tasks, so there's no reliable manual window to clear state after a bump — **the purge has to land in the same catalog that swaps the binary.**

## Fix
A `refreshonly` exec that `rm -f`s the cache-state files, triggered **only when a generic-worker binary actually changes** (`subscribe` to the binary `File` resources). Idempotent and engine-agnostic — multiuser* keeps state in `/var/root`, the simple engine in the data dir — so it covers both without branching and is a no-op when nothing changed. The files regenerate on the next clean worker start.

## Validation
Validated end-to-end on prod m4-219: bumped 91.0.2 → 100.5.0, the purge fired **in the same puppet apply** as the binary download, and after reboot the worker came up clean at 100.5.0 (past `Mounts/Caches`, no `PANIC`/`ownerUsername`). Confirmed no shutdown-flush race — the puppet-run-time placement is sufficient. Cache-state files regenerate in the new schema (verified absent post-purge, i.e. no stale `ownerUsername`).

Local `puppet parser validate` + `puppet-lint` + `Validate Puppet manifests` pass.

## Scope
`worker_runner` only. The prod m4 `taskcluster_version` bump used to exercise this (draft #1268) is intentionally **not** included here — that belongs in the normal staging→prod canary.