### PR TITLE
reprovision_runner: activate step_renew on m4-81 (auto-renewing cert)

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -18,23 +18,16 @@ ntp_server: time.apple.org
 #     client_key: |       mTLS key — PEM
 reprovision_runner:
   enabled: true
-  # 'vault' = cert+key delivered via /var/root/vault.yaml. step-ca isn't reachable
-  # from MDC1 (GCP/IAP-only), so the auto-renewing step_renew daemon can't run here
-  # yet. The 'vault' cert is capped at step-ca's global 24h provisioner limit, so it
-  # must be re-minted (scripts/mint-runner-cert.sh in relops-bootstrap) periodically.
-  # DURABLE FIX once step-ca is MDC1-reachable: see the ready-to-activate block below.
-  cert_mode: vault
+  # AUTO-RENEWING certs. step-ca is reachable from MDC1 by IP (verified 2026-07-10: TCP 443 +
+  # /health 200); its hostname just isn't in MDC1 DNS, so step_ca_ip pins it in /etc/hosts. The
+  # module then runs a `step ca renew --daemon` LaunchDaemon that rotates the cert within step-ca's
+  # 24h provisioner cap — key generated on-host, nothing in vault. Replaces the manual
+  # mint-runner-cert.sh reissue chore (relops-bootstrap#28).
+  cert_mode: step_renew
+  step_ca_ip: 34.61.3.27
   repo_revision: main
   runner_id: "%{facts.networking.hostname}"
   # hangar_api_url + step_ca_url use the module defaults.
 
-# --- Flip to auto-renewing certs once step-ca is reachable from MDC1 ---------------
-# Tracked in relops-bootstrap#28. To activate: change `cert_mode: vault` above to
-# `cert_mode: step_renew`, uncomment the fingerprint line below, then run puppet on
-# the host (the module installs `step` + a `step ca renew --daemon` LaunchDaemon that
-# generates the key on-host and auto-rotates within the 24h cap). Finally remove
-# client_cert/client_key from that host's /var/root/vault.yaml. Bootstrap options
-# (single-use token vs. one-time on-host `step ca certificate`) are in
-# ronin_puppet modules/reprovision_runner/README.md.
-#
-#   reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6
+# step-ca root CA fingerprint — pins trust during `step ca bootstrap` (non-secret).
+reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6

--- a/modules/reprovision_runner/manifests/init.pp
+++ b/modules/reprovision_runner/manifests/init.pp
@@ -66,6 +66,7 @@ class reprovision_runner (
   Optional[Sensitive[String[1]]]   $client_cert    = undef,
   Optional[Sensitive[String[1]]]   $client_key     = undef,
   String[1]                        $step_ca_url    = 'https://step-ca.relops.mozilla',
+  Optional[String[1]]              $step_ca_ip     = undef,
   String[1]                        $step_version   = '0.28.2',
   Hash[Pattern[/^REPROVISION_[A-Z0-9_]+$/], Sensitive[String]] $secrets = {},
 ) {

--- a/modules/reprovision_runner/manifests/step_renew.pp
+++ b/modules/reprovision_runner/manifests/step_renew.pp
@@ -35,9 +35,26 @@ class reprovision_runner::step_renew (
   $cert_path   = $reprovision_runner::cert_path
   $key_path    = $reprovision_runner::key_path
   $step_ca_url = $reprovision_runner::step_ca_url
+  $step_ca_ip  = $reprovision_runner::step_ca_ip
   $step_ver    = $reprovision_runner::step_version
   $runner_id   = $reprovision_runner::runner_id
   $plist_label = $reprovision_runner::plist_label
+
+  # step-ca lives in GCP and is only reachable from MDC1 by IP; its hostname isn't in MDC1 DNS.
+  # When $step_ca_ip is set, pin it in /etc/hosts so `step ca bootstrap`/`renew` resolve the
+  # name (the cert's SAN is the hostname, so TLS validates against the name, not the IP).
+  $ca_host = regsubst(regsubst($step_ca_url, '^https?://', ''), '[:/].*$', '')
+  if $step_ca_ip {
+    host { $ca_host:
+      ensure => present,
+      ip     => $step_ca_ip,
+    }
+    # Ensure the hosts entry is written before the bootstrap tries to resolve the name.
+    # (Exec['step_ca_bootstrap'] only exists when $ca_fingerprint is set — guard the ordering.)
+    if $ca_fingerprint {
+      Host[$ca_host] -> Exec['step_ca_bootstrap']
+    }
+  }
 
   $step_bin    = '/usr/local/bin/step'
   $step_path   = "${conf_dir}/step" # STEPPATH: CA trust bundle + config

--- a/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
@@ -47,6 +47,7 @@ class roles_profiles::profiles::reprovision_runner {
       repo_url       => pick_default($rr['repo_url'], 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
       repo_revision  => pick_default($rr['repo_revision'], 'main'),
       step_ca_url    => pick_default($rr['step_ca_url'], 'https://step-ca.relops.mozilla'),
+      step_ca_ip     => pick_default($rr['step_ca_ip'], undef),
       client_cert    => $client_cert,
       client_key     => $client_key,
       secrets        => $secrets,


### PR DESCRIPTION
Ends the manual runner-cert reissue chore (relops-bootstrap#28) by flipping m4-81 to the module's auto-renewing `cert_mode: step_renew`.

**Key finding (2026-07-10):** step-ca *is* reachable from MDC1 — a probe from m4-81 got TCP 443 + `/health` 200. The only gap was DNS (`step-ca.relops.mozilla` doesn't resolve in MDC1).

**Changes:**
- New `$step_ca_ip` param (module `init.pp` + profile). When set, `step_renew.pp` pins step-ca's hostname → that IP in `/etc/hosts` (ordered before the bootstrap), so `step ca bootstrap`/`renew` resolve the name and TLS validates against the cert's SAN.
- Role `gecko_t_osx_1500_m4_reprovision_runner`: `cert_mode: step_renew`, `step_ca_ip: 34.61.3.27`, and `reprovision_runner::step_renew::ca_fingerprint` set.

**Behavior:** the `step ca renew --daemon` LaunchDaemon rotates the runner's existing cert in place (key stays on-host, nothing in vault), within step-ca's 24h provisioner cap. The current cert (~21h left) covers until the daemon's first renewal (~2/3 lifetime).

**Validation:** `puppet parser validate` + pre-commit (puppet-lint, yaml) clean. Rollout plan: apply on m4-81 via the `ronin_settings` `PUPPET_BRANCH` override first, verify the renew daemon + runner, then merge. After proven, remove `client_cert`/`client_key` from m4-81's `/var/root/vault.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)