### PR TITLE
Add reprovision_runner module/profile/role for the on-network runner host

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -1,0 +1,26 @@
+---
+ntp_server: time.apple.org
+
+# Hangar reprovision-runner. Non-secret config lives here; creds + the step-ca
+# enrollment live in vault.yaml (see modules/reprovision_runner/README.md).
+reprovision_runner:
+  enabled: true
+  cert_mode: step_renew
+  repo_revision: main
+  runner_id: "%{facts.networking.hostname}"
+  # hangar_api_url + step_ca_url use the module defaults
+  #
+  # Secrets (data/secrets/vault.yaml, fetched per-host) — same values the
+  # operator CLI resolves from the RelOps 1Password vault:
+  #   reprovision_runner:
+  #     tc_client_id:        <op://RelOps/Taskcluster Quarantine/username>
+  #     tc_access_token:     <op://RelOps/Taskcluster Quarantine/password>
+  #     simplemdm_api_key:   <op://RelOps/SimpleMDM API admin/password>
+  #     ssh_admin_password:  <op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password>
+  #     ssh_admin_key: |     <op://RelOps/RelOps Worker Admin Key/notesPlain>
+  #       -----BEGIN OPENSSH PRIVATE KEY-----
+  #       ...
+  #
+  # step-ca enrollment (cert_mode: step_renew), also in vault.yaml:
+  #   reprovision_runner::step_renew::ca_fingerprint: <root CA SHA-256 fingerprint>
+  #   reprovision_runner::step_renew::enrollment_token: <single-use bootstrap token>

--- a/modules/reprovision_runner/README.md
+++ b/modules/reprovision_runner/README.md
@@ -1,0 +1,98 @@
+# reprovision_runner
+
+Installs the **Hangar reprovision-runner** on an on-network (MDC1) macOS host.
+
+Hangar (Cloud Run) cannot SSH into MDC1, so it only *queues* reprovision jobs.
+This runner lives on the VPN, polls Hangar over **mTLS (outbound only, no inbound
+to MDC1)**, claims a job, runs the `reprovision` CLI (from the relops-bootstrap
+orchestrator), and streams progress back. It is the **only** component that holds
+worker SSH/admin creds; Hangar holds none.
+
+See also: `relops-bootstrap/orchestrator/orchestrator/runner.py` and
+`hangar/docs/reprovision-mdc1-runner-design.md`.
+
+## What Puppet manages
+
+- Python 3.11 (framework build, via `packages::python3`)
+- A clone of relops-bootstrap + a venv with the orchestrator editable-installed
+  (`/opt/reprovision-runner`)
+- A **LaunchDaemon** (`com.mozilla.reprovision-runner`, `RunAtLoad` + `KeepAlive`)
+  that survives reboots and disconnects — no more foreground ssh session
+- A root-only (`0600`) env file the daemon sources: `HANGAR_API_URL`, `RUNNER_*`,
+  and the `REPROVISION_*` creds
+- The mTLS client cert (see cert modes below)
+
+## Cert modes
+
+`reprovision_runner.cert_mode`:
+
+- **`step_renew`** (default, recommended): Puppet installs the smallstep `step`
+  CLI and a **cert-renew LaunchDaemon** (`step ca renew --daemon`). The private
+  key is generated **on-host** and never leaves it (nothing in vault/git); certs
+  are short-lived and auto-rotated; renewal is mTLS-authenticated by the current
+  cert; the cert is centrally revocable. On renewal the runner is kicked
+  (`launchctl kickstart`) so it picks up the new cert.
+- **`vault`**: cert + key are delivered through `vault.yaml` and written `0600`.
+  Simple and ronin-native, but a long-lived key at rest + manual rotation. Use
+  only where `step_renew` isn't viable.
+
+## Assigning the role
+
+Point the host at the dedicated role so `bolt plan run deploy::apply` rebuilds
+everything:
+
+```
+roles_profiles::roles::gecko_t_osx_1500_m4_reprovision_runner
+```
+
+Non-secret config: `data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml`.
+
+## Secrets (vault.yaml, fetched per-host)
+
+Same values the operator CLI resolves from the RelOps 1Password vault:
+
+```yaml
+reprovision_runner:
+  tc_client_id:       "..."   # op://RelOps/Taskcluster Quarantine/username
+  tc_access_token:    "..."   # op://RelOps/Taskcluster Quarantine/password
+  simplemdm_api_key:  "..."   # op://RelOps/SimpleMDM API admin/password
+  ssh_admin_password: "..."   # op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password
+  ssh_admin_key: |            # op://RelOps/RelOps Worker Admin Key/notesPlain
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+```
+
+## One-time step-ca bootstrap (`cert_mode: step_renew`)
+
+The renew daemon needs an initial cert. Two supported paths:
+
+1. **Puppet-driven (single-use token in vault):** set in `vault.yaml`
+
+   ```yaml
+   reprovision_runner::step_renew::ca_fingerprint: "<root CA SHA-256 fingerprint>"
+   reprovision_runner::step_renew::enrollment_token: "<single-use bootstrap token>"
+   ```
+
+   Puppet runs `step ca certificate` once (guarded by `creates` on the cert).
+   A short-lived, single-use token is far weaker material than a long-lived key.
+
+2. **Operator-driven (no token in vault):** set only `ca_fingerprint`, then once
+   on the host:
+
+   ```bash
+   export STEPPATH=/var/root/reprovision-runner/step
+   step ca bootstrap --ca-url https://step-ca.relops.mozilla --fingerprint <fp>
+   step ca certificate "$(hostname -s)" \
+     /var/root/reprovision-runner/client.crt \
+     /var/root/reprovision-runner/client.key \
+     --provisioner <provisioner>
+   ```
+
+The cert CN must be the host's short name (e.g. `macmini-m4-81`); Hangar
+authorizes the runner on the cert Subject CN against `REPROVISION_RUNNER_HOSTS`.
+The SPIFFE SAN role is `gecko_t_osx_1500_m4_no_sip` (matches the step-ca
+template used elsewhere).
+
+## Logs
+
+`/var/log/reprovision-runner/{runner,certrenew}.{out,err}`

--- a/modules/reprovision_runner/manifests/init.pp
+++ b/modules/reprovision_runner/manifests/init.pp
@@ -1,0 +1,255 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Installs the Hangar reprovision-runner on an on-network (MDC1) host.
+#
+# Hangar (Cloud Run) cannot SSH into MDC1, so it only *queues* reprovision jobs.
+# This runner lives on the VPN, polls Hangar over mTLS (outbound only, no inbound
+# to MDC1), claims a job, runs the `reprovision` CLI, and streams progress back.
+# It is the only component that holds worker SSH/admin creds; Hangar holds none.
+# See relops-bootstrap: orchestrator/orchestrator/runner.py and
+# hangar/docs/reprovision-mdc1-runner-design.md.
+#
+# This is a component module: single-OS (macOS), no profile calls, no hiera
+# lookups. All configuration (including secret values) is passed by the
+# roles_profiles::profiles::reprovision_runner profile.
+#
+# @param enabled
+#   Master switch. When false the class is inert (nothing is managed).
+# @param hangar_api_url
+#   Base API URL Hangar exposes, e.g. https://hangar.relops.mozilla.com/api .
+# @param runner_id
+#   Label this runner reports to Hangar (defaults to the host's short name).
+# @param repo_url
+#   Git source of the relops-bootstrap repo that ships the orchestrator.
+# @param repo_revision
+#   Git ref (branch/tag/sha) to deploy.
+# @param install_dir
+#   Where the repo clone + venv live.
+# @param python_version
+#   python.org framework version to install (via packages::python3).
+# @param poll_seconds
+#   Claim poll interval when the queue is empty.
+# @param cert_mode
+#   How the mTLS client cert is provisioned:
+#     'step_renew' (recommended) - Puppet installs the `step` CLI and a renew
+#        LaunchDaemon that keeps a short-lived step-ca cert fresh; the private
+#        key is generated on-host and never stored in vault/git. The one-time
+#        initial enrollment is an operator bootstrap step (see README).
+#     'vault' - cert + key content are delivered through vault.yaml and written
+#        0600. Simple, ronin-native, but a long-lived key at rest + manual
+#        rotation. Fallback only.
+# @param client_cert
+#   PEM client cert (leaf + intermediates). Required for cert_mode 'vault';
+#   for 'step_renew' this path is populated by the initial enrollment + renew.
+# @param client_key
+#   PEM private key. Only consumed for cert_mode 'vault'.
+# @param step_ca_url
+#   step-ca base URL (cert_mode 'step_renew').
+# @param step_version
+#   smallstep `step` CLI version to install (cert_mode 'step_renew').
+# @param secrets
+#   REPROVISION_* creds the `reprovision` CLI needs, keyed by env var name, e.g.
+#   { 'REPROVISION_TC_CLIENT_ID' => Sensitive('...'), ... }. Sourced from vault
+#   by the profile and written to a 0600 env file the daemon sources.
+class reprovision_runner (
+  Boolean                          $enabled        = false,
+  String[1]                        $hangar_api_url = 'https://hangar.relops.mozilla.com/api',
+  String[1]                        $runner_id      = $facts['networking']['hostname'],
+  String[1]                        $repo_url       = 'https://github.com/mozilla-platform-ops/relops-bootstrap.git',
+  String[1]                        $repo_revision  = 'main',
+  String[1]                        $install_dir    = '/opt/reprovision-runner',
+  Pattern[/^\d+\.\d+\.\d+$/]       $python_version = '3.11.0',
+  Integer[1]                       $poll_seconds   = 10,
+  Enum['step_renew', 'vault']      $cert_mode      = 'step_renew',
+  Optional[Sensitive[String[1]]]   $client_cert    = undef,
+  Optional[Sensitive[String[1]]]   $client_key     = undef,
+  String[1]                        $step_ca_url    = 'https://step-ca.relops.mozilla',
+  String[1]                        $step_version   = '0.28.2',
+  Hash[Pattern[/^REPROVISION_[A-Z0-9_]+$/], Sensitive[String]] $secrets = {},
+) {
+  if $enabled {
+    $short_python  = split(String($python_version), '[.]')[0, 2].join('.')
+    $python_bin    = "/Library/Frameworks/Python.framework/Versions/${short_python}/bin/python3"
+    $repo_dir      = "${install_dir}/repo"
+    $orch_dir      = "${repo_dir}/orchestrator"
+    $venv_dir      = "${install_dir}/.venv"
+    $runner_bin    = "${venv_dir}/bin/reprovision-runner"
+
+    $conf_dir      = '/var/root/reprovision-runner'
+    $cert_path     = "${conf_dir}/client.crt"
+    $key_path      = "${conf_dir}/client.key"
+    $env_file      = "${conf_dir}/runner.env"
+    $wrapper       = '/usr/local/bin/reprovision-runner.sh'
+    $log_dir       = '/var/log/reprovision-runner'
+    $plist_label   = 'com.mozilla.reprovision-runner'
+    $plist_path    = "/Library/LaunchDaemons/${plist_label}.plist"
+
+    # ---- python 3.11 (framework build, same source as scriptworker_prereqs) ----
+    class { 'packages::python3':
+      version => $python_version,
+    }
+
+    # ---- code: clone relops-bootstrap + build a venv + editable-install ----
+    file { $install_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'wheel',
+      mode   => '0755',
+    }
+
+    vcsrepo { $repo_dir:
+      ensure   => latest,
+      provider => git,
+      source   => $repo_url,
+      revision => $repo_revision,
+      owner    => 'root',
+      group    => 'wheel',
+      require  => File[$install_dir],
+      notify   => Exec['reprovision_runner_pip_install'],
+    }
+
+    exec { 'reprovision_runner_venv':
+      command => "${python_bin} -m venv ${venv_dir}",
+      path    => ['/usr/bin', '/bin'],
+      creates => "${venv_dir}/bin/python",
+      require => [Class['packages::python3'], File[$install_dir]],
+    }
+
+    # Editable install so a repo bump (vcsrepo latest) takes effect without a
+    # rebuild. Re-runs when the venv is (re)created or the repo advances.
+    exec { 'reprovision_runner_pip_install':
+      command     => "${venv_dir}/bin/pip install --upgrade pip && ${venv_dir}/bin/pip install -e ${orch_dir}",
+      path        => ['/usr/bin', '/bin'],
+      refreshonly => true,
+      timeout     => 900,
+      subscribe   => Exec['reprovision_runner_venv'],
+      require     => [Exec['reprovision_runner_venv'], Vcsrepo[$repo_dir]],
+      notify      => Exec['reprovision_runner_reload'],
+    }
+
+    # ---- config dir + cert/key + env file (all root-only) ----
+    file { $conf_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'wheel',
+      mode   => '0700',
+    }
+
+    file { $log_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'wheel',
+      mode   => '0755',
+    }
+
+    # mTLS cert acquisition.
+    case $cert_mode {
+      'vault': {
+        # Long-lived cert + key delivered through vault.yaml. Written 0600; the
+        # private key is at rest here, so rotate it before expiry (see README).
+        if $client_cert =~ Undef or $client_key =~ Undef {
+          fail('reprovision_runner: cert_mode "vault" requires client_cert and client_key')
+        }
+        file { $cert_path:
+          ensure    => file,
+          owner     => 'root',
+          group     => 'wheel',
+          mode      => '0600',
+          show_diff => false,
+          content   => $client_cert,
+          require   => File[$conf_dir],
+          notify    => Exec['reprovision_runner_reload'],
+        }
+        file { $key_path:
+          ensure    => file,
+          owner     => 'root',
+          group     => 'wheel',
+          mode      => '0600',
+          show_diff => false,
+          content   => $client_key,
+          require   => File[$conf_dir],
+          notify    => Exec['reprovision_runner_reload'],
+        }
+      }
+      'step_renew': {
+        # Recommended: on-host key, short-lived cert, auto-renewed. Puppet manages
+        # the `step` CLI + a renew daemon; the *initial* enrollment is a one-time
+        # operator bootstrap (README) because it needs a single-use credential.
+        # The private key never lands in vault or git.
+        contain reprovision_runner::step_renew
+      }
+      default: {
+        fail("reprovision_runner: unsupported cert_mode '${cert_mode}'")
+      }
+    }
+
+    # Secrets -> 0600 env file the daemon sources. Values are single-quote-escaped
+    # so multi-line PEM keys and arbitrary chars survive `source`. The whole
+    # content is Sensitive; show_diff is off so secrets never hit the puppet log.
+    $secret_exports = $secrets.map |$k, $v| {
+      $escaped = regsubst($v.unwrap, "'", "'\\''", 'G')
+      "export ${k}='${escaped}'"
+    }.join("\n")
+
+    $env_content = @("ENVFILE"/L)
+      # Managed by Puppet (reprovision_runner). Do not edit.
+      export HANGAR_API_URL='${hangar_api_url}'
+      export RUNNER_ID='${runner_id}'
+      export RUNNER_CLIENT_CERT='${cert_path}'
+      export RUNNER_CLIENT_KEY='${key_path}'
+      export RUNNER_POLL_SECONDS='${poll_seconds}'
+      ${secret_exports}
+      | ENVFILE
+
+    file { $env_file:
+      ensure    => file,
+      owner     => 'root',
+      group     => 'wheel',
+      mode      => '0600',
+      show_diff => false,
+      content   => Sensitive($env_content),
+      require   => File[$conf_dir],
+      notify    => Exec['reprovision_runner_reload'],
+    }
+
+    # ---- wrapper: source the env file, exec the venv runner ----
+    file { $wrapper:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0755',
+      content => epp("${module_name}/reprovision-runner.sh.epp", {
+        env_file   => $env_file,
+        runner_bin => $runner_bin,
+      }),
+      notify  => Exec['reprovision_runner_reload'],
+    }
+
+    # ---- LaunchDaemon: RunAtLoad + KeepAlive, headless, survives reboot ----
+    file { $plist_path:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0644',
+      content => epp("${module_name}/com.mozilla.reprovision-runner.plist.epp", {
+        label   => $plist_label,
+        wrapper => $wrapper,
+        log_dir => $log_dir,
+      }),
+      require => [File[$wrapper], File[$env_file]],
+      notify  => Exec['reprovision_runner_reload'],
+    }
+
+    # system domain: loads headlessly, no console session required. bootout then
+    # bootstrap so an edited plist is actually re-read (kickstart alone would
+    # not pick up plist changes). Wrapped in bash -c for the shell operators.
+    exec { 'reprovision_runner_reload':
+      command     => "/bin/bash -c 'launchctl bootout system ${plist_path} 2>/dev/null || true; launchctl bootstrap system ${plist_path}'",
+      path        => ['/bin', '/usr/bin'],
+      refreshonly => true,
+      require     => File[$plist_path],
+    }
+  }
+}

--- a/modules/reprovision_runner/manifests/step_renew.pp
+++ b/modules/reprovision_runner/manifests/step_renew.pp
@@ -1,0 +1,121 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# cert_mode 'step_renew' helper for reprovision_runner (the recommended,
+# review-friendly cert path).
+#
+# Installs the smallstep `step` CLI and a renew LaunchDaemon that keeps the
+# runner's short-lived mTLS client cert fresh. Properties a security review
+# looks for:
+#   - the private key is generated ON-HOST at enrollment and never leaves it
+#     (nothing in vault, nothing in git),
+#   - certs are short-lived and auto-rotated (small blast radius),
+#   - renewal is authenticated by the *current* cert (mTLS), so after bootstrap
+#     there is no stored long-lived credential,
+#   - the cert is centrally revocable at step-ca.
+#
+# The one-time INITIAL enrollment needs a single-use credential, so it is an
+# operator bootstrap step (see README) UNLESS a single-use $enrollment_token is
+# supplied via vault, in which case Puppet enrolls once (when the cert is
+# absent). A short-lived token in vault is far weaker material than a long-lived
+# private key would be.
+#
+# Params are bound from hiera (e.g. vault.yaml):
+#   reprovision_runner::step_renew::ca_fingerprint
+#   reprovision_runner::step_renew::enrollment_token
+class reprovision_runner::step_renew (
+  Optional[String[1]]            $ca_fingerprint   = undef,
+  Optional[Sensitive[String[1]]] $enrollment_token = undef,
+) {
+  assert_private('reprovision_runner::step_renew is a private helper of reprovision_runner')
+
+  # Pull the shared paths/config from the enclosing class.
+  $conf_dir    = $reprovision_runner::conf_dir
+  $cert_path   = $reprovision_runner::cert_path
+  $key_path    = $reprovision_runner::key_path
+  $step_ca_url = $reprovision_runner::step_ca_url
+  $step_ver    = $reprovision_runner::step_version
+  $runner_id   = $reprovision_runner::runner_id
+  $plist_label = $reprovision_runner::plist_label
+
+  $step_bin    = '/usr/local/bin/step'
+  $step_path   = "${conf_dir}/step" # STEPPATH: CA trust bundle + config
+  $arch        = $facts['os']['architecture'] ? { 'arm64' => 'arm64', default => 'amd64' }
+  $renew_label = 'com.mozilla.reprovision-runner-certrenew'
+  $renew_plist = "/Library/LaunchDaemons/${renew_label}.plist"
+
+  # ---- install the step CLI ----
+  exec { 'install_step_cli':
+    command => "/bin/bash -c 'set -e; tmp=\$(mktemp -d); cd \"\$tmp\"; \
+                curl -fsSL -o step.tar.gz https://github.com/smallstep/cli/releases/download/v${step_ver}/step_darwin_${step_ver}_${arch}.tar.gz; \
+                tar -xzf step.tar.gz; mkdir -p /usr/local/bin; \
+                install -m 0755 step_${step_ver}/bin/step ${step_bin}; \
+                cd /; rm -rf \"\$tmp\"'",
+    path    => ['/usr/bin', '/bin'],
+    creates => $step_bin,
+    timeout => 300,
+  }
+
+  file { $step_path:
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0700',
+    require => File[$conf_dir],
+  }
+
+  # ---- bootstrap CA trust (idempotent; needs the CA root fingerprint) ----
+  if $ca_fingerprint {
+    exec { 'step_ca_bootstrap':
+      command     => "${step_bin} ca bootstrap --ca-url ${step_ca_url} --fingerprint ${ca_fingerprint} --force",
+      environment => ["STEPPATH=${step_path}"],
+      path        => ['/usr/bin', '/bin', '/usr/local/bin'],
+      creates     => "${step_path}/certs/root_ca.crt",
+      require     => [Exec['install_step_cli'], File[$step_path]],
+    }
+    $enroll_require = [Exec['step_ca_bootstrap']]
+  } else {
+    $enroll_require = [Exec['install_step_cli']]
+  }
+
+  # ---- optional automated initial enrollment (one-time, when cert absent) ----
+  # command is Sensitive so the single-use token never lands in the puppet log.
+  if $enrollment_token =~ NotUndef {
+    exec { 'step_initial_enroll':
+      command     => Sensitive("${step_bin} ca certificate ${runner_id} ${cert_path} ${key_path} --token ${enrollment_token.unwrap} --force"),
+      environment => ["STEPPATH=${step_path}"],
+      path        => ['/usr/bin', '/bin', '/usr/local/bin'],
+      creates     => $cert_path,
+      require     => $enroll_require + [File[$conf_dir]],
+      notify      => Exec['reprovision_runner_reload'],
+    }
+  }
+
+  # ---- renew daemon: refresh at ~2/3 lifetime, kick the runner on renewal ----
+  # `step ca renew --daemon` no-ops until a cert exists, so this is safe to load
+  # before the initial enrollment; KeepAlive + ThrottleInterval back it off.
+  file { $renew_plist:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0644',
+    content => epp('reprovision_runner/com.mozilla.reprovision-runner-certrenew.plist.epp', {
+      label     => $renew_label,
+      step_bin  => $step_bin,
+      step_path => $step_path,
+      cert_path => $cert_path,
+      key_path  => $key_path,
+      exec_kick => "/bin/launchctl kickstart -k system/${plist_label}",
+    }),
+    require => Exec['install_step_cli'],
+    notify  => Exec['reprovision_runner_certrenew_reload'],
+  }
+
+  exec { 'reprovision_runner_certrenew_reload':
+    command     => "/bin/bash -c 'launchctl bootout system ${renew_plist} 2>/dev/null || true; launchctl bootstrap system ${renew_plist}'",
+    path        => ['/bin', '/usr/bin'],
+    refreshonly => true,
+    require     => File[$renew_plist],
+  }
+}

--- a/modules/reprovision_runner/templates/com.mozilla.reprovision-runner-certrenew.plist.epp
+++ b/modules/reprovision_runner/templates/com.mozilla.reprovision-runner-certrenew.plist.epp
@@ -1,0 +1,41 @@
+<%- | String $label,
+      String $step_bin,
+      String $step_path,
+      String $cert_path,
+      String $key_path,
+      String $exec_kick,
+| -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string><%= $label %></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $step_bin %></string>
+        <string>ca</string>
+        <string>renew</string>
+        <string>--daemon</string>
+        <string>--exec</string>
+        <string><%= $exec_kick %></string>
+        <string><%= $cert_path %></string>
+        <string><%= $key_path %></string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>STEPPATH</key>
+        <string><%= $step_path %></string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>/var/log/reprovision-runner/certrenew.out</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/reprovision-runner/certrenew.err</string>
+</dict>
+</plist>

--- a/modules/reprovision_runner/templates/com.mozilla.reprovision-runner.plist.epp
+++ b/modules/reprovision_runner/templates/com.mozilla.reprovision-runner.plist.epp
@@ -1,0 +1,26 @@
+<%- | String $label,
+      String $wrapper,
+      String $log_dir,
+| -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string><%= $label %></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $wrapper %></string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string><%= $log_dir %>/runner.out</string>
+    <key>StandardErrorPath</key>
+    <string><%= $log_dir %>/runner.err</string>
+</dict>
+</plist>

--- a/modules/reprovision_runner/templates/reprovision-runner.sh.epp
+++ b/modules/reprovision_runner/templates/reprovision-runner.sh.epp
@@ -1,0 +1,13 @@
+<%- | String $env_file,
+      String $runner_bin,
+| -%>
+#!/bin/bash
+# Managed by Puppet (reprovision_runner). Do not edit.
+# Source the root-only env file (HANGAR_API_URL, RUNNER_*, REPROVISION_* creds)
+# then exec the runner. The env file is the only place secrets live at rest.
+set -euo pipefail
+set -a
+# shellcheck disable=SC1090
+source '<%= $env_file %>'
+set +a
+exec '<%= $runner_bin %>'

--- a/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Profile for the Hangar reprovision-runner on an on-network (MDC1) host.
+# Does the hiera lookups (non-secret config from role data, creds from
+# vault.yaml) and hands them to the reprovision_runner component module.
+#
+# Inert unless reprovision_runner.enabled is true in hiera, so it is safe to
+# include broadly and enable per-host via role data.
+class roles_profiles::profiles::reprovision_runner {
+  $enabled = lookup('reprovision_runner.enabled', Boolean, 'first', false)
+
+  if $enabled {
+    $cert_mode = lookup('reprovision_runner.cert_mode', Enum['step_renew', 'vault'], 'first', 'step_renew')
+
+    # Worker/admin creds the `reprovision` CLI needs, sourced from vault.yaml.
+    # Wrapped Sensitive so they never surface in logs/reports.
+    $secrets = {
+      'REPROVISION_TC_CLIENT_ID'       => Sensitive(lookup('reprovision_runner.tc_client_id', String, 'first', '')),
+      'REPROVISION_TC_ACCESS_TOKEN'    => Sensitive(lookup('reprovision_runner.tc_access_token', String, 'first', '')),
+      'REPROVISION_SIMPLEMDM_API_KEY'  => Sensitive(lookup('reprovision_runner.simplemdm_api_key', String, 'first', '')),
+      'REPROVISION_SSH_ADMIN_PASSWORD' => Sensitive(lookup('reprovision_runner.ssh_admin_password', String, 'first', '')),
+      'REPROVISION_SSH_ADMIN_KEY'      => Sensitive(lookup('reprovision_runner.ssh_admin_key', String, 'first', '')),
+    }
+
+    # cert_mode 'vault' additionally delivers the cert + key through vault.yaml.
+    # 'step_renew' (default) generates the key on-host and needs neither here.
+    $client_cert = $cert_mode ? {
+      'vault' => Sensitive(lookup('reprovision_runner.client_cert', String, 'first', '')),
+      default => undef,
+    }
+    $client_key = $cert_mode ? {
+      'vault' => Sensitive(lookup('reprovision_runner.client_key', String, 'first', '')),
+      default => undef,
+    }
+
+    class { 'reprovision_runner':
+      enabled        => true,
+      cert_mode      => $cert_mode,
+      hangar_api_url => lookup('reprovision_runner.hangar_api_url', String, 'first', 'https://hangar.relops.mozilla.com/api'),
+      runner_id      => lookup('reprovision_runner.runner_id', String, 'first', $facts['networking']['hostname']),
+      repo_url       => lookup('reprovision_runner.repo_url', String, 'first', 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
+      repo_revision  => lookup('reprovision_runner.repo_revision', String, 'first', 'main'),
+      step_ca_url    => lookup('reprovision_runner.step_ca_url', String, 'first', 'https://step-ca.relops.mozilla'),
+      client_cert    => $client_cert,
+      client_key     => $client_key,
+      secrets        => $secrets,
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1500_m4_reprovision_runner.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1500_m4_reprovision_runner.pp
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Dedicated role for an M4 mini repurposed as the on-network reprovision-runner
+# host (e.g. macmini-m4-81, off-CI). It is NOT a CI worker: no generic-worker,
+# talos, screenshot helper, etc. It carries the base OS/user/management profiles
+# plus the reprovision_runner profile.
+class roles_profiles::roles::gecko_t_osx_1500_m4_reprovision_runner {
+  # base OS niceties (harmless, shared with the CI m4 role)
+  include macos_utils::disable_bluetooth_setup
+  include macos_utils::always_show_scroll_bars
+  include macos_utils::suppress_keyboard_assistant
+
+  # access + management
+  include roles_profiles::profiles::relops_users
+  include roles_profiles::profiles::users
+  include roles_profiles::profiles::sudo
+  include roles_profiles::profiles::vnc
+  include roles_profiles::profiles::macos_run_puppet
+  include roles_profiles::profiles::motd
+  include roles_profiles::profiles::network
+  include roles_profiles::profiles::ntp
+  include roles_profiles::profiles::timezone
+
+  # the point of this host
+  include roles_profiles::profiles::reprovision_runner
+}


### PR DESCRIPTION
Makes the Hangar **reprovision-runner** (currently hand-assembled on m4-81) reproducible via Puppet, so a rebuilt host re-establishes it with no manual setup.

### Why
Today m4-81's runner is hacked together: code `rsync`'d from a laptop, secrets pasted through an ssh heredoc, a 1-hour hand-minted cert, and a foreground ssh session that dies on disconnect. Nothing rebuilds it. This makes it a declarative role.

### What Puppet manages
- **Python 3.11** (`packages::python3`), a **clone of relops-bootstrap** + a venv with the orchestrator editable-installed (`/opt/reprovision-runner`)
- A **LaunchDaemon** (`com.mozilla.reprovision-runner`, `RunAtLoad` + `KeepAlive`) — survives reboots/disconnects
- A root-only **`0600` env file** the daemon sources (`HANGAR_API_URL`, `RUNNER_*`, `REPROVISION_*` creds from vault)
- The **mTLS client cert** (see cert modes)

### Cert modes (`reprovision_runner.cert_mode`)
- **`step_renew`** (default, recommended): installs the smallstep `step` CLI + a **renew LaunchDaemon** (`step ca renew --daemon`). Private key generated **on-host**, never in vault/git; short-lived, auto-rotated, mTLS-renewed, centrally revocable. On renewal it kicks the runner to reload the cert. The path that most cleanly passes a security review.
- **`vault`**: cert+key delivered through `vault.yaml`, written `0600`. Simple fallback; long-lived key at rest + manual rotation.

### Layout
- `modules/reprovision_runner/` — component module (macOS) + `step_renew` helper + EPP templates + README
- `roles_profiles::profiles::reprovision_runner` — hiera lookups → module (inert unless `reprovision_runner.enabled`)
- `roles_profiles::roles::gecko_t_osx_1500_m4_reprovision_runner` — lean dedicated role (base OS/user/mgmt profiles + runner; **no CI worker**) + role data

### Depends on
- **mozilla-platform-ops/relops-bootstrap#21** — the LaunchDaemon runs the venv binary without activation, exactly the `reprovision`-not-on-PATH case that fix resolves.

### One-time bootstrap (module README)
step-ca enrollment via a **single-use token** in vault (`reprovision_runner::step_renew::enrollment_token` + `ca_fingerprint`) or an operator `step ca certificate` run. Cert CN = host short name; Hangar authorizes on the Subject CN.

### Validation
`puppet parser validate`, `puppet epp validate`, `puppet-lint --fail-on-warnings` (repo flags), YAML load, full **pre-commit passed**. Not yet applied — first `bolt … deploy::apply` against m4-81 is the live test.