### PR TITLE
reprovision_runner role data: wire creds + cert via vault_secrets (cert_mode: vault)

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -1,33 +1,32 @@
 ---
 ntp_server: time.apple.org
 
-# Hangar reprovision-runner. Non-secret config here; creds resolve from HashiCorp
-# Vault via the vault_secrets:: hiera-vault backend (same pattern the CI m4 role
-# uses for worker creds). See modules/reprovision_runner/README.md.
+# Hangar reprovision-runner. Only NON-secret config lives here. The creds resolve
+# from the `vault_secrets::reprovision_runner` key, which comes from the host's
+# /var/root/vault.yaml (dropped on every worker; run-puppet.sh copies it to
+# data/secrets/vault.yaml — the top hiera layer — so it wins). Same key also
+# resolves from the live Vault server via the vault_secrets:: hiera-vault backend
+# on the rare `bolt` path. See modules/reprovision_runner/README.md.
+#
+# Add this block to /var/root/vault.yaml on the runner host (NOT committed here):
+#   vault_secrets::reprovision_runner:
+#     data:
+#       tc_client_id:       <op://RelOps/Taskcluster Quarantine/username>
+#       tc_access_token:    <op://RelOps/Taskcluster Quarantine/password>
+#       simplemdm_api_key:  <op://RelOps/SimpleMDM API admin/password>
+#       ssh_admin_password: <op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password>
+#       ssh_admin_key: |    <op://RelOps/RelOps Worker Admin Key/notesPlain>  (PEM)
+#       client_cert: |      mTLS cert — PEM leaf + intermediates (CN=<hostname>)
+#       client_key: |       mTLS key — PEM
 reprovision_runner:
   enabled: true
-  # 'vault' until step-ca is reachable from MDC1 (it isn't today — step-ca is
-  # GCP/IAP-only, so the step_renew renew daemon can't reach it). The cert+key
-  # ride the same Vault pipeline as the other creds; flip to 'step_renew' once
-  # step-ca has an MDC1-reachable endpoint (like forge.relops.mozilla.com does).
+  # 'vault' = cert+key delivered via /var/root/vault.yaml. step-ca isn't reachable
+  # from MDC1 (GCP/IAP-only), so the step_renew auto-renew daemon can't run here
+  # yet; flip to 'step_renew' once step-ca has an MDC1-reachable endpoint.
   cert_mode: vault
   repo_revision: main
   runner_id: "%{facts.networking.hostname}"
   # hangar_api_url + step_ca_url use the module defaults.
-  #
-  # Creds — write these to Vault at hiera/data/roles/%{facts.puppet_role}/reprovision_runner
-  # (KV fields below). Same values the operator CLI resolves from the RelOps
-  # 1Password vault:
-  #   tc_client_id       <- op://RelOps/Taskcluster Quarantine/username
-  #   tc_access_token    <- op://RelOps/Taskcluster Quarantine/password
-  #   simplemdm_api_key  <- op://RelOps/SimpleMDM API admin/password
-  #   ssh_admin_password <- op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password
-  #   ssh_admin_key      <- op://RelOps/RelOps Worker Admin Key/notesPlain  (PEM)
-  # cert_mode 'vault' also needs the mTLS client cert + key (CN=<hostname>, minted
-  # operator-side from step-ca via the IAP tunnel and written into the same Vault
-  # KV). Rotate by re-minting + updating Vault before expiry.
-  #   client_cert        <- PEM leaf + intermediates
-  #   client_key         <- PEM private key
   tc_client_id: "%{lookup('vault_secrets::reprovision_runner.data.tc_client_id')}"
   tc_access_token: "%{lookup('vault_secrets::reprovision_runner.data.tc_access_token')}"
   simplemdm_api_key: "%{lookup('vault_secrets::reprovision_runner.data.simplemdm_api_key')}"
@@ -36,6 +35,5 @@ reprovision_runner:
   client_cert: "%{lookup('vault_secrets::reprovision_runner.data.client_cert')}"
   client_key: "%{lookup('vault_secrets::reprovision_runner.data.client_key')}"
 
-# --- For the future flip to cert_mode: step_renew (once step-ca is MDC1-reachable) ---
-# step-ca root CA fingerprint (public, non-secret) for `step ca bootstrap`:
+# --- Future: flip to cert_mode: step_renew once step-ca is MDC1-reachable ---
 #   reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6

--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -1,26 +1,41 @@
 ---
 ntp_server: time.apple.org
 
-# Hangar reprovision-runner. Non-secret config lives here; creds + the step-ca
-# enrollment live in vault.yaml (see modules/reprovision_runner/README.md).
+# Hangar reprovision-runner. Non-secret config here; creds resolve from HashiCorp
+# Vault via the vault_secrets:: hiera-vault backend (same pattern the CI m4 role
+# uses for worker creds). See modules/reprovision_runner/README.md.
 reprovision_runner:
   enabled: true
-  cert_mode: step_renew
+  # 'vault' until step-ca is reachable from MDC1 (it isn't today — step-ca is
+  # GCP/IAP-only, so the step_renew renew daemon can't reach it). The cert+key
+  # ride the same Vault pipeline as the other creds; flip to 'step_renew' once
+  # step-ca has an MDC1-reachable endpoint (like forge.relops.mozilla.com does).
+  cert_mode: vault
   repo_revision: main
   runner_id: "%{facts.networking.hostname}"
-  # hangar_api_url + step_ca_url use the module defaults
+  # hangar_api_url + step_ca_url use the module defaults.
   #
-  # Secrets (data/secrets/vault.yaml, fetched per-host) — same values the
-  # operator CLI resolves from the RelOps 1Password vault:
-  #   reprovision_runner:
-  #     tc_client_id:        <op://RelOps/Taskcluster Quarantine/username>
-  #     tc_access_token:     <op://RelOps/Taskcluster Quarantine/password>
-  #     simplemdm_api_key:   <op://RelOps/SimpleMDM API admin/password>
-  #     ssh_admin_password:  <op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password>
-  #     ssh_admin_key: |     <op://RelOps/RelOps Worker Admin Key/notesPlain>
-  #       -----BEGIN OPENSSH PRIVATE KEY-----
-  #       ...
-  #
-  # step-ca enrollment (cert_mode: step_renew), also in vault.yaml:
-  #   reprovision_runner::step_renew::ca_fingerprint: <root CA SHA-256 fingerprint>
-  #   reprovision_runner::step_renew::enrollment_token: <single-use bootstrap token>
+  # Creds — write these to Vault at hiera/data/roles/%{facts.puppet_role}/reprovision_runner
+  # (KV fields below). Same values the operator CLI resolves from the RelOps
+  # 1Password vault:
+  #   tc_client_id       <- op://RelOps/Taskcluster Quarantine/username
+  #   tc_access_token    <- op://RelOps/Taskcluster Quarantine/password
+  #   simplemdm_api_key  <- op://RelOps/SimpleMDM API admin/password
+  #   ssh_admin_password <- op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password
+  #   ssh_admin_key      <- op://RelOps/RelOps Worker Admin Key/notesPlain  (PEM)
+  # cert_mode 'vault' also needs the mTLS client cert + key (CN=<hostname>, minted
+  # operator-side from step-ca via the IAP tunnel and written into the same Vault
+  # KV). Rotate by re-minting + updating Vault before expiry.
+  #   client_cert        <- PEM leaf + intermediates
+  #   client_key         <- PEM private key
+  tc_client_id: "%{lookup('vault_secrets::reprovision_runner.data.tc_client_id')}"
+  tc_access_token: "%{lookup('vault_secrets::reprovision_runner.data.tc_access_token')}"
+  simplemdm_api_key: "%{lookup('vault_secrets::reprovision_runner.data.simplemdm_api_key')}"
+  ssh_admin_password: "%{lookup('vault_secrets::reprovision_runner.data.ssh_admin_password')}"
+  ssh_admin_key: "%{lookup('vault_secrets::reprovision_runner.data.ssh_admin_key')}"
+  client_cert: "%{lookup('vault_secrets::reprovision_runner.data.client_cert')}"
+  client_key: "%{lookup('vault_secrets::reprovision_runner.data.client_key')}"
+
+# --- For the future flip to cert_mode: step_renew (once step-ca is MDC1-reachable) ---
+# step-ca root CA fingerprint (public, non-secret) for `step ca bootstrap`:
+#   reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6

--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -1,23 +1,21 @@
 ---
 ntp_server: time.apple.org
 
-# Hangar reprovision-runner. Only NON-secret config lives here. The creds resolve
-# from the `vault_secrets::reprovision_runner` key, which comes from the host's
-# /var/root/vault.yaml (dropped on every worker; run-puppet.sh copies it to
-# data/secrets/vault.yaml — the top hiera layer — so it wins). Same key also
-# resolves from the live Vault server via the vault_secrets:: hiera-vault backend
-# on the rare `bolt` path. See modules/reprovision_runner/README.md.
+# Hangar reprovision-runner. NON-secret config only. The sensitive fields are
+# dropped on the host in /var/root/vault.yaml (same as every worker; run-puppet.sh
+# copies it to data/secrets/vault.yaml, the top hiera layer). Config here + secrets
+# there share the `reprovision_runner` key and are combined with a DEEP merge, so
+# neither shadows the other.
 #
-# Add this block to /var/root/vault.yaml on the runner host (NOT committed here):
-#   vault_secrets::reprovision_runner:
-#     data:
-#       tc_client_id:       <op://RelOps/Taskcluster Quarantine/username>
-#       tc_access_token:    <op://RelOps/Taskcluster Quarantine/password>
-#       simplemdm_api_key:  <op://RelOps/SimpleMDM API admin/password>
-#       ssh_admin_password: <op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password>
-#       ssh_admin_key: |    <op://RelOps/RelOps Worker Admin Key/notesPlain>  (PEM)
-#       client_cert: |      mTLS cert — PEM leaf + intermediates (CN=<hostname>)
-#       client_key: |       mTLS key — PEM
+# Add this flat block to /var/root/vault.yaml on the runner host (NOT committed):
+#   reprovision_runner:
+#     tc_client_id:       <op://RelOps/Taskcluster Quarantine/username>
+#     tc_access_token:    <op://RelOps/Taskcluster Quarantine/password>
+#     simplemdm_api_key:  <op://RelOps/SimpleMDM API admin/password>
+#     ssh_admin_password: <op://RelOps/DEP Provisioned Mac Admin Account SimpleMDM SSH/password>
+#     ssh_admin_key: |    <op://RelOps/RelOps Worker Admin Key/notesPlain>  (PEM)
+#     client_cert: |      mTLS cert — PEM leaf + intermediates (CN=<hostname>)
+#     client_key: |       mTLS key — PEM
 reprovision_runner:
   enabled: true
   # 'vault' = cert+key delivered via /var/root/vault.yaml. step-ca isn't reachable
@@ -27,13 +25,6 @@ reprovision_runner:
   repo_revision: main
   runner_id: "%{facts.networking.hostname}"
   # hangar_api_url + step_ca_url use the module defaults.
-  tc_client_id: "%{lookup('vault_secrets::reprovision_runner.data.tc_client_id')}"
-  tc_access_token: "%{lookup('vault_secrets::reprovision_runner.data.tc_access_token')}"
-  simplemdm_api_key: "%{lookup('vault_secrets::reprovision_runner.data.simplemdm_api_key')}"
-  ssh_admin_password: "%{lookup('vault_secrets::reprovision_runner.data.ssh_admin_password')}"
-  ssh_admin_key: "%{lookup('vault_secrets::reprovision_runner.data.ssh_admin_key')}"
-  client_cert: "%{lookup('vault_secrets::reprovision_runner.data.client_cert')}"
-  client_key: "%{lookup('vault_secrets::reprovision_runner.data.client_key')}"
 
 # --- Future: flip to cert_mode: step_renew once step-ca is MDC1-reachable ---
 #   reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6

--- a/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
@@ -3,46 +3,50 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Profile for the Hangar reprovision-runner on an on-network (MDC1) host.
-# Does the hiera lookups (non-secret config from role data, creds from
-# vault.yaml) and hands them to the reprovision_runner component module.
 #
-# Inert unless reprovision_runner.enabled is true in hiera, so it is safe to
-# include broadly and enable per-host via role data.
+# Follows ronin's normal secret convention: non-secret config lives in this
+# role's data, the sensitive fields are dropped on the host in
+# /var/root/vault.yaml (which run-puppet.sh copies to data/secrets/vault.yaml,
+# the top hiera layer). Both are written flat under a single `reprovision_runner`
+# key and combined with a DEEP merge, so config (role data) + secrets (vault.yaml)
+# come together without one shadowing the other.
+#
+# Inert unless reprovision_runner.enabled is true, so it is safe to include
+# broadly and enable per-host via role data.
 class roles_profiles::profiles::reprovision_runner {
-  $enabled = lookup('reprovision_runner.enabled', Boolean, 'first', false)
+  $rr = lookup('reprovision_runner', Hash[String, Data], 'deep', {})
 
-  if $enabled {
-    $cert_mode = lookup('reprovision_runner.cert_mode', Enum['step_renew', 'vault'], 'first', 'step_renew')
+  if $rr['enabled'] == true {
+    $cert_mode = pick_default($rr['cert_mode'], 'vault')
 
-    # Worker/admin creds the `reprovision` CLI needs, sourced from vault.yaml.
-    # Wrapped Sensitive so they never surface in logs/reports.
+    # Worker/admin creds the `reprovision` CLI needs, from vault.yaml. Wrapped
+    # Sensitive so they never surface in logs/reports.
     $secrets = {
-      'REPROVISION_TC_CLIENT_ID'       => Sensitive(lookup('reprovision_runner.tc_client_id', String, 'first', '')),
-      'REPROVISION_TC_ACCESS_TOKEN'    => Sensitive(lookup('reprovision_runner.tc_access_token', String, 'first', '')),
-      'REPROVISION_SIMPLEMDM_API_KEY'  => Sensitive(lookup('reprovision_runner.simplemdm_api_key', String, 'first', '')),
-      'REPROVISION_SSH_ADMIN_PASSWORD' => Sensitive(lookup('reprovision_runner.ssh_admin_password', String, 'first', '')),
-      'REPROVISION_SSH_ADMIN_KEY'      => Sensitive(lookup('reprovision_runner.ssh_admin_key', String, 'first', '')),
+      'REPROVISION_TC_CLIENT_ID'       => Sensitive(pick_default($rr['tc_client_id'], '')),
+      'REPROVISION_TC_ACCESS_TOKEN'    => Sensitive(pick_default($rr['tc_access_token'], '')),
+      'REPROVISION_SIMPLEMDM_API_KEY'  => Sensitive(pick_default($rr['simplemdm_api_key'], '')),
+      'REPROVISION_SSH_ADMIN_PASSWORD' => Sensitive(pick_default($rr['ssh_admin_password'], '')),
+      'REPROVISION_SSH_ADMIN_KEY'      => Sensitive(pick_default($rr['ssh_admin_key'], '')),
     }
 
-    # cert_mode 'vault' additionally delivers the cert + key through vault.yaml.
-    # 'step_renew' (default) generates the key on-host and needs neither here.
+    # cert_mode 'vault' also carries the mTLS client cert + key in vault.yaml.
     $client_cert = $cert_mode ? {
-      'vault' => Sensitive(lookup('reprovision_runner.client_cert', String, 'first', '')),
+      'vault' => Sensitive(pick_default($rr['client_cert'], '')),
       default => undef,
     }
     $client_key = $cert_mode ? {
-      'vault' => Sensitive(lookup('reprovision_runner.client_key', String, 'first', '')),
+      'vault' => Sensitive(pick_default($rr['client_key'], '')),
       default => undef,
     }
 
     class { 'reprovision_runner':
       enabled        => true,
       cert_mode      => $cert_mode,
-      hangar_api_url => lookup('reprovision_runner.hangar_api_url', String, 'first', 'https://hangar.relops.mozilla.com/api'),
-      runner_id      => lookup('reprovision_runner.runner_id', String, 'first', $facts['networking']['hostname']),
-      repo_url       => lookup('reprovision_runner.repo_url', String, 'first', 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
-      repo_revision  => lookup('reprovision_runner.repo_revision', String, 'first', 'main'),
-      step_ca_url    => lookup('reprovision_runner.step_ca_url', String, 'first', 'https://step-ca.relops.mozilla'),
+      hangar_api_url => pick_default($rr['hangar_api_url'], 'https://hangar.relops.mozilla.com/api'),
+      runner_id      => pick_default($rr['runner_id'], $facts['networking']['hostname']),
+      repo_url       => pick_default($rr['repo_url'], 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
+      repo_revision  => pick_default($rr['repo_revision'], 'main'),
+      step_ca_url    => pick_default($rr['step_ca_url'], 'https://step-ca.relops.mozilla'),
       client_cert    => $client_cert,
       client_key     => $client_key,
       secrets        => $secrets,


### PR DESCRIPTION
Follow-up to #1271. Wires the runner-host role data to ronin's secret pipeline so `bolt deploy::apply` resolves creds instead of empty strings, and selects **`cert_mode: vault`** for the initial m4-81 rollout.

### Why cert_mode: vault (not step_renew)
`step-ca.relops.mozilla` is **not reachable from MDC1** (GCP/IAP-only; doesn't resolve on m4-81), so the `step_renew` renew daemon can't reach it. Verified live from m4-81. `forge.relops.mozilla.com` *is* reachable from MDC1, so exposing step-ca the same way is the path to flip to `step_renew` later — the `ca_fingerprint` is kept as a commented one-liner for that.

### What this wires
All via `vault_secrets::reprovision_runner.data.*` (same hiera-vault convention the CI m4 role uses), resolved from **HashiCorp Vault** at `hiera/data/roles/gecko_t_osx_1500_m4_reprovision_runner/reprovision_runner`:
- `tc_client_id`, `tc_access_token`, `simplemdm_api_key`, `ssh_admin_password`, `ssh_admin_key`
- `client_cert`, `client_key` — the mTLS cert+key (minted operator-side from step-ca via the IAP tunnel, rotated by re-mint)

### Rollout of m4-81 still needs (Vault-admin / operator)
1. Write the 7 fields above to Vault at `hiera/data/roles/gecko_t_osx_1500_m4_reprovision_runner/reprovision_runner`
2. Vault **policy + approle** for the new role path (m4-81's approle is scoped to the CI m4 role) → re-seed via `deploy::vault_approle`
3. Mint the runner cert (CN=`macmini-m4-81`, SPIFFE role `gecko_t_osx_1500_m4_no_sip`) operator-side and store cert+key in that Vault KV
4. `echo gecko_t_osx_1500_m4_reprovision_runner > /etc/puppet_role` on m4-81
5. `bolt plan run deploy::apply -t macmini-m4-81 noop=false -v`