### PR TITLE
profiles::tart: manage admin autologin (kcpassword) for reboot-resilience

### DIFF
--- a/data/roles/tart_worker.yaml
+++ b/data/roles/tart_worker.yaml
@@ -32,3 +32,9 @@ tart:
   user: 'admin'
   manage_image: false
   launchd_type: 'daemon'
+  # base64 of the admin user's /etc/kcpassword — enables puppet-managed autologin
+  # so the host reliably comes back with an admin GUI session on reboot (required
+  # for Apple Virtualization Framework / `tart run`; see profiles::tart). Leave
+  # blank here and set the real value via vault / a secure override — do NOT
+  # commit the credential. Blank = autologin unmanaged.
+  autologin_kcpassword: ''

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -40,6 +40,26 @@ class roles_profiles::profiles::tart {
   $manage_image   = lookup('tart.manage_image',   Boolean, 'first', true)
   $launchd_type   = lookup('tart.launchd_type',   Enum['agent', 'daemon'], 'first', 'agent')
 
+  # Autologin the VM-host user. Apple's Virtualization Framework needs an active
+  # GUI (Aqua) session for `tart run` to start a VM, and on a headless host that
+  # session only exists via autologin at boot. Without a puppet-managed
+  # /etc/kcpassword, a host can reboot to the login window with no session: the
+  # launchd daemons load fine but every VM fails to start with "Internal
+  # Virtualization error" (hit on macmini-m4-187, 2026-07-16 — its kcpassword
+  # was missing while sibling hosts happened to have it). Managing it here makes
+  # reboot-resilience guaranteed instead of dependent on original provisioning.
+  #
+  # tart.autologin_kcpassword = base64 of the admin user's /etc/kcpassword.
+  # Populate it in vault/hiera; left empty it is a no-op (autologin unmanaged,
+  # falls back to whatever the host was provisioned with).
+  $autologin_kcpassword = lookup('tart.autologin_kcpassword', String, 'first', '')
+  if $autologin_kcpassword != '' {
+    class { 'macos_utils::autologin_user':
+      user       => $user,
+      kcpassword => $autologin_kcpassword,
+    }
+  }
+
   $install_dir   = '/Applications'
   $bin_path      = '/usr/local/bin/tart'
   $tart_url      = "https://github.com/cirruslabs/tart/releases/download/${version}/tart.tar.gz"


### PR DESCRIPTION
## Why
The `tart_worker` daemon persistence silently depends on **autologin**: Apple's Virtualization Framework needs an active admin GUI session for `tart run` to start a VM, and on a headless host that session only comes from autologin at boot. `profiles::tart` never managed autologin, so each host relied on whatever its *original* provisioning left behind.

That bit us on **macmini-m4-187** (2026-07-16): `/etc/kcpassword` was missing, so after its first reboot in ~250 days it sat at the login window with no admin session — the launchd daemons loaded fine but **every VM failed with `VZErrorDomain … Internal Virtualization error`** (even a pristine clone). Sibling hosts (185/186/188–191) happened to have `/etc/kcpassword` and recovered. So reboot-resilience was luck, not enforcement.

## What
Declare the existing **`macos_utils::autologin_user`** class from `profiles::tart` (it manages both `autoLoginUser` and `/etc/kcpassword`, `show_diff=false`), gated on a non-empty `tart.autologin_kcpassword` lookup:

```puppet
$autologin_kcpassword = lookup('tart.autologin_kcpassword', String, 'first', '')
if $autologin_kcpassword != '' {
  class { 'macos_utils::autologin_user':
    user       => $user,          # admin
    kcpassword => $autologin_kcpassword,
  }
}
```

`data/roles/tart_worker.yaml` gets the documented **empty** key.

## Operator step to activate
Set `tart.autologin_kcpassword` (base64 of the admin user's `/etc/kcpassword`) via vault / a secure override — **not** committed here. Until set, this is a **no-op** (autologin stays whatever the host has), so merging is safe.

## Effect
Reboot-resilience for the `gecko-t-osx-1500-m-vms` tart hosts becomes puppet-enforced and can't silently drift — directly hardening the daemon-based VM persistence (the ongoing fork→master + agent→daemon consolidation). No behavior change on hosts until the value is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)