### PR TITLE
oci_registry_host: make the Tart image registry reboot-resilient + self-maintaining

### DIFF
--- a/data/roles/oci_registry_host.yaml
+++ b/data/roles/oci_registry_host.yaml
@@ -1,0 +1,43 @@
+---
+# Role data for oci_registry_host: the self-hosted OCI registry (registry:2 in
+# a Colima/Docker VM) that serves Tart VM images to the gecko-t-osx-1500-m-vms
+# tester fleet. See roles_profiles::roles::oci_registry_host.
+#
+# Homebrew is expected to be preinstalled (Apple-Silicon /opt/homebrew,
+# admin-owned); the role only ensures the docker/lima/colima formulae.
+
+docker:
+  user: admin
+  package_name: docker
+  cpu: 8
+  memory: 8
+  disk_size: 200
+  # How often the colima LaunchDaemon re-checks/heals colima (seconds).
+  colima_ensure_interval: 300
+  registry_port: 5000
+  registry_network: bridge
+
+oci_registry:
+  enable_delete: true
+  # Host bind-mount that backs /var/lib/registry inside the container. This is
+  # the live storage path; do not change without migrating the data.
+  registry_dir: /Users/admin/registry-data
+  registry_name: tart-registry
+  # Daily maintenance retention: keep the newest N prod-<sha> images, prune
+  # transient PR build tags (pr-<n>-<sha>); "*-latest" moving tags are always
+  # kept. maintenance_hour is the local hour (0-23) the GC job runs.
+  keep_prod_shas: 10
+  prune_pr_shas: true
+  maintenance_hour: 9
+  # Health check: alert when the storage volume is at/above this percent full,
+  # or /v2/ is unreachable. health_interval is the poll cadence (seconds).
+  disk_threshold_pct: 85
+  health_interval: 300
+  alert_email: releng-ci-alerts@mozilla.com
+  smtp_relay: smtp1.mail.mdc1.mozilla.com
+
+# Optional autologin safety net for Colima (headless, normally NOT needed).
+# Leave blank; populate via a secure override only if a host proves to need a
+# live console session for the VZ backend. Blank = autologin unmanaged.
+colima:
+  autologin_kcpassword: ''

--- a/modules/roles_profiles/manifests/profiles/colima_docker.pp
+++ b/modules/roles_profiles/manifests/profiles/colima_docker.pp
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Ensures the docker/lima/colima Homebrew formulae are present and, critically,
+# makes Colima reboot-persistent.
+#
+# Homebrew itself is NOT installed here (the host is bootstrapped once with brew
+# preinstalled at the Apple-Silicon path /opt/homebrew, admin-owned). We assert
+# it is present and fail with a clear message otherwise.
+#
+# Reboot persistence: the original design started Colima with a one-shot
+# `exec { unless colima status | grep running }`, which only fires during a
+# puppet apply. On a registry host with no puppet cron that means a reboot
+# leaves Colima (and therefore the whole OCI registry the tester fleet depends
+# on) DOWN until a human runs `colima start`. Instead we install a system
+# LaunchDaemon that runs an idempotent ensure-script at boot (RunAtLoad) and on
+# an interval (self-heal). Combined with the registry container's
+# `--restart=always`, the registry comes back on its own after any reboot.
+#
+# Colima runs headless Linux VMs (no graphical framebuffer), so unlike Tart it
+# does not require an Aqua GUI session — the system LaunchDaemon starts it as
+# `admin` without a login. `colima.autologin_kcpassword` is offered as an
+# optional safety net (empty = unmanaged); populate it via vault/hiera only if a
+# host turns out to need a live console session.
+class roles_profiles::profiles::colima_docker {
+  $user            = lookup('docker.user',                  String,  'first', 'admin')
+  $package_name    = lookup('docker.package_name',          String,  'first', 'docker')
+  $cpu             = lookup('docker.cpu',                    Integer, 'first', 8)
+  $memory          = lookup('docker.memory',                Integer, 'first', 8)
+  $disk_size       = lookup('docker.disk_size',             Integer, 'first', 200)
+  $ensure_interval = lookup('docker.colima_ensure_interval', Integer, 'first', 300)
+
+  $brew_path = '/opt/homebrew/bin/brew'
+  $home      = "/Users/${user}"
+
+  # Homebrew must be preinstalled. Fail loudly (once, at compile-of-exec time)
+  # rather than silently proceeding to a broken `brew install`.
+  exec { 'assert_homebrew_present':
+    command => "/bin/echo 'Homebrew missing at ${brew_path}; bootstrap this host with brew before applying oci_registry_host' >&2 && exit 1",
+    unless  => "/bin/test -x ${brew_path}",
+    path    => ['/usr/bin', '/bin'],
+  }
+
+  # Ensure docker + lima + colima formulae (idempotent; no-op once present).
+  exec { 'install_docker_colima':
+    command   => "/usr/bin/su - ${user} -c '${brew_path} install ${package_name} lima colima || true'",
+    unless    => "/usr/bin/su - ${user} -c '${brew_path} list --formula | grep -E \"(${package_name}|lima|colima)\"'",
+    path      => ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin'],
+    timeout   => 0,
+    logoutput => true,
+    require   => Exec['assert_homebrew_present'],
+  }
+
+  exec { 'verify_docker_colima':
+    command => "/opt/homebrew/bin/docker --version && /usr/bin/su - ${user} -c '/opt/homebrew/bin/colima version'",
+    unless  => "/opt/homebrew/bin/docker --version >/dev/null 2>&1 && /usr/bin/su - ${user} -c '/opt/homebrew/bin/colima version >/dev/null 2>&1'",
+    path    => ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin'],
+    require => Exec['install_docker_colima'],
+  }
+
+  # Idempotent ensure-script: starts Colima only if it is not already running,
+  # reusing the persisted profile so it never resizes an existing VM.
+  file { '/usr/local/bin/colima-ensure.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0755',
+    content => epp('roles_profiles/oci_registry/colima-ensure.sh.epp', {
+      user      => $user,
+      cpu       => $cpu,
+      memory    => $memory,
+      disk_size => $disk_size,
+    }),
+    require => Exec['verify_docker_colima'],
+  }
+
+  # System LaunchDaemon: starts Colima at boot (RunAtLoad) and self-heals on an
+  # interval. Loads headlessly, no console session required.
+  file { '/Library/LaunchDaemons/com.mozilla.colima.plist':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0644',
+    content => epp('roles_profiles/oci_registry/com.mozilla.colima.plist.epp', {
+      user            => $user,
+      ensure_interval => $ensure_interval,
+    }),
+    require => File['/usr/local/bin/colima-ensure.sh'],
+    notify  => Exec['load_colima_daemon'],
+  }
+
+  exec { 'load_colima_daemon':
+    command     => '/bin/bash -c \'launchctl bootout system /Library/LaunchDaemons/com.mozilla.colima.plist 2>/dev/null || true; launchctl bootstrap system /Library/LaunchDaemons/com.mozilla.colima.plist\'',
+    path        => ['/bin', '/usr/bin'],
+    refreshonly => true,
+    require     => File['/Library/LaunchDaemons/com.mozilla.colima.plist'],
+  }
+
+  # Optional autologin safety net (default off). Colima is headless so this is
+  # normally unnecessary; populate colima.autologin_kcpassword only if needed.
+  $autologin_kcpassword = lookup('colima.autologin_kcpassword', String, 'first', '')
+  if $autologin_kcpassword != '' {
+    class { 'macos_utils::autologin_user':
+      user       => $user,
+      kcpassword => $autologin_kcpassword,
+    }
+  }
+}

--- a/modules/roles_profiles/manifests/profiles/oci_registry.pp
+++ b/modules/roles_profiles/manifests/profiles/oci_registry.pp
@@ -1,0 +1,148 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Runs the local, insecure Docker-based OCI registry that serves Tart VM images
+# to the tester fleet, and keeps it healthy over time.
+#
+# Resilience features added on top of the basic container:
+#   * The container runs with --restart=always, and Colima itself is made
+#     boot-persistent by roles_profiles::profiles::colima_docker, so the
+#     registry returns on its own after a reboot.
+#   * A daily maintenance LaunchDaemon prunes disposable tags and runs
+#     `registry garbage-collect` so storage does not grow without bound
+#     (registry:2 never reclaims deleted blobs on its own).
+#   * A periodic health-check LaunchDaemon verifies /v2/ is reachable and that
+#     the storage volume has headroom, writes a status file for dashboards to
+#     scrape, and emails on trouble.
+#
+# Idempotency note: a *running* container of the expected name is left
+# untouched (no needless bounce on every apply). Only a missing or stale
+# (exited) container is (re)created. Storage lives in a host bind-mount, so
+# recreating the container never loses image data.
+class roles_profiles::profiles::oci_registry {
+  $registry_port     = lookup('docker.registry_port',           Integer, 'first', 5000)
+  $registry_network  = lookup('docker.registry_network',        String,  'first', 'bridge')
+  $enable_delete     = lookup('oci_registry.enable_delete',     Boolean, 'first', true)
+  $registry_dir      = lookup('oci_registry.registry_dir',      String,  'first', '/Users/admin/registry-data')
+  $registry_name     = lookup('oci_registry.registry_name',     String,  'first', 'tart-registry')
+  $user              = lookup('docker.user',                    String,  'first', 'admin')
+  $keep_prod_shas    = lookup('oci_registry.keep_prod_shas',    Integer, 'first', 10)
+  $prune_pr_shas     = lookup('oci_registry.prune_pr_shas',     Boolean, 'first', true)
+  $maintenance_hour  = lookup('oci_registry.maintenance_hour',  Integer, 'first', 9)
+  $disk_threshold    = lookup('oci_registry.disk_threshold_pct', Integer, 'first', 85)
+  $health_interval   = lookup('oci_registry.health_interval',   Integer, 'first', 300)
+  $alert_email       = lookup('oci_registry.alert_email',       String,  'first', 'releng-ci-alerts@mozilla.com')
+  $smtp_relay        = lookup('oci_registry.smtp_relay',        String,  'first', 'smtp1.mail.mdc1.mozilla.com')
+
+  $su          = "/usr/bin/su - ${user} -c"
+  $docker      = '/opt/homebrew/bin/docker'
+  $ps_name     = "${docker} ps --filter name=${registry_name} --format {{.Names}}"
+  $ps_all_name = "${docker} ps -a --filter name=${registry_name} --format {{.Names}}"
+
+  # Storage dir (host bind-mount). Managed as present only; ownership/mode left
+  # alone so we never chown the large live data directory.
+  file { $registry_dir:
+    ensure => directory,
+  }
+
+  # Remove only a STALE (exists but not running) container before (re)creating.
+  # A healthy running container is left as-is by the `unless` on the run exec.
+  exec { 'remove_stale_registry_container':
+    command   => "${su} 'PATH=/opt/homebrew/bin:\$PATH ${docker} rm -f ${registry_name}'",
+    onlyif    => "${su} '${ps_all_name}' | grep -q ${registry_name}",
+    unless    => "${su} '${ps_name}' | grep -q ${registry_name}",
+    path      => ['/opt/homebrew/bin', '/usr/bin', '/bin'],
+    logoutput => on_failure,
+    require   => [Class['roles_profiles::profiles::colima_docker'], File[$registry_dir]],
+  }
+
+  $docker_run_cmd = "${su} 'PATH=/opt/homebrew/bin:\$PATH ${docker} run -d --network ${registry_network} -p ${registry_port}:${registry_port} --restart=always --name ${registry_name} -v ${registry_dir}:/var/lib/registry -e REGISTRY_HTTP_ADDR=0.0.0.0:${registry_port} -e REGISTRY_STORAGE_DELETE_ENABLED=${enable_delete} registry:2'" # lint:ignore:140chars
+
+  exec { 'run_registry_container':
+    command   => $docker_run_cmd,
+    unless    => "${su} '${ps_name}' | grep -q ${registry_name}",
+    path      => ['/opt/homebrew/bin', '/usr/bin', '/bin'],
+    logoutput => on_failure,
+    require   => Exec['remove_stale_registry_container'],
+  }
+
+  exec { 'verify_registry':
+    command   => "/usr/bin/curl -fsSL http://localhost:${registry_port}/v2/ || (echo 'Registry not reachable' && exit 1)",
+    path      => ['/usr/bin', '/bin'],
+    tries     => 3,
+    try_sleep => 5,
+    logoutput => on_failure,
+    require   => Exec['run_registry_container'],
+  }
+
+  # --- Daily maintenance: tag retention + garbage collection ----------------
+  file { '/usr/local/bin/registry-maintenance.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0755',
+    content => epp('roles_profiles/oci_registry/registry-maintenance.sh.epp', {
+      user           => $user,
+      registry_name  => $registry_name,
+      registry_port  => $registry_port,
+      keep_prod_shas => $keep_prod_shas,
+      prune_pr_shas  => $prune_pr_shas,
+    }),
+    require => Exec['verify_registry'],
+  }
+
+  file { '/Library/LaunchDaemons/com.mozilla.registry-maintenance.plist':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0644',
+    content => epp('roles_profiles/oci_registry/com.mozilla.registry-maintenance.plist.epp', {
+      hour => $maintenance_hour,
+    }),
+    require => File['/usr/local/bin/registry-maintenance.sh'],
+    notify  => Exec['load_registry_maintenance_daemon'],
+  }
+
+  exec { 'load_registry_maintenance_daemon':
+    command     => '/bin/bash -c \'launchctl bootout system /Library/LaunchDaemons/com.mozilla.registry-maintenance.plist 2>/dev/null || true; launchctl bootstrap system /Library/LaunchDaemons/com.mozilla.registry-maintenance.plist\'', # lint:ignore:140chars
+    path        => ['/bin', '/usr/bin'],
+    refreshonly => true,
+    require     => File['/Library/LaunchDaemons/com.mozilla.registry-maintenance.plist'],
+  }
+
+  # --- Periodic health + disk monitoring ------------------------------------
+  file { '/usr/local/bin/registry-healthcheck.sh':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0755',
+    content => epp('roles_profiles/oci_registry/registry-healthcheck.sh.epp', {
+      registry_port  => $registry_port,
+      registry_dir   => $registry_dir,
+      disk_threshold => $disk_threshold,
+      alert_email    => $alert_email,
+      smtp_relay     => $smtp_relay,
+    }),
+    require => Exec['verify_registry'],
+  }
+
+  file { '/Library/LaunchDaemons/com.mozilla.registry-healthcheck.plist':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'wheel',
+    mode    => '0644',
+    content => epp('roles_profiles/oci_registry/com.mozilla.registry-healthcheck.plist.epp', {
+      interval => $health_interval,
+    }),
+    require => File['/usr/local/bin/registry-healthcheck.sh'],
+    notify  => Exec['load_registry_healthcheck_daemon'],
+  }
+
+  exec { 'load_registry_healthcheck_daemon':
+    command     => '/bin/bash -c \'launchctl bootout system /Library/LaunchDaemons/com.mozilla.registry-healthcheck.plist 2>/dev/null || true; launchctl bootstrap system /Library/LaunchDaemons/com.mozilla.registry-healthcheck.plist\'', # lint:ignore:140chars
+    path        => ['/bin', '/usr/bin'],
+    refreshonly => true,
+    require     => File['/Library/LaunchDaemons/com.mozilla.registry-healthcheck.plist'],
+  }
+}

--- a/modules/roles_profiles/manifests/roles/oci_registry_host.pp
+++ b/modules/roles_profiles/manifests/roles/oci_registry_host.pp
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Sets up a local, insecure OCI registry for Tart VM images.
+#
+# The registry is a `registry:2` container running under Docker inside a
+# Colima (Lima + Apple Virtualization.framework) VM, published on the host at
+# :5000. The whole Tart tester fleet (gecko-t-osx-1500-m-vms) pulls its images
+# from here, so this host is single-point-of-failure infrastructure. The
+# profiles below add the reboot-resilience, garbage-collection and health
+# monitoring that keep it dependable:
+#
+#   colima_docker  - ensures the docker/lima/colima Homebrew formulae and,
+#                    critically, a system LaunchDaemon that (re)starts Colima
+#                    at boot and heals it if it dies, so the registry survives
+#                    a reboot without a human running `colima start`.
+#   oci_registry   - runs the registry:2 container (--restart=always), plus a
+#                    daily maintenance job (tag retention + garbage-collect to
+#                    stop unbounded disk growth) and a periodic health/disk
+#                    check that alerts on trouble.
+#
+# Homebrew itself is NOT managed here: this host is bootstrapped once with brew
+# preinstalled (Apple-Silicon /opt/homebrew, admin-owned). colima_docker asserts
+# brew is present and fails with a clear message if it is missing, rather than
+# vendoring a full installer.
+class roles_profiles::roles::oci_registry_host {
+  include roles_profiles::profiles::colima_docker
+  include roles_profiles::profiles::oci_registry
+}

--- a/modules/roles_profiles/templates/oci_registry/colima-ensure.sh.epp
+++ b/modules/roles_profiles/templates/oci_registry/colima-ensure.sh.epp
@@ -1,0 +1,37 @@
+<%- | String $user, Integer $cpu, Integer $memory, Integer $disk_size | -%>
+#!/bin/bash
+# Managed by Puppet (roles_profiles::profiles::colima_docker). Do not edit.
+#
+# Idempotent: starts Colima only when it is not already running. Reuses the
+# persisted default profile if it exists, so it never resizes a live VM; only
+# a brand-new host (no profile yet) gets created with the sized flags.
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export HOME="/Users/<%= $user %>"
+
+COLIMA="/opt/homebrew/bin/colima"
+PROFILE_YAML="${HOME}/.colima/default/colima.yaml"
+
+if [ ! -x "${COLIMA}" ]; then
+  echo "$(date -u +%FT%TZ) colima binary missing at ${COLIMA}" >&2
+  exit 1
+fi
+
+if "${COLIMA}" status 2>/dev/null | grep -qi running; then
+  echo "$(date -u +%FT%TZ) colima already running; nothing to do"
+  exit 0
+fi
+
+if [ -f "${PROFILE_YAML}" ]; then
+  echo "$(date -u +%FT%TZ) starting existing colima profile"
+  exec "${COLIMA}" start
+else
+  echo "$(date -u +%FT%TZ) no profile found; creating colima VM (first run)"
+  exec "${COLIMA}" start \
+    --arch aarch64 \
+    --vm-type vz \
+    --cpu <%= $cpu %> \
+    --memory <%= $memory %> \
+    --disk <%= $disk_size %> \
+    --network-address
+fi

--- a/modules/roles_profiles/templates/oci_registry/com.mozilla.colima.plist.epp
+++ b/modules/roles_profiles/templates/oci_registry/com.mozilla.colima.plist.epp
@@ -1,0 +1,31 @@
+<%- | String $user, Integer $ensure_interval | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.colima</string>
+    <key>UserName</key>
+    <string><%= $user %></string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/colima-ensure.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/<%= $user %></string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer><%= $ensure_interval %></integer>
+    <key>StandardOutPath</key>
+    <string>/var/log/colima-ensure.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/colima-ensure.log</string>
+</dict>
+</plist>

--- a/modules/roles_profiles/templates/oci_registry/com.mozilla.registry-healthcheck.plist.epp
+++ b/modules/roles_profiles/templates/oci_registry/com.mozilla.registry-healthcheck.plist.epp
@@ -1,0 +1,22 @@
+<%- | Integer $interval | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.registry-healthcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/registry-healthcheck.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer><%= $interval %></integer>
+    <key>StandardOutPath</key>
+    <string>/var/log/registry-healthcheck.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/registry-healthcheck.log</string>
+</dict>
+</plist>

--- a/modules/roles_profiles/templates/oci_registry/com.mozilla.registry-maintenance.plist.epp
+++ b/modules/roles_profiles/templates/oci_registry/com.mozilla.registry-maintenance.plist.epp
@@ -1,0 +1,25 @@
+<%- | Integer $hour | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.registry-maintenance</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/registry-maintenance.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer><%= $hour %></integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/var/log/registry-maintenance.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/registry-maintenance.log</string>
+</dict>
+</plist>

--- a/modules/roles_profiles/templates/oci_registry/registry-healthcheck.sh.epp
+++ b/modules/roles_profiles/templates/oci_registry/registry-healthcheck.sh.epp
@@ -1,0 +1,81 @@
+<%- | Integer $registry_port, String $registry_dir, Integer $disk_threshold, String $alert_email, String $smtp_relay | -%>
+#!/bin/bash
+# Managed by Puppet (roles_profiles::profiles::oci_registry). Do not edit.
+#
+# Periodic health + disk check for the OCI registry. Writes a JSON status file
+# (/var/log/registry-health.json) for dashboards (Hangar) to scrape, and emails
+# on trouble with a cooldown so a sustained problem does not spam the inbox.
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+PORT=<%= $registry_port %>
+REG_DIR="<%= $registry_dir %>"
+THRESHOLD=<%= $disk_threshold %>
+ALERT_EMAIL="<%= $alert_email %>"
+SMTP_RELAY="<%= $smtp_relay %>"
+STATUS_FILE="/var/log/registry-health.json"
+COOLDOWN_FILE="/var/tmp/registry-health.last-alert"
+COOLDOWN_SECS=21600  # 6h
+
+NOW=$(date -u +%FT%TZ)
+FQDN=$(hostname -f 2>/dev/null || hostname)
+
+# /v2/ reachability
+if curl -fsS --max-time 10 "http://localhost:${PORT}/v2/" >/dev/null 2>&1; then
+  REACHABLE=true
+else
+  REACHABLE=false
+fi
+
+# disk usage of the storage volume (macOS df: Capacity is field 5, e.g. "73%")
+DISK_PCT=$(df -k "${REG_DIR}" 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
+[ -z "${DISK_PCT}" ] && DISK_PCT=-1
+
+PROBLEMS=()
+[ "${REACHABLE}" = "false" ] && PROBLEMS+=("registry /v2/ unreachable on :${PORT}")
+if [ "${DISK_PCT}" -ge "${THRESHOLD}" ] 2>/dev/null; then
+  PROBLEMS+=("storage ${DISK_PCT}% >= ${THRESHOLD}% threshold on ${REG_DIR}")
+fi
+
+if [ "${#PROBLEMS[@]}" -eq 0 ]; then HEALTHY=true; else HEALTHY=false; fi
+
+cat > "${STATUS_FILE}" <<JSON
+{"host":"${FQDN}","checked":"${NOW}","healthy":${HEALTHY},"reachable":${REACHABLE},"disk_pct":${DISK_PCT},"disk_threshold":${THRESHOLD},"problems":$(printf '%s\n' "${PROBLEMS[@]}" | python3 -c 'import json,sys; print(json.dumps([l for l in sys.stdin.read().splitlines() if l]))')}
+JSON
+
+[ "${HEALTHY}" = "true" ] && exit 0
+
+# Cooldown: only email if none sent in the last COOLDOWN_SECS.
+LAST=0
+[ -f "${COOLDOWN_FILE}" ] && LAST=$(cat "${COOLDOWN_FILE}" 2>/dev/null || echo 0)
+EPOCH=$(date +%s)
+if [ $((EPOCH - LAST)) -lt "${COOLDOWN_SECS}" ]; then
+  echo "${NOW} unhealthy but within cooldown; not emailing"
+  exit 0
+fi
+echo "${EPOCH}" > "${COOLDOWN_FILE}"
+
+BODY="OCI registry health check FAILED on ${FQDN} at ${NOW}:\n\n"
+for p in "${PROBLEMS[@]}"; do BODY="${BODY} - ${p}\n"; done
+
+SMTP_RELAY="${SMTP_RELAY}" ALERT_EMAIL="${ALERT_EMAIL}" FQDN="${FQDN}" BODY="${BODY}" python3 <<'PYEOF'
+import os, smtplib, email.utils, datetime
+sender = "ci-worker@mozilla.com"
+recipient = os.environ["ALERT_EMAIL"]
+subject = f"OCI registry unhealthy on {os.environ['FQDN']}"
+body = os.environ["BODY"].replace("\\n", "\n")
+msg = f"""From: {sender}
+To: {recipient}
+Date: {email.utils.formatdate()}
+Subject: {subject}
+
+{body}
+"""
+try:
+    s = smtplib.SMTP(os.environ["SMTP_RELAY"], 25, timeout=30)
+    s.sendmail(sender, recipient, msg)
+    s.quit()
+    print("alert email sent")
+except Exception as e:
+    print(f"WARN could not send alert email: {e}")
+PYEOF

--- a/modules/roles_profiles/templates/oci_registry/registry-maintenance.sh.epp
+++ b/modules/roles_profiles/templates/oci_registry/registry-maintenance.sh.epp
@@ -1,0 +1,117 @@
+<%- | String $user, String $registry_name, Integer $registry_port, Integer $keep_prod_shas, Boolean $prune_pr_shas | -%>
+#!/bin/bash
+# Managed by Puppet (roles_profiles::profiles::oci_registry). Do not edit.
+#
+# Daily registry maintenance: prune disposable tags, then garbage-collect so
+# registry:2 actually reclaims the freed storage (it never does on its own).
+#
+# Retention policy (per repository):
+#   * keep every "*-latest" moving tag (e.g. prod-latest, pr-19-latest)
+#   * <% if $prune_pr_shas { -%>delete transient PR build tags: pr-<n>-<sha><% } else { -%>keep PR build tags<% } -%>
+#
+#   * keep the newest <%= $keep_prod_shas %> prod-<sha> tags (by image created time), delete older
+#
+# GC caveat: garbage-collect runs against the live registry. registry:2 has a
+# documented race where a blob uploaded *during* GC can be collected. We run in
+# a low-traffic window (image promotes are infrequent and operator-driven) to
+# avoid it; if that ever changes, switch the container to read-only for the GC.
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+REG="http://localhost:<%= $registry_port %>"
+REGISTRY_NAME="<%= $registry_name %>"
+KEEP_PROD_SHAS=<%= $keep_prod_shas %>
+PRUNE_PR_SHAS=<%= $prune_pr_shas ? { true => 1, default => 0 } %>
+DOCKER="/opt/homebrew/bin/docker"
+SU_USER="<%= $user %>"
+
+log() { echo "$(date -u +%FT%TZ) $*"; }
+
+log "=== registry maintenance start ==="
+
+# Tag pruning via the registry HTTP API (delete manifests by digest).
+/usr/bin/python3 - "$REG" "$KEEP_PROD_SHAS" "$PRUNE_PR_SHAS" <<'PYEOF'
+import json, sys, re, urllib.request
+
+reg, keep_prod, prune_pr = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "1"
+ACCEPT = ", ".join([
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+])
+
+def req(method, path, headers=None):
+    r = urllib.request.Request(reg + path, method=method)
+    for k, v in (headers or {}).items():
+        r.add_header(k, v)
+    return urllib.request.urlopen(r, timeout=30)
+
+def get_json(path, headers=None):
+    with req("GET", path, headers) as resp:
+        return json.load(resp), dict(resp.headers)
+
+def digest_for(repo, tag):
+    with req("GET", f"/v2/{repo}/manifests/{tag}", {"Accept": ACCEPT}) as resp:
+        return resp.headers.get("Docker-Content-Digest")
+
+def created_for(repo, tag):
+    # Best-effort image created time; return None (=> keep) if unavailable.
+    try:
+        man, _ = get_json(f"/v2/{repo}/manifests/{tag}", {"Accept": ACCEPT})
+        cfg = man.get("config", {}).get("digest")
+        if not cfg:
+            return None
+        blob, _ = get_json(f"/v2/{repo}/blobs/{cfg}")
+        return blob.get("created")
+    except Exception:
+        return None
+
+try:
+    repos = get_json("/v2/_catalog")[0].get("repositories", [])
+except Exception as e:
+    print(f"  ERROR listing catalog: {e}", flush=True)
+    sys.exit(0)
+
+to_delete = []  # (repo, tag)
+for repo in repos:
+    try:
+        tags = get_json(f"/v2/{repo}/tags/list")[0].get("tags") or []
+    except Exception as e:
+        print(f"  {repo}: ERROR listing tags: {e}", flush=True)
+        continue
+    prod_shas = []
+    for t in tags:
+        if t.endswith("-latest"):
+            continue
+        if prune_pr and re.match(r"^pr-.+-[0-9a-f]{7,}$", t):
+            to_delete.append((repo, t)); continue
+        if re.match(r"^prod-[0-9a-f]{7,}$", t):
+            prod_shas.append(t)
+    # Keep the newest KEEP_PROD_SHAS prod-<sha> by created time; delete the rest.
+    if len(prod_shas) > keep_prod:
+        dated = sorted(prod_shas, key=lambda t: (created_for(repo, t) or ""), reverse=True)
+        for t in dated[keep_prod:]:
+            to_delete.append((repo, t))
+
+# Delete unique manifests (dedupe by digest).
+seen = set()
+for repo, tag in to_delete:
+    try:
+        dig = digest_for(repo, tag)
+        if not dig or (repo, dig) in seen:
+            continue
+        seen.add((repo, dig))
+        req("DELETE", f"/v2/{repo}/manifests/{dig}").read()
+        print(f"  deleted {repo}:{tag} ({dig})", flush=True)
+    except Exception as e:
+        print(f"  WARN could not delete {repo}:{tag}: {e}", flush=True)
+
+print(f"  pruned {len(seen)} manifest(s)", flush=True)
+PYEOF
+
+# Reclaim the storage freed by the deleted manifests.
+log "running garbage-collect inside ${REGISTRY_NAME}"
+/usr/bin/su - "${SU_USER}" -c "PATH=/opt/homebrew/bin:\$PATH ${DOCKER} exec ${REGISTRY_NAME} registry garbage-collect /etc/docker/registry/config.yml" || log "WARN garbage-collect returned non-zero"
+
+log "=== registry maintenance done ==="


### PR DESCRIPTION
## Why

The self-hosted OCI registry that serves Tart VM images to the whole `gecko-t-osx-1500-m-vms` tester fleet (`registry:2` in a Colima/Docker VM on **macmini-m4-194**, `10.49.56.161:5000`) is single-point-of-failure infra, and it was carrying three real resilience gaps found while auditing it:

1. **No reboot persistence.** Colima was started by hand (up since 30 Oct 2025) with **no launchd unit**. The old `colima_docker` only did a one-shot `exec { unless colima status | grep running }`, which fires only during a puppet apply — and this host has **no puppet cron**. So a reboot (power blip, OS update, crash) leaves the registry — and the entire tester fleet's image source — **down until a human runs `colima start`**. Same reboot-cliff class we just eliminated on the tart VM hosts.
2. **Unbounded disk growth.** Delete was enabled but `registry garbage-collect` was never run and old tags never pruned: **86 GB used / ~54 GB free**, straight-lining to a disk-full outage.
3. **Needless bounce + drift.** The fork profile `docker rm -f`'d the container on *every* apply, and its hiera had a typo (`rregistry_dir`) pointing at the wrong path.

The role also lived **only on a private fork** (`rcurranmoz@oci_worker_config`), never upstreamed.

## What this does

Upstreams `oci_registry_host` to master and hardens it.

**`colima_docker`**
- Installs a system LaunchDaemon `com.mozilla.colima` that starts Colima at boot (`RunAtLoad`) and self-heals on an interval via an idempotent ensure-script (reuses the persisted profile, so it never resizes a live VM). **Closes the reboot cliff.**
- Does **not** install Homebrew (asserts it's present with a clear bootstrap message); still ensures the docker/lima/colima formulae.
- Optional `colima.autologin_kcpassword` safety net (default off; Colima is headless so, unlike Tart, it should not need an Aqua GUI session).

**`oci_registry`**
- Leaves a healthy running container **untouched**; only (re)creates a *stale* one. Storage is a host bind-mount, so recreate never loses image data.
- Daily maintenance LaunchDaemon: prune disposable `pr-<sha>` tags, keep the newest N `prod-<sha>`, then `registry garbage-collect`.
- Periodic health/disk check: verifies `/v2/` + storage headroom, writes `/var/log/registry-health.json` for dashboards (Hangar), emails on trouble with a 6h cooldown.

**`data/roles/oci_registry_host.yaml`** — values matched to the live host (`registry_dir=/Users/admin/registry-data`, colima 8cpu/8gb/200gb, retention + alert thresholds).

## Validation
- `puppet parser validate` + `puppet epp validate` — OK
- YAML — OK
- All pre-commit hooks incl. **puppet-lint** and the EPP-templated-script syntax check — Passed
- `shellcheck` on all three rendered scripts — clean

## Deploy (follow-up, not in this PR)
Move m4-194 off its fork (`ronin_settings` → `mozilla-platform-ops/master`, same as the tart hosts) → apply (safe: healthy container untouched, first `colima-ensure` is a no-op) → **reboot-test** to prove Colima + registry auto-return headless (enable the autologin knob if it turns out a console session is needed). Reboot briefly drops the registry, but tester hosts are `manage_image: false` so they only pull during operator-driven image updates → low fleet impact.

## Out of scope (deferred follow-ups)
Eliminate the SPOF (off-box backup / warm-standby second registry) and TLS/auth (touches every client's `insecure: true`) — separate tickets, alongside the flaky build runner (m4-116) and the graceful build→promote→rollout pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)