### PR TITLE
[PHASE B — hold] reprovision_runner: point m4-81 at hangar-runner.* frontend

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -27,7 +27,11 @@ reprovision_runner:
   step_ca_ip: 34.61.3.27
   repo_revision: main
   runner_id: "%{facts.networking.hostname}"
-  # hangar_api_url + step_ca_url use the module defaults.
+  # Talk to Hangar's DEDICATED runner frontend (mTLS on its own hostname). The human/browser
+  # frontend (hangar.relops.mozilla.com) no longer carries mTLS, so the runner MUST use this
+  # host to reach /api/reprovision/runner/* + /api/screen/agent/*. See hangar PR #65.
+  hangar_api_url: https://hangar-runner.relops.mozilla.com/api
+  # step_ca_url uses the module default.
 
 # step-ca root CA fingerprint — pins trust during `step ca bootstrap` (non-secret).
 reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6


### PR DESCRIPTION
**DRAFT / gated.** Companion to hangar #65. Sets the runner's `hangar_api_url` to the new dedicated mTLS frontend `https://hangar-runner.relops.mozilla.com/api`.

⚠️ **Do NOT merge until** the `hangar-runner` managed cert is ACTIVE and DNS resolves (hangar #65 Phase A). Merging early points the runner at a hostname that doesn't answer → runner can't claim jobs.

Rollout: after Phase A (frontend up, DNS + cert live), mark ready + merge, then run-puppet on m4-81 and confirm it claims over the new hostname. Then hangar #65 Phase C removes mTLS from the human frontend.