### PR TITLE
oci_registry: move push_htpasswd to a top-level vault key (fix hiera shadowing)

### DIFF
--- a/data/roles/oci_registry_host.yaml
+++ b/data/roles/oci_registry_host.yaml
@@ -16,14 +16,7 @@ oci_registry:
   registry_dir: '/Users/admin/registry-data'
   registry_port: 5000
   user: admin
-  # Push authentication (Bug 2049579 rec #4). Leave push_htpasswd EMPTY here —
-  # ronin_puppet is public, so the credential must NOT be committed. Populate it
-  # via a secret override (the bcrypt htpasswd body, e.g. `builder:$2y$05$...`
-  # from `htpasswd -nbB builder '<password>'`); the plaintext password goes only
-  # to the builder's GitHub Actions secret. When set, an nginx proxy requires
-  # auth for pushes and the registry binds internal_port (loopback) behind it.
-  # Empty = no proxy, registry binds registry_port directly (open push).
-  push_htpasswd: ''
+  # Internal loopback port the registry binds when the push-auth proxy is on.
   internal_port: 5001
   # http.secret signs upload state; single-node so not sensitive, but override
   # via a secure source if desired.

--- a/modules/roles_profiles/manifests/profiles/oci_registry.pp
+++ b/modules/roles_profiles/manifests/profiles/oci_registry.pp
@@ -35,15 +35,21 @@ class roles_profiles::profiles::oci_registry {
   $alert_email    = lookup('oci_registry.alert_email',    String,  'first', 'releng-ci-alerts@mozilla.com')
   $smtp_relay     = lookup('oci_registry.smtp_relay',     String,  'first', 'smtp1.mail.mdc1.mozilla.com')
 
-  # Push authentication (Bug 2049579 rec #4). When oci_registry.push_htpasswd is
-  # set (a bcrypt htpasswd file body, delivered via a SECRET override — never
+  # Push authentication (Bug 2049579 rec #4). When oci_registry_push_htpasswd is
+  # set (an htpasswd file body, delivered via a SECRET override — never
   # committed; ronin_puppet is public), an nginx reverse proxy fronts the
   # registry and requires basic auth for writes (PUT/POST/PATCH/DELETE) while
   # leaving pulls (GET/HEAD) anonymous, so only the holder of the push
   # credential can publish images. The registry then binds loopback only and
   # nginx owns the public port. Empty (default) = no proxy, registry binds the
   # public port directly (open push, the pre-hardening behaviour).
-  $push_htpasswd = lookup('oci_registry.push_htpasswd', String,  'first', '')
+  #
+  # NB: this is a TOP-LEVEL key, deliberately NOT nested under the oci_registry
+  # hash. Secrets live in vault.yaml (the highest-priority hiera layer) and
+  # lookups here use 'first' (no deep merge); a partial `oci_registry:` hash in
+  # vault.yaml would shadow the whole role-data `oci_registry` hash (hiding
+  # binary_url etc.). A distinct top-level key avoids that collision.
+  $push_htpasswd = lookup('oci_registry_push_htpasswd', String,  'first', '')
   $internal_port = lookup('oci_registry.internal_port', Integer, 'first', 5001)
   $push_auth     = $push_htpasswd != ''
   $listen_addr   = $push_auth ? { true => "127.0.0.1:${internal_port}", default => "0.0.0.0:${registry_port}" }


### PR DESCRIPTION
Follow-up to #1288. Deploying push-auth to m4-194 broke catalog compilation:

```
Error: Function lookup() did not find a value for the name 'oci_registry.binary_url'
```

## Cause
The push credential was looked up as `oci_registry.push_htpasswd` (nested in the `oci_registry` hash). Secrets live in `vault.yaml` — the **highest-priority** hiera layer — and these lookups use **`first`** (no deep merge). So putting a partial `oci_registry: { push_htpasswd: ... }` in the host's `vault.yaml` **shadowed the entire role-data `oci_registry` hash**, hiding `binary_url`/`binary_sha256`/etc. → compile error. (No damage — the apply failed at compile, registry untouched.)

## Fix
Look the secret up under a distinct **top-level** key, `oci_registry_push_htpasswd`, so it can't collide with the `oci_registry` config hash:

```yaml
# /var/root/vault.yaml
oci_registry_push_htpasswd: 'builder:$apr1$...'
```

Role config stays under `oci_registry`. Empty/unset = proxy off (unchanged default). No functional change to #1288 beyond the key name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)