### PR TITLE
oci_registry: push authentication (anon pull, auth push) — Bug 2049579 rec #4

### DIFF
--- a/data/roles/oci_registry_host.yaml
+++ b/data/roles/oci_registry_host.yaml
@@ -16,6 +16,15 @@ oci_registry:
   registry_dir: '/Users/admin/registry-data'
   registry_port: 5000
   user: admin
+  # Push authentication (Bug 2049579 rec #4). Leave push_htpasswd EMPTY here —
+  # ronin_puppet is public, so the credential must NOT be committed. Populate it
+  # via a secret override (the bcrypt htpasswd body, e.g. `builder:$2y$05$...`
+  # from `htpasswd -nbB builder '<password>'`); the plaintext password goes only
+  # to the builder's GitHub Actions secret. When set, an nginx proxy requires
+  # auth for pushes and the registry binds internal_port (loopback) behind it.
+  # Empty = no proxy, registry binds registry_port directly (open push).
+  push_htpasswd: ''
+  internal_port: 5001
   # http.secret signs upload state; single-node so not sensitive, but override
   # via a secure source if desired.
   http_secret: 'm4-194-oci-registry-shared-secret'

--- a/modules/roles_profiles/manifests/profiles/oci_registry.pp
+++ b/modules/roles_profiles/manifests/profiles/oci_registry.pp
@@ -35,6 +35,23 @@ class roles_profiles::profiles::oci_registry {
   $alert_email    = lookup('oci_registry.alert_email',    String,  'first', 'releng-ci-alerts@mozilla.com')
   $smtp_relay     = lookup('oci_registry.smtp_relay',     String,  'first', 'smtp1.mail.mdc1.mozilla.com')
 
+  # Push authentication (Bug 2049579 rec #4). When oci_registry.push_htpasswd is
+  # set (a bcrypt htpasswd file body, delivered via a SECRET override — never
+  # committed; ronin_puppet is public), an nginx reverse proxy fronts the
+  # registry and requires basic auth for writes (PUT/POST/PATCH/DELETE) while
+  # leaving pulls (GET/HEAD) anonymous, so only the holder of the push
+  # credential can publish images. The registry then binds loopback only and
+  # nginx owns the public port. Empty (default) = no proxy, registry binds the
+  # public port directly (open push, the pre-hardening behaviour).
+  $push_htpasswd = lookup('oci_registry.push_htpasswd', String,  'first', '')
+  $internal_port = lookup('oci_registry.internal_port', Integer, 'first', 5001)
+  $push_auth     = $push_htpasswd != ''
+  $listen_addr   = $push_auth ? { true => "127.0.0.1:${internal_port}", default => "0.0.0.0:${registry_port}" }
+  # Host-local tooling (maintenance, verify) talks straight to the registry,
+  # bypassing the auth proxy: internal port when the proxy is on, public port
+  # otherwise.
+  $local_port    = $push_auth ? { true => $internal_port, default => $registry_port }
+
   $bin_path    = '/usr/local/bin/registry'
   $config_dir  = '/usr/local/etc/oci-registry'
   $config_path = "${config_dir}/config.yml"
@@ -79,9 +96,9 @@ class roles_profiles::profiles::oci_registry {
     group   => 'wheel',
     mode    => '0644',
     content => epp('roles_profiles/oci_registry/config.yml.epp', {
-      registry_dir  => $registry_dir,
-      registry_port => $registry_port,
-      http_secret   => $http_secret,
+      registry_dir => $registry_dir,
+      listen_addr  => $listen_addr,
+      http_secret  => $http_secret,
     }),
     notify  => Exec['load_oci_registry_daemon'],
   }
@@ -116,13 +133,95 @@ class roles_profiles::profiles::oci_registry {
     require     => File[$daemon],
   }
 
+  # Verify the registry process itself (direct, bypassing any proxy).
   exec { 'verify_oci_registry':
-    command   => "/usr/bin/curl -fsSL http://localhost:${registry_port}/v2/ || (echo 'Registry not reachable' && exit 1)",
+    command   => "/usr/bin/curl -fsSL http://localhost:${local_port}/v2/ || (echo 'Registry not reachable' && exit 1)",
     path      => ['/usr/bin', '/bin'],
     tries     => 5,
     try_sleep => 3,
     logoutput => on_failure,
     require   => Exec['load_oci_registry_daemon'],
+  }
+
+  # --- Push-auth reverse proxy (nginx): anonymous pull, authenticated push --
+  $nginx_conf   = "${config_dir}/nginx.conf"
+  $htpasswd     = "${config_dir}/htpasswd"
+  $nginx_daemon = '/Library/LaunchDaemons/com.mozilla.oci-registry-nginx.plist'
+  $nginx_bin    = '/opt/homebrew/bin/nginx'
+
+  if $push_auth {
+    exec { 'install_nginx':
+      command => "/usr/bin/su - ${user} -c '/opt/homebrew/bin/brew install nginx || true'",
+      unless  => "/bin/test -x ${nginx_bin}",
+      path    => ['/opt/homebrew/bin', '/usr/bin', '/bin'],
+      timeout => 600,
+    }
+
+    file { $htpasswd:
+      ensure    => file,
+      owner     => 'root',
+      group     => 'wheel',
+      mode      => '0644',
+      content   => "${push_htpasswd}\n",
+      show_diff => false,
+      require   => File[$config_dir],
+      notify    => Exec['load_oci_registry_nginx'],
+    }
+
+    file { $nginx_conf:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0644',
+      content => epp('roles_profiles/oci_registry/nginx.conf.epp', {
+        registry_port => $registry_port,
+        internal_port => $internal_port,
+        htpasswd_path => $htpasswd,
+      }),
+      require => File[$config_dir],
+      notify  => Exec['load_oci_registry_nginx'],
+    }
+
+    file { $nginx_daemon:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0644',
+      content => epp('roles_profiles/oci_registry/com.mozilla.oci-registry-nginx.plist.epp', {
+        nginx_bin => $nginx_bin,
+        conf_path => $nginx_conf,
+      }),
+      require => [Exec['install_nginx'], File[$nginx_conf], File[$htpasswd], Exec['verify_oci_registry']],
+      notify  => Exec['load_oci_registry_nginx'],
+    }
+
+    exec { 'load_oci_registry_nginx':
+      command     => "/bin/bash -c 'launchctl bootout system ${nginx_daemon} 2>/dev/null || true; launchctl bootstrap system ${nginx_daemon}'",
+      path        => ['/bin', '/usr/bin'],
+      refreshonly => true,
+      require     => File[$nginx_daemon],
+    }
+
+    # Self-test: anonymous GET works, unauthenticated write is refused (401).
+    exec { 'verify_push_auth':
+      command   => "/bin/bash -c 'set -e; /usr/bin/curl -fsS http://localhost:${registry_port}/v2/ >/dev/null; code=\$(/usr/bin/curl -s -o /dev/null -w \"%{http_code}\" -X POST http://localhost:${registry_port}/v2/_authtest/blobs/uploads/); test \"\$code\" = 401'", # lint:ignore:140chars
+      path      => ['/usr/bin', '/bin'],
+      tries     => 5,
+      try_sleep => 3,
+      logoutput => on_failure,
+      require   => Exec['load_oci_registry_nginx'],
+    }
+  } else {
+    # Proxy disabled: ensure any previously-installed front-end is removed.
+    exec { 'bootout_oci_registry_nginx':
+      command => "/bin/bash -c 'launchctl bootout system ${nginx_daemon} 2>/dev/null || true'",
+      onlyif  => "/bin/test -f ${nginx_daemon}",
+      path    => ['/bin', '/usr/bin'],
+    }
+    file { [$nginx_daemon, $nginx_conf, $htpasswd]:
+      ensure  => absent,
+      require => Exec['bootout_oci_registry_nginx'],
+    }
   }
 
   # --- Daily maintenance: tag retention + native garbage collection --------
@@ -135,7 +234,7 @@ class roles_profiles::profiles::oci_registry {
       user           => $user,
       bin_path       => $bin_path,
       config_path    => $config_path,
-      registry_port  => $registry_port,
+      registry_port  => $local_port,
       keep_prod_shas => $keep_prod_shas,
       prune_pr_shas  => $prune_pr_shas,
     }),

--- a/modules/roles_profiles/templates/oci_registry/com.mozilla.oci-registry-nginx.plist.epp
+++ b/modules/roles_profiles/templates/oci_registry/com.mozilla.oci-registry-nginx.plist.epp
@@ -1,0 +1,25 @@
+<%- | String $nginx_bin, String $conf_path | -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.oci-registry-nginx</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string><%= $nginx_bin %></string>
+        <string>-g</string>
+        <string>daemon off;</string>
+        <string>-c</string>
+        <string><%= $conf_path %></string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/oci-registry-nginx.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/oci-registry-nginx.log</string>
+</dict>
+</plist>

--- a/modules/roles_profiles/templates/oci_registry/config.yml.epp
+++ b/modules/roles_profiles/templates/oci_registry/config.yml.epp
@@ -1,4 +1,4 @@
-<%- | String $registry_dir, Integer $registry_port, String $http_secret | -%>
+<%- | String $registry_dir, String $listen_addr, String $http_secret | -%>
 # Managed by Puppet (roles_profiles::profiles::oci_registry). Do not edit.
 # distribution (registry) v3 config, filesystem storage, insecure HTTP.
 version: 0.1
@@ -16,5 +16,5 @@ storage:
       interval: 24h
       dryrun: false
 http:
-  addr: 0.0.0.0:<%= $registry_port %>
+  addr: <%= $listen_addr %>
   secret: <%= $http_secret %>

--- a/modules/roles_profiles/templates/oci_registry/nginx.conf.epp
+++ b/modules/roles_profiles/templates/oci_registry/nginx.conf.epp
@@ -1,0 +1,45 @@
+<%- | Integer $registry_port, Integer $internal_port, String $htpasswd_path | -%>
+# Managed by Puppet (roles_profiles::profiles::oci_registry). Do not edit.
+#
+# Fronts the native OCI registry to enforce Bug 2049579 rec #4: anonymous pull
+# (GET/HEAD), authenticated push (PUT/POST/PATCH/DELETE). Only the holder of the
+# push credential can publish/overwrite images (e.g. *-prod-latest); the tester
+# fleet keeps pulling anonymously with no client change.
+worker_processes 1;
+error_log /var/log/oci-registry-nginx-error.log warn;
+pid /var/run/oci-registry-nginx.pid;
+
+events { worker_connections 256; }
+
+http {
+  access_log /var/log/oci-registry-nginx-access.log;
+
+  # Registries stream large image layers; do not cap the body or buffer it.
+  client_max_body_size 0;
+  chunked_transfer_encoding on;
+
+  upstream oci_registry_backend {
+    server 127.0.0.1:<%= $internal_port %>;
+  }
+
+  server {
+    listen <%= $registry_port %>;
+    server_name _;
+
+    location / {
+      # Writes require basic auth; reads (GET/HEAD) stay anonymous.
+      limit_except GET HEAD {
+        auth_basic           "oci-registry push";
+        auth_basic_user_file <%= $htpasswd_path %>;
+      }
+
+      proxy_pass                          http://oci_registry_backend;
+      proxy_set_header  Host              $http_host;
+      proxy_set_header  X-Real-IP         $remote_addr;
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_read_timeout                  900;
+      proxy_request_buffering             off;
+    }
+  }
+}


### PR DESCRIPTION
Phase 0 of safely reconnecting the macos-vms self-hosted build runner: restrict who can publish images to the tester registry. This closes the **"restrict registry push"** remediation item (#4) from the disclosed self-hosted-runner RCE (**Bug 2049579**) and is the security foundation for the build→promote→rollout pipeline.

## Approach
`distribution` v3's htpasswd auth is all-or-nothing (an authenticated user can pull *and* push), so it can't express "only the builder pushes." The standard pattern for **anonymous pull + authenticated push** is a thin **nginx reverse proxy**: `GET`/`HEAD` anonymous, basic-auth on `PUT`/`POST`/`PATCH`/`DELETE`.

- When `oci_registry.push_htpasswd` is set, the registry binds **loopback** (`internal_port`) and nginx owns the public port, enforcing auth on writes via a managed htpasswd. A puppet self-test confirms anonymous `GET /v2/` works and an unauthenticated write returns **401**.
- **Empty (default) = no proxy**, registry binds the public port directly (pre-hardening behaviour) — opt-in, safe no-op until the credential is set.
- ronin_puppet is **public**, so `push_htpasswd` is empty in role data and must come from a **secret override** (bcrypt htpasswd body); the plaintext password goes only to the builder's GitHub Actions secret.
- Host-local tooling (maintenance/verify) talks straight to the registry on the internal port, bypassing the proxy.

## Tester fleet impact
None — pulls stay anonymous `GET`, no client change on the 13 tester hosts.

## Validation
`puppet parser validate` + `puppet epp validate` OK; rendered nginx.conf/config.yml correct; all pre-commit hooks (incl. puppet-lint) Passed.

## Rollout (separate, operator)
Generate the push credential (`htpasswd -nbB builder '<pw>'`), set `push_htpasswd` via a secret override on m4-194, apply; then the builder authenticates with the plaintext password from a GitHub Actions secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)