### PR TITLE
macos_safaridriver: retry + observability on the proven two-step Safari enable

### DIFF
--- a/modules/macos_safaridriver/files/safari-enable-remote-automation.applescript
+++ b/modules/macos_safaridriver/files/safari-enable-remote-automation.applescript
@@ -1,71 +1,137 @@
 -- safari-enable-remote-automation.applescript
 -- Used on macOS 14+ (Darwin 23+) where SIP is enabled.
 -- Runs via LaunchAgent as cltbld so osascript has full GUI session context.
--- Handles its own semaphore so it is idempotent.
+-- Idempotent + retry-hardened.
+--
+-- Semaphore contract:
+--   * File contains "1" ONLY on successful completion.
+--   * File does NOT exist between runs — no empty-file leftovers to confuse the
+--     downstream checks (puppet exec `unless`, the driver check_done, the exec's
+--     polling loop). If this script fails, the file is not written at all, and the
+--     next invocation starts fresh.
+--
+-- UI navigation is the PROVEN macOS 14/15 two-step: Advanced pane ->
+-- "Show features for web developers" -> Developer tab -> "Allow remote automation".
+-- Do NOT "simplify" this to a one-step direct toggle in the Advanced pane: the
+-- "Allow remote automation" checkbox is NOT in the Advanced pane on macOS 15.3 /
+-- Safari 18.3 (System Events -1728 "can't get checkbox"). That regression was
+-- ronin #1262, reverted in #1279. This change only adds the retry/log/semaphore
+-- framework around the same proven UI steps.
 
 set semaphoreFile to "/Users/cltbld/Library/Preferences/semaphore/safari-enable-remote-automation-has-run"
 set semaphoreVersion to "1"
+set logFile to "/Users/cltbld/Library/Logs/safari-enable-remote-automation.log"
 
--- Check semaphore
+-- Ensure log + semaphore dirs exist so error tracing works even on first run.
+do shell script "mkdir -p /Users/cltbld/Library/Logs /Users/cltbld/Library/Preferences/semaphore"
+
+on logLine(msg)
+    global logFile
+    do shell script "echo \"[$(date '+%Y-%m-%dT%H:%M:%S')] " & msg & "\" >> " & quoted form of logFile
+end logLine
+
+-- Skip if already succeeded (semaphore contains "1").
 try
     set semaphoreContent to do shell script "cat " & quoted form of semaphoreFile
     if semaphoreContent is semaphoreVersion then
+        my logLine("semaphore already at version 1 — nothing to do")
         return
     end if
 on error
-    -- file doesn't exist, proceed
+    -- file doesn't exist yet, proceed
 end try
 
--- Create semaphore dir and empty file (signals script is running)
-do shell script "mkdir -p /Users/cltbld/Library/Preferences/semaphore && touch " & quoted form of semaphoreFile
-
--- Activate Safari
-tell application "Safari"
-    activate
-end tell
-delay 15
-
-tell application "System Events"
-    tell process "Safari"
-        set frontmost to true
+-- Wait for the GUI session to be ready before driving Safari. Dock running is the
+-- standard proxy for "session initialized enough to accept UI automation" — the
+-- LaunchAgent can fire before this on a fresh cltbld autologin.
+my logLine("waiting for Dock to be running (GUI session readiness)")
+set dockReady to false
+repeat 12 times
+    try
+        do shell script "pgrep -x Dock >/dev/null"
+        set dockReady to true
+        exit repeat
+    on error
         delay 5
+    end try
+end repeat
+if not dockReady then
+    my logLine("Dock never came up — bailing")
+    error "GUI session did not initialize (Dock process absent after 60s)"
+end if
+my logLine("Dock is up")
 
-        -- Open Settings (ellipsis is U+2026)
-        click menu item "Settings…" of menu "Safari" of menu bar 1
-        delay 5
+-- Extra settle time even after Dock — Safari's first launch can race the menu-bar
+-- accessibility tree if we jump straight in.
+delay 5
 
-        -- Go to Advanced tab
-        click button "Advanced" of toolbar 1 of window 1
-        delay 5
-
-        -- Enable Show features for web developers
-        tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-            if value is not 1 then
-                error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
-            end if
+-- Retry the whole UI automation up to 3 times. Each attempt is idempotent (each
+-- toggle checks state before clicking), so a partial success doesn't corrupt
+-- anything on the next attempt.
+set maxAttempts to 3
+set attempt to 0
+repeat maxAttempts times
+    set attempt to attempt + 1
+    my logLine("attempt " & attempt & " of " & maxAttempts)
+    try
+        -- Activate Safari (also launches it if not running).
+        tell application "Safari"
+            activate
         end tell
-        delay 5
+        delay 15
 
-        -- Open Developer tab
-        click button "Developer" of toolbar 1 of window 1
-        delay 5
+        tell application "System Events"
+            tell process "Safari"
+                set frontmost to true
+                delay 5
 
-        -- Enable Allow remote automation
-        tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-            if value is not 1 then
-                error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
-            end if
+                -- Open Settings (ellipsis is U+2026)
+                click menu item "Settings…" of menu "Safari" of menu bar 1
+                delay 5
+
+                -- Go to Advanced tab
+                click button "Advanced" of toolbar 1 of window 1
+                delay 5
+
+                -- Enable "Show features for web developers"
+                tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
+                    if value is 0 then click it
+                    delay 5
+                    if value is not 1 then
+                        error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
+                    end if
+                end tell
+                delay 5
+
+                -- Open Developer tab
+                click button "Developer" of toolbar 1 of window 1
+                delay 5
+
+                -- Enable "Allow remote automation"
+                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
+                    if value is 0 then click it
+                    delay 5
+                    if value is not 1 then
+                        error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
+                    end if
+                end tell
+            end tell
         end tell
-    end tell
-end tell
 
-tell application "Safari" to quit
+        tell application "Safari" to quit
 
--- Write semaphore (version 1 = done)
--- Only reached if both checkbox verifications above passed; either errors abort the
--- script before this line, leaving the semaphore as the empty file written at start.
-do shell script "printf '1' > " & quoted form of semaphoreFile
+        -- Success — write the semaphore and stop.
+        my logLine("remote automation enabled — writing semaphore")
+        do shell script "printf '1' > " & quoted form of semaphoreFile
+        return
+    on error errMsg number errNum
+        my logLine("attempt " & attempt & " failed (error " & errNum & "): " & errMsg)
+        try
+            tell application "Safari" to quit
+        end try
+        delay 10
+    end try
+end repeat
+
+my logLine("all " & maxAttempts & " attempts failed")
+error "safari enable script failed after " & maxAttempts & " attempts — see " & logFile

--- a/modules/macos_safaridriver/files/safari-tp-enable-remote-automation.applescript
+++ b/modules/macos_safaridriver/files/safari-tp-enable-remote-automation.applescript
@@ -1,76 +1,127 @@
 -- safari-tp-enable-remote-automation.applescript
 -- Used on macOS 14+ (Darwin 23+) where SIP is enabled.
 -- Runs via LaunchAgent as cltbld so osascript has full GUI session context.
--- Handles its own semaphore so it is idempotent.
+-- Idempotent + retry-hardened.
 --
 -- Mirror of safari-enable-remote-automation.applescript, but addressing the
--- "Safari Technology Preview" app instead of stable Safari. Safari TP has
--- its own separate "Allow Remote Automation" toggle that the stable Safari
--- enable does not flip.
+-- "Safari Technology Preview" app instead of stable Safari. Safari TP has its own
+-- separate "Allow Remote Automation" toggle that the stable Safari enable does not flip.
+--
+-- Semaphore contract:
+--   * File contains "1" ONLY on successful completion (no empty-file leftovers).
+--
+-- UI navigation is the PROVEN macOS 14/15 two-step (Advanced -> "Show features for
+-- web developers" -> Developer tab -> "Allow remote automation"). Do NOT collapse it
+-- to a one-step Advanced-pane toggle — that regressed on Safari 18.3 (ronin #1262,
+-- reverted in #1279). This change only adds the retry/log/semaphore framework.
 
 set semaphoreFile to "/Users/cltbld/Library/Preferences/semaphore/safari-tech-preview-enable-remote-automation-has-run"
 set semaphoreVersion to "1"
+set logFile to "/Users/cltbld/Library/Logs/safari-tp-enable-remote-automation.log"
 
--- Check semaphore
+-- Ensure log + semaphore dirs exist so error tracing works even on first run.
+do shell script "mkdir -p /Users/cltbld/Library/Logs /Users/cltbld/Library/Preferences/semaphore"
+
+on logLine(msg)
+    global logFile
+    do shell script "echo \"[$(date '+%Y-%m-%dT%H:%M:%S')] " & msg & "\" >> " & quoted form of logFile
+end logLine
+
+-- Skip if already succeeded (semaphore contains "1").
 try
     set semaphoreContent to do shell script "cat " & quoted form of semaphoreFile
     if semaphoreContent is semaphoreVersion then
+        my logLine("semaphore already at version 1 — nothing to do")
         return
     end if
 on error
-    -- file doesn't exist, proceed
+    -- file doesn't exist yet, proceed
 end try
 
--- Create semaphore dir and empty file (signals script is running)
-do shell script "mkdir -p /Users/cltbld/Library/Preferences/semaphore && touch " & quoted form of semaphoreFile
-
--- Activate Safari Technology Preview
-tell application "Safari Technology Preview"
-    activate
-end tell
-delay 15
-
-tell application "System Events"
-    tell process "Safari Technology Preview"
-        set frontmost to true
+-- Wait for the GUI session to be ready before driving Safari TP. Dock running is the
+-- standard proxy for "session initialized enough to accept UI automation".
+my logLine("waiting for Dock to be running (GUI session readiness)")
+set dockReady to false
+repeat 12 times
+    try
+        do shell script "pgrep -x Dock >/dev/null"
+        set dockReady to true
+        exit repeat
+    on error
         delay 5
+    end try
+end repeat
+if not dockReady then
+    my logLine("Dock never came up — bailing")
+    error "GUI session did not initialize (Dock process absent after 60s)"
+end if
+my logLine("Dock is up")
 
-        -- Open Settings (ellipsis is U+2026)
-        click menu item "Settings…" of menu "Safari Technology Preview" of menu bar 1
-        delay 5
+delay 5
 
-        -- Go to Advanced tab
-        click button "Advanced" of toolbar 1 of window 1
-        delay 5
-
-        -- Enable Show features for web developers
-        tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-            if value is not 1 then
-                error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
-            end if
+-- Retry the whole UI automation up to 3 times; each attempt is idempotent.
+set maxAttempts to 3
+set attempt to 0
+repeat maxAttempts times
+    set attempt to attempt + 1
+    my logLine("attempt " & attempt & " of " & maxAttempts)
+    try
+        tell application "Safari Technology Preview"
+            activate
         end tell
-        delay 5
+        delay 15
 
-        -- Open Developer tab
-        click button "Developer" of toolbar 1 of window 1
-        delay 5
+        tell application "System Events"
+            tell process "Safari Technology Preview"
+                set frontmost to true
+                delay 5
 
-        -- Enable Allow remote automation
-        tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
-            if value is 0 then click it
-            delay 5
-            if value is not 1 then
-                error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
-            end if
+                -- Open Settings (ellipsis is U+2026)
+                click menu item "Settings…" of menu "Safari Technology Preview" of menu bar 1
+                delay 5
+
+                -- Go to Advanced tab
+                click button "Advanced" of toolbar 1 of window 1
+                delay 5
+
+                -- Enable "Show features for web developers"
+                tell checkbox "Show features for web developers" of group 1 of group 1 of window 1
+                    if value is 0 then click it
+                    delay 5
+                    if value is not 1 then
+                        error "Show features for web developers did not toggle on (value=" & (value as string) & ")"
+                    end if
+                end tell
+                delay 5
+
+                -- Open Developer tab
+                click button "Developer" of toolbar 1 of window 1
+                delay 5
+
+                -- Enable "Allow remote automation"
+                tell checkbox "Allow remote automation" of group 1 of group 1 of window 1
+                    if value is 0 then click it
+                    delay 5
+                    if value is not 1 then
+                        error "Allow remote automation did not toggle on (value=" & (value as string) & ")"
+                    end if
+                end tell
+            end tell
         end tell
-    end tell
-end tell
 
-tell application "Safari Technology Preview" to quit
+        tell application "Safari Technology Preview" to quit
 
--- Write semaphore (version 1 = done)
--- Only reached if both checkbox verifications above passed; either errors abort the
--- script before this line, leaving the semaphore as the empty file written at start.
-do shell script "printf '1' > " & quoted form of semaphoreFile
+        my logLine("remote automation enabled — writing semaphore")
+        do shell script "printf '1' > " & quoted form of semaphoreFile
+        return
+    on error errMsg number errNum
+        my logLine("attempt " & attempt & " failed (error " & errNum & "): " & errMsg)
+        try
+            tell application "Safari Technology Preview" to quit
+        end try
+        delay 10
+    end try
+end repeat
+
+my logLine("all " & maxAttempts & " attempts failed")
+error "safari TP enable script failed after " & maxAttempts & " attempts — see " & logFile


### PR DESCRIPTION
## What
Re-applies #1262's retry/observability framework **on top of the proven two-step Safari-enable UI path** (both Safari + Safari-TP applescripts). #1279 reverted #1262 wholesale to restore the working UI navigation, which also dropped these genuinely-useful bits.

- **Retry** the whole UI automation up to 3× (each toggle is state-checked → idempotent) — tolerates a transient `System Events` race on a fresh cltbld autologin instead of failing on the first miss.
- **Wait for the Dock** (GUI-session readiness) before driving Safari.
- **Timestamped logging** to `~/Library/Logs/safari-*-enable-remote-automation.log`.
- **Semaphore written only on success** — no empty "script running" file left behind to poison the downstream puppet/driver checks.

## What is NOT changed
The UI navigation — Advanced → "Show features for web developers" → **Developer tab** → "Allow remote automation" — is **byte-for-byte the proven macOS 15.3 / Safari 18.3 path**. A prominent comment warns against re-collapsing it to the one-step Advanced-pane form that regressed in #1262 (`-1728`). This PR is purely an additive wrapper.

## Validation plan (before merge)
The current reverted script works, so this is a reliability enhancement — but Safari applescripts are finicky, so validate before merge:
1. Pin a staging host to this branch (`ronin_settings` `PUPPET_BRANCH` + `run-puppet.sh`).
2. `rm` its `safari-enable-remote-automation-has-run` semaphore and trigger the LaunchAgent (non-destructive — no wipe needed).
3. Confirm it enables remote automation, writes the semaphore, and logs cleanly.
4. Merge, then un-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)