### PR TITLE
Revert macos_safaridriver applescripts to pre-#1262 (fix fresh-EACS Safari -1728)

### DIFF
--- a/modules/macos_safaridriver/files/safari-enable-remote-automation.applescript
+++ b/modules/macos_safaridriver/files/safari-enable-remote-automation.applescript
@@ -1,161 +1,71 @@
 -- safari-enable-remote-automation.applescript
 -- Used on macOS 14+ (Darwin 23+) where SIP is enabled.
 -- Runs via LaunchAgent as cltbld so osascript has full GUI session context.
--- Idempotent + retry-hardened.
---
--- Semaphore contract:
---   * File contains "1" only on successful completion.
---   * File does NOT exist between runs — no empty-file leftovers to confuse
---     downstream checks (puppet exec `unless`, driver LaunchDaemon
---     check_done, etc.). If this script fails, the file is not written at
---     all, and the next invocation starts fresh.
+-- Handles its own semaphore so it is idempotent.
 
 set semaphoreFile to "/Users/cltbld/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
 set semaphoreVersion to "1"
-set logFile to "/Users/cltbld/Library/Logs/safari-enable-remote-automation.log"
 
--- Ensure log dir + semaphore dir exist so error tracing works even on first run
-do shell script "mkdir -p /Users/cltbld/Library/Logs /Users/cltbld/Library/Preferences/semaphore"
-
-on logLine(msg)
-    global logFile
-    do shell script "echo \"[$(date '+%Y-%m-%dT%H:%M:%S')] " & msg & "\" >> " & quoted form of logFile
-end logLine
-
--- Skip if already succeeded (semaphore contains "1")
+-- Check semaphore
 try
     set semaphoreContent to do shell script "cat " & quoted form of semaphoreFile
     if semaphoreContent is semaphoreVersion then
-        my logLine("semaphore already at version 1 — nothing to do")
         return
     end if
 on error
-    -- file doesn't exist yet, proceed
+    -- file doesn't exist, proceed
 end try
 
--- Wait for GUI session to be fully ready before driving Safari.
--- Dock running is the standard proxy for "user session initialized enough
--- to accept UI automation". The LaunchAgent can fire before this on a
--- fresh login, so we wait up to 60s.
-my logLine("waiting for Dock to be running (GUI session readiness)")
-set dockReady to false
-repeat 12 times
-    try
-        do shell script "pgrep -x Dock >/dev/null"
-        set dockReady to true
-        exit repeat
-    on error
+-- Create semaphore dir and empty file (signals script is running)
+do shell script "mkdir -p /Users/cltbld/Library/Preferences/semaphore && touch " & quoted form of semaphoreFile
+
+-- Activate Safari
+tell application "Safari"
+    activate
+end tell
+delay 15
+
+tell application "System Events"
+    tell process "Safari"
+        set frontmost to true
         delay 5
-    end try
-end repeat
-if not dockReady then
-    my logLine("Dock never came up — bailing")
-    error "GUI session did not initialize (Dock process absent after 60s)"
-end if
-my logLine("Dock is up")
 
--- Additional settle time — even after Dock is running, Safari's initial
--- launch can hit races with the menu-bar accessibility tree if we jump
--- straight in.
-delay 5
+        -- Open Settings (ellipsis is U+2026)
+        click menu item "Settings…" of menu "Safari" of menu bar 1
+        delay 5
 
--- Retry the whole UI automation up to 3 times. Each attempt is idempotent
--- (each click checks state before toggling), so a partial success doesn't
--- corrupt anything on the next attempt.
-set maxAttempts to 3
-set attempt to 0
-repeat maxAttempts times
-    set attempt to attempt + 1
-    my logLine("attempt " & attempt & " of " & maxAttempts)
-    try
-        -- Activate Safari (also launches it if not running)
-        tell application "Safari"
-            activate
+        -- Go to Advanced tab
+        click button "Advanced" of toolbar 1 of window 1
+        delay 5
+
+        -- Enable Show features for web developers
+        tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
+            if value is 0 then click it
+            delay 5
+            if value is not 1 then
+                error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
+            end if
         end tell
-        delay 15
+        delay 5
 
-        tell application "System Events"
-            tell process "Safari"
-                set frontmost to true
-                delay 5
+        -- Open Developer tab
+        click button "Developer" of toolbar 1 of window 1
+        delay 5
 
-                -- Open Settings (ellipsis is U+2026)
-                click menu item "Settings…" of menu "Safari" of menu bar 1
-                delay 5
-
-                -- Go to Advanced tab
-                click button "Advanced" of toolbar 1 of window 1
-                delay 5
-
-                -- Enable "Allow remote automation"
-                -- Safari 18 (macOS 15) restructured the Settings UI: the Advanced
-                -- pane now contains what used to be a separate Developer tab,
-                -- and the "Show features for web developers" gate was removed
-                -- entirely. "Allow remote automation" is directly at the same
-                -- depth. If we ever need to support older Safari (17 / macOS 14),
-                -- we'd need to conditionalize this or fall back to the old
-                -- two-step (enable dev features -> Developer tab -> click).
-                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-                    if value is 0 then click it
-                    delay 3
-                end tell
-
-                -- Safari shows a confirmation sheet ("Are you sure? Allow Remote
-                -- Automation?") when the checkbox is toggled on. The sheet has
-                -- a confirm button that varies by macOS version — commonly
-                -- "Enable", "Allow", or "Turn On". Try each; if none work,
-                -- enumerate the sheet's buttons and log them for diagnosis.
-                try
-                    if exists sheet 1 of window 1 then
-                        set sheetHandled to false
-                        repeat with btnName in {"Enable", "Allow", "Turn On", "OK"}
-                            try
-                                click button (btnName as string) of sheet 1 of window 1
-                                set sheetHandled to true
-                                exit repeat
-                            end try
-                        end repeat
-                        if not sheetHandled then
-                            -- Fallback: log every button on the sheet for diagnosis,
-                            -- then click the first non-Cancel one.
-                            set btnNames to name of every button of sheet 1 of window 1
-                            do shell script "echo \"confirmation sheet buttons: " & (btnNames as string) & "\" >> /Users/cltbld/Library/Logs/safari-enable-remote-automation.log"
-                            repeat with b in (buttons of sheet 1 of window 1)
-                                if (name of b) is not "Cancel" then
-                                    click b
-                                    exit repeat
-                                end if
-                            end repeat
-                        end if
-                        delay 5
-                    end if
-                end try
-
-                -- Verify checkbox is now on
-                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-                    if value is not 1 then
-                        error "Allow remote automation did not toggle on (value=" & (value as string) & ") — confirmation sheet may not have been handled"
-                    end if
-                end tell
-            end tell
+        -- Enable Allow remote automation
+        tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
+            if value is 0 then click it
+            delay 5
+            if value is not 1 then
+                error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
+            end if
         end tell
+    end tell
+end tell
 
-        tell application "Safari" to quit
+tell application "Safari" to quit
 
-        -- Success. Write semaphore only now that both toggles are verified.
-        do shell script "printf '1' > " & quoted form of semaphoreFile
-        my logLine("attempt " & attempt & " succeeded, semaphore written")
-        return
-
-    on error errMsg number errNum
-        my logLine("attempt " & attempt & " failed (error " & errNum & "): " & errMsg)
-        -- Clean up any partial Safari state before the next attempt
-        try
-            tell application "Safari" to quit
-        end try
-        delay 10
-    end try
-end repeat
-
-my logLine("all " & maxAttempts & " attempts failed")
-error "safari enable script failed after " & maxAttempts & " attempts — see " & logFile
+-- Write semaphore (version 1 = done)
+-- Only reached if both checkbox verifications above passed; either errors abort the
+-- script before this line, leaving the semaphore as the empty file written at start.
+do shell script "printf '1' > " & quoted form of semaphoreFile

--- a/modules/macos_safaridriver/files/safari-tp-enable-remote-automation.applescript
+++ b/modules/macos_safaridriver/files/safari-tp-enable-remote-automation.applescript
@@ -1,133 +1,76 @@
 -- safari-tp-enable-remote-automation.applescript
 -- Used on macOS 14+ (Darwin 23+) where SIP is enabled.
 -- Runs via LaunchAgent as cltbld so osascript has full GUI session context.
--- Idempotent + retry-hardened.
+-- Handles its own semaphore so it is idempotent.
 --
 -- Mirror of safari-enable-remote-automation.applescript, but addressing the
 -- "Safari Technology Preview" app instead of stable Safari. Safari TP has
 -- its own separate "Allow Remote Automation" toggle that the stable Safari
 -- enable does not flip.
---
--- Semaphore contract: same as the stable Safari script — file contains "1"
--- only on success, does NOT exist between runs.
 
 set semaphoreFile to "/Users/cltbld/Library/Preferences/semaphore/safari-tech-preview-enable-remote-automation-has-run"
 set semaphoreVersion to "1"
-set logFile to "/Users/cltbld/Library/Logs/safari-tp-enable-remote-automation.log"
 
-do shell script "mkdir -p /Users/cltbld/Library/Logs /Users/cltbld/Library/Preferences/semaphore"
-
-on logLine(msg)
-    global logFile
-    do shell script "echo \"[$(date '+%Y-%m-%dT%H:%M:%S')] " & msg & "\" >> " & quoted form of logFile
-end logLine
-
--- Skip if already succeeded
+-- Check semaphore
 try
     set semaphoreContent to do shell script "cat " & quoted form of semaphoreFile
     if semaphoreContent is semaphoreVersion then
-        my logLine("semaphore already at version 1 — nothing to do")
         return
     end if
 on error
-    -- file doesn't exist yet
+    -- file doesn't exist, proceed
 end try
 
-my logLine("waiting for Dock to be running (GUI session readiness)")
-set dockReady to false
-repeat 12 times
-    try
-        do shell script "pgrep -x Dock >/dev/null"
-        set dockReady to true
-        exit repeat
-    on error
+-- Create semaphore dir and empty file (signals script is running)
+do shell script "mkdir -p /Users/cltbld/Library/Preferences/semaphore && touch " & quoted form of semaphoreFile
+
+-- Activate Safari Technology Preview
+tell application "Safari Technology Preview"
+    activate
+end tell
+delay 15
+
+tell application "System Events"
+    tell process "Safari Technology Preview"
+        set frontmost to true
         delay 5
-    end try
-end repeat
-if not dockReady then
-    my logLine("Dock never came up — bailing")
-    error "GUI session did not initialize (Dock process absent after 60s)"
-end if
-my logLine("Dock is up")
 
-delay 5
+        -- Open Settings (ellipsis is U+2026)
+        click menu item "Settings…" of menu "Safari Technology Preview" of menu bar 1
+        delay 5
 
-set maxAttempts to 3
-set attempt to 0
-repeat maxAttempts times
-    set attempt to attempt + 1
-    my logLine("attempt " & attempt & " of " & maxAttempts)
-    try
-        tell application "Safari Technology Preview"
-            activate
+        -- Go to Advanced tab
+        click button "Advanced" of toolbar 1 of window 1
+        delay 5
+
+        -- Enable Show features for web developers
+        tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
+            if value is 0 then click it
+            delay 5
+            if value is not 1 then
+                error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
+            end if
         end tell
-        delay 15
+        delay 5
 
-        tell application "System Events"
-            tell process "Safari Technology Preview"
-                set frontmost to true
-                delay 5
+        -- Open Developer tab
+        click button "Developer" of toolbar 1 of window 1
+        delay 5
 
-                click menu item "Settings…" of menu "Safari Technology Preview" of menu bar 1
-                delay 5
-
-                click button "Advanced" of toolbar 1 of window 1
-                delay 5
-
-                -- Safari 18 consolidation (see stable-Safari script for details) —
-                -- "Allow remote automation" is directly in the Advanced pane.
-                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-                    if value is 0 then click it
-                    delay 3
-                end tell
-
-                -- Confirmation-sheet handling (see stable-Safari script comment).
-                try
-                    if exists sheet 1 of window 1 then
-                        set sheetHandled to false
-                        repeat with btnName in {"Enable", "Allow", "Turn On", "OK"}
-                            try
-                                click button (btnName as string) of sheet 1 of window 1
-                                set sheetHandled to true
-                                exit repeat
-                            end try
-                        end repeat
-                        if not sheetHandled then
-                            set btnNames to name of every button of sheet 1 of window 1
-                            do shell script "echo \"confirmation sheet buttons: " & (btnNames as string) & "\" >> /Users/cltbld/Library/Logs/safari-tp-enable-remote-automation.log"
-                            repeat with b in (buttons of sheet 1 of window 1)
-                                if (name of b) is not "Cancel" then
-                                    click b
-                                    exit repeat
-                                end if
-                            end repeat
-                        end if
-                        delay 5
-                    end if
-                end try
-
-                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-                    if value is not 1 then
-                        error "Allow remote automation did not toggle on (value=" & (value as string) & ") — confirmation sheet may not have been handled"
-                    end if
-                end tell
-            end tell
+        -- Enable Allow remote automation
+        tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
+            if value is 0 then click it
+            delay 5
+            if value is not 1 then
+                error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
+            end if
         end tell
+    end tell
+end tell
 
-        tell application "Safari Technology Preview" to quit
+tell application "Safari Technology Preview" to quit
 
-        do shell script "printf '1' > " & quoted form of semaphoreFile
-        my logLine("attempt " & attempt & " succeeded, semaphore written")
-        return
-
-    on error errMsg number errNum
-        my logLine("attempt " & attempt & " failed (error " & errNum & "): " & errMsg)
-        try
-            tell application "Safari Technology Preview" to quit
-        end try
-        delay 10
-    end try
-end repeat
-
-my logLine("all " & maxAttempts & " attempts failed")
-error "safari TP enable script failed after " & maxAttempts & " attempts — see " & logFile
+-- Write semaphore (version 1 = done)
+-- Only reached if both checkbox verifications above passed; either errors abort the
+-- script before this line, leaving the semaphore as the empty file written at start.
+do shell script "printf '1' > " & quoted form of semaphoreFile

--- a/modules/macos_safaridriver/manifests/init.pp
+++ b/modules/macos_safaridriver/manifests/init.pp
@@ -77,16 +77,12 @@ class macos_safaridriver (
                 require => [File[$applescript], Exec['execute perms script']],
               }
 
-              # Poll for 300s (150 * 2s) — the applescript's Dock-wait +
-              # settle + 3 retry attempts fits inside ~250s worst case.
-              # Puppet timeout at 400s to allow for the launchctl bootstrap
-              # itself + a safety margin over the internal polling loop.
               exec { 'execute enable remote automation script':
-                command => "/bin/bash -c 'if /bin/launchctl print gui/${user_uid}/com.mozilla.safari.enableautomation > /dev/null 2>&1; then /bin/launchctl kickstart -k gui/${user_uid}/com.mozilla.safari.enableautomation; else /bin/launchctl bootstrap gui/${user_uid} ${launchagent_plist}; fi; count=0; while [ \$count -lt 150 ] && ! /bin/bash -c \"test -f ${semaphore_file} && grep -q 1 ${semaphore_file}\"; do sleep 2; count=\$((count+2)); done; grep -q 1 ${semaphore_file}'",
+                command => "/bin/bash -c 'if /bin/launchctl print gui/${user_uid}/com.mozilla.safari.enableautomation > /dev/null 2>&1; then /bin/launchctl kickstart -k gui/${user_uid}/com.mozilla.safari.enableautomation; else /bin/launchctl bootstrap gui/${user_uid} ${launchagent_plist}; fi; count=0; while [ \$count -lt 120 ] && ! /bin/bash -c \"test -f ${semaphore_file} && grep -q 1 ${semaphore_file}\"; do sleep 2; count=\$((count+2)); done; grep -q 1 ${semaphore_file}'",
                 require => [File[$applescript], File[$launchagent_plist], Exec['execute perms script']],
                 cwd     => "/Users/${user_running_safari}",
                 unless  => "/bin/bash -c 'test -f ${semaphore_file} && grep -q 1 ${semaphore_file}'",
-                timeout => 400,
+                timeout => 180,
                 # logoutput => true,
               }
 
@@ -119,12 +115,12 @@ class macos_safaridriver (
               }
 
               exec { 'execute enable remote automation script (Safari TP)':
-                command => "/bin/bash -c 'if /bin/launchctl print gui/${user_uid}/com.mozilla.safari-tp.enableautomation > /dev/null 2>&1; then /bin/launchctl kickstart -k gui/${user_uid}/com.mozilla.safari-tp.enableautomation; else /bin/launchctl bootstrap gui/${user_uid} ${tp_launchagent_plist}; fi; count=0; while [ \$count -lt 150 ] && ! /bin/bash -c \"test -f ${tp_semaphore_file} && grep -q 1 ${tp_semaphore_file}\"; do sleep 2; count=\$((count+2)); done; grep -q 1 ${tp_semaphore_file}'",
+                command => "/bin/bash -c 'if /bin/launchctl print gui/${user_uid}/com.mozilla.safari-tp.enableautomation > /dev/null 2>&1; then /bin/launchctl kickstart -k gui/${user_uid}/com.mozilla.safari-tp.enableautomation; else /bin/launchctl bootstrap gui/${user_uid} ${tp_launchagent_plist}; fi; count=0; while [ \$count -lt 120 ] && ! /bin/bash -c \"test -f ${tp_semaphore_file} && grep -q 1 ${tp_semaphore_file}\"; do sleep 2; count=\$((count+2)); done; grep -q 1 ${tp_semaphore_file}'",
                 require => [File[$tp_applescript], File[$tp_launchagent_plist], Exec['execute perms script']],
                 cwd     => "/Users/${user_running_safari}",
                 onlyif  => '/bin/test -d "/Applications/Safari Technology Preview.app"',
                 unless  => "/bin/bash -c 'test -f ${tp_semaphore_file} && grep -q 1 ${tp_semaphore_file}'",
-                timeout => 400,
+                timeout => 180,
               }
             } else {
               # macOS 10.15-13: typically deployed with SIP disabled; run directly


### PR DESCRIPTION
## What broke
Fresh-EACS M4 workers hang in bootstrap: the `macos_safaridriver` enable-remote-automation puppet Exec loops every 60s because its applescript fails with:
```
error -1728: System Events got an error: Can't get checkbox "Allow remote automation"
             of group 1 of group 1 of window 1 of process Safari
```
→ semaphore never written → worker never installs → never registers. Observed live on `macmini-m4-115`.

## Cause: #1262
#1262 (merged to master today 12:55) bundled a Safari-enable rewrite that replaced the working two-step flow (enable "Show features for web developers" → click **Developer** tab → toggle "Allow remote automation") with a one-step direct toggle in the Advanced pane, assuming Safari 18/macOS 15 moved it there. On the fleet's actual build (**macOS 15.3 / Safari 18.3**) the checkbox isn't at that path → `-1728`. Yesterday's master had the working two-step.

## Fix
Revert ONLY the `macos_safaridriver` module (both applescripts + `init.pp`) to pre-#1262. #1262's BST auto-escrow + mTLS vault-fetch changes are left intact.

## Validation
Pin `macmini-m4-115` (stuck in the `-1728` loop) at this branch via `ronin_settings` `PUPPET_BRANCH`; its running loop pulls the reverted applescript next cycle and should complete + register — no re-wipe. Merge once 115 registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)