### PR TITLE
reprovision_runner: also run the hangar-screen-agent (VNC live view)

### DIFF
--- a/modules/reprovision_runner/manifests/init.pp
+++ b/modules/reprovision_runner/manifests/init.pp
@@ -86,6 +86,13 @@ class reprovision_runner (
     $plist_label   = 'com.mozilla.reprovision-runner'
     $plist_path    = "/Library/LaunchDaemons/${plist_label}.plist"
 
+    # Companion: the hangar-screen-agent (on-demand VNC frames for the live view). Same
+    # venv, same env file (HANGAR_API_URL + mTLS cert + admin creds), second LaunchDaemon.
+    $screen_bin          = "${venv_dir}/bin/hangar-screen-agent"
+    $screen_wrapper      = '/usr/local/bin/hangar-screen-agent.sh'
+    $screen_plist_label  = 'com.mozilla.hangar-screen-agent'
+    $screen_plist_path   = "/Library/LaunchDaemons/${screen_plist_label}.plist"
+
     # ---- python 3.11 (framework build, same source as scriptworker_prereqs) ----
     class { 'packages::python3':
       version => $python_version,
@@ -140,10 +147,12 @@ class reprovision_runner (
       command     => "${venv_dir}/bin/pip install --upgrade pip && ${venv_dir}/bin/pip install -e ${orch_dir}",
       path        => ['/usr/bin', '/bin'],
       environment => ['PIP_CONFIG_FILE=/dev/null'],
-      creates     => $runner_bin,
+      # Guard on the *screen-agent* bin (the newest console script) so an existing venv
+      # re-installs to pick up asyncvnc + hangar-screen-agent, not just reprovision-runner.
+      creates     => $screen_bin,
       timeout     => 900,
       require     => [Exec['reprovision_runner_venv'], Vcsrepo[$repo_dir]],
-      notify      => Exec['reprovision_runner_reload'],
+      notify      => [Exec['reprovision_runner_reload'], Exec['reprovision_runner_screen_reload']],
     }
 
     # ---- config dir + cert/key + env file (all root-only) ----
@@ -251,9 +260,10 @@ class reprovision_runner (
       group   => 'wheel',
       mode    => '0644',
       content => epp("${module_name}/com.mozilla.reprovision-runner.plist.epp", {
-        label   => $plist_label,
-        wrapper => $wrapper,
-        log_dir => $log_dir,
+        label    => $plist_label,
+        wrapper  => $wrapper,
+        log_dir  => $log_dir,
+        log_name => 'runner',
       }),
       require => [File[$wrapper], File[$env_file]],
       notify  => Exec['reprovision_runner_reload'],
@@ -267,6 +277,44 @@ class reprovision_runner (
       path        => ['/bin', '/usr/bin'],
       refreshonly => true,
       require     => File[$plist_path],
+    }
+
+    # ---- companion: hangar-screen-agent (VNC frames for the live view) ----
+    # Reuses the runner's env file + the same wrapper/plist templates, pointed at the
+    # screen-agent bin.
+    file { $screen_wrapper:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0755',
+      content => epp("${module_name}/reprovision-runner.sh.epp", {
+        env_file   => $env_file,
+        runner_bin => $screen_bin,
+      }),
+      require => Exec['reprovision_runner_pip_install'],
+      notify  => Exec['reprovision_runner_screen_reload'],
+    }
+
+    file { $screen_plist_path:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0644',
+      content => epp("${module_name}/com.mozilla.reprovision-runner.plist.epp", {
+        label    => $screen_plist_label,
+        wrapper  => $screen_wrapper,
+        log_dir  => $log_dir,
+        log_name => 'screen-agent',
+      }),
+      require => [File[$screen_wrapper], File[$env_file]],
+      notify  => Exec['reprovision_runner_screen_reload'],
+    }
+
+    exec { 'reprovision_runner_screen_reload':
+      command     => "/bin/bash -c 'launchctl bootout system ${screen_plist_path} 2>/dev/null || true; launchctl bootstrap system ${screen_plist_path}'",
+      path        => ['/bin', '/usr/bin'],
+      refreshonly => true,
+      require     => File[$screen_plist_path],
     }
   }
 }

--- a/modules/reprovision_runner/templates/com.mozilla.reprovision-runner.plist.epp
+++ b/modules/reprovision_runner/templates/com.mozilla.reprovision-runner.plist.epp
@@ -1,6 +1,7 @@
 <%- | String $label,
       String $wrapper,
       String $log_dir,
+      String $log_name,
 | -%>
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -19,8 +20,8 @@
     <key>ThrottleInterval</key>
     <integer>30</integer>
     <key>StandardOutPath</key>
-    <string><%= $log_dir %>/runner.out</string>
+    <string><%= $log_dir %>/<%= $log_name %>.out</string>
     <key>StandardErrorPath</key>
-    <string><%= $log_dir %>/runner.err</string>
+    <string><%= $log_dir %>/<%= $log_name %>.err</string>
 </dict>
 </plist>


### PR DESCRIPTION
Phase 3 of the worker live-view feature — the Puppet deploy for the capture agent (relops-bootstrap#24).

Adds a **second LaunchDaemon** (`com.mozilla.hangar-screen-agent`) on the runner host, reusing everything the runner already has:
- same venv + editable install (the pip guard now keys on the **screen-agent bin**, so an existing venv re-installs to pull in `asyncvnc` + the new `hangar-screen-agent` console script)
- same `/var/root/reprovision-runner/runner.env` (HANGAR_API_URL + mTLS cert + admin creds — all the agent needs)
- same wrapper + plist templates (parameterized the plist log filename so the two daemons don't collide on `runner.out/.err`)

### Depends on / deploy order
1. **relops-bootstrap#24** merged (screen agent code on main — the venv clones it)
2. **hangar#53** deployed (the `/screen/*` endpoints)
3. this PR merged → `run-puppet.sh` on m4-81 → installs deps + loads the 2nd daemon

Validated on m4-81 via the same `ronin_settings` branch-override flow we used for the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)