### PR TITLE
colima_docker: fix colima-ensure run-state detection + daemon log path

### DIFF
--- a/modules/roles_profiles/manifests/profiles/colima_docker.pp
+++ b/modules/roles_profiles/manifests/profiles/colima_docker.pp
@@ -75,15 +75,15 @@ class roles_profiles::profiles::colima_docker {
     require => Exec['verify_docker_colima'],
   }
 
-  # System LaunchDaemon: starts Colima at boot (RunAtLoad) and self-heals on an
-  # interval. Loads headlessly, no console session required.
+  # System LaunchDaemon (runs as root, drives colima via `su - ${user}`): starts
+  # Colima at boot (RunAtLoad) and self-heals on an interval. Loads headlessly,
+  # no console session required.
   file { '/Library/LaunchDaemons/com.mozilla.colima.plist':
     ensure  => file,
     owner   => 'root',
     group   => 'wheel',
     mode    => '0644',
     content => epp('roles_profiles/oci_registry/com.mozilla.colima.plist.epp', {
-      user            => $user,
       ensure_interval => $ensure_interval,
     }),
     require => File['/usr/local/bin/colima-ensure.sh'],

--- a/modules/roles_profiles/templates/oci_registry/colima-ensure.sh.epp
+++ b/modules/roles_profiles/templates/oci_registry/colima-ensure.sh.epp
@@ -5,33 +5,34 @@
 # Idempotent: starts Colima only when it is not already running. Reuses the
 # persisted default profile if it exists, so it never resizes a live VM; only
 # a brand-new host (no profile yet) gets created with the sized flags.
+#
+# Runs as root (system LaunchDaemon) and drives colima as the target user via
+# `su -`, so /var/log is writable for logging. `colima status` logs to stderr
+# and exits 0 only when the VM is running, so we key off its exit code, never
+# its text.
 set -uo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-export HOME="/Users/<%= $user %>"
 
+USER_NAME="<%= $user %>"
 COLIMA="/opt/homebrew/bin/colima"
-PROFILE_YAML="${HOME}/.colima/default/colima.yaml"
+PROFILE_YAML="/Users/${USER_NAME}/.colima/default/colima.yaml"
+
+as_user() { /usr/bin/su - "${USER_NAME}" -c "PATH=/opt/homebrew/bin:\$PATH $*"; }
 
 if [ ! -x "${COLIMA}" ]; then
   echo "$(date -u +%FT%TZ) colima binary missing at ${COLIMA}" >&2
   exit 1
 fi
 
-if "${COLIMA}" status 2>/dev/null | grep -qi running; then
+if as_user "${COLIMA} status" >/dev/null 2>&1; then
   echo "$(date -u +%FT%TZ) colima already running; nothing to do"
   exit 0
 fi
 
 if [ -f "${PROFILE_YAML}" ]; then
   echo "$(date -u +%FT%TZ) starting existing colima profile"
-  exec "${COLIMA}" start
+  as_user "${COLIMA} start"
 else
   echo "$(date -u +%FT%TZ) no profile found; creating colima VM (first run)"
-  exec "${COLIMA}" start \
-    --arch aarch64 \
-    --vm-type vz \
-    --cpu <%= $cpu %> \
-    --memory <%= $memory %> \
-    --disk <%= $disk_size %> \
-    --network-address
+  as_user "${COLIMA} start --arch aarch64 --vm-type vz --cpu <%= $cpu %> --memory <%= $memory %> --disk <%= $disk_size %> --network-address"
 fi

--- a/modules/roles_profiles/templates/oci_registry/com.mozilla.colima.plist.epp
+++ b/modules/roles_profiles/templates/oci_registry/com.mozilla.colima.plist.epp
@@ -1,12 +1,10 @@
-<%- | String $user, Integer $ensure_interval | -%>
+<%- | Integer $ensure_interval | -%>
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
     <string>com.mozilla.colima</string>
-    <key>UserName</key>
-    <string><%= $user %></string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
@@ -14,8 +12,6 @@
     </array>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>HOME</key>
-        <string>/Users/<%= $user %></string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>


### PR DESCRIPTION
Follow-up to #1285, found on the first live apply to **macmini-m4-194**: the `com.mozilla.colima` daemon reported `LastExitStatus 78` and wrote no log.

## Two bugs

1. **Run-state detection.** The ensure script checked `colima status 2>/dev/null | grep -qi running`, but `colima status` logs to **stderr** and leaves **stdout empty** (verified live: exit 0, all output on stderr). So the check always failed → the script ran `colima start` on every cycle. Harmless on an already-running VM (`colima start` returns 78, "already running") but wrong, and noisy every `StartInterval`.
   **Fix:** key off `colima status`'s **exit code** (0 == running), which is the reliable signal.

2. **Daemon log path.** The daemon ran as `UserName=admin`, which cannot write `/var/log`, so `StandardOutPath` was silently dropped (no log ever appeared).
   **Fix:** run the daemon as **root** and drive colima via `su - ${user}` — consistent with the `registry-maintenance`/`registry-healthcheck` daemons, and `/var/log` becomes writable.

## Impact
No change to the reboot-recovery path — colima still starts when it's down (both branches lead to `colima start`). This just makes the steady state a true no-op and restores logging, so the upcoming reboot-test has clean signal.

## Validation
`puppet parser validate` + `puppet epp validate` OK; all pre-commit hooks (incl. puppet-lint) Passed; `shellcheck` on the rendered ensure script clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)