### PR TITLE
puppet: harden two footguns found deploying registry push-auth (tart secret key + brew ownership)

### DIFF
--- a/data/roles/tart_worker.yaml
+++ b/data/roles/tart_worker.yaml
@@ -32,9 +32,11 @@ tart:
   user: 'admin'
   manage_image: false
   launchd_type: 'daemon'
-  # base64 of the admin user's /etc/kcpassword — enables puppet-managed autologin
-  # so the host reliably comes back with an admin GUI session on reboot (required
-  # for Apple Virtualization Framework / `tart run`; see profiles::tart). Leave
-  # blank here and set the real value via vault / a secure override — do NOT
-  # commit the credential. Blank = autologin unmanaged.
-  autologin_kcpassword: ''
+
+# Puppet-managed autologin for the VM host (see profiles::tart): base64 of the
+# admin user's /etc/kcpassword, enabling an admin GUI session on reboot (required
+# for Apple Virtualization Framework / `tart run`). This is a TOP-LEVEL key, NOT
+# nested under `tart:` — a secret nested there would shadow the whole tart config
+# hash via hiera 'first' merge. Set the real value via vault / a secure override
+# only; do NOT commit the credential. Unset/blank = autologin unmanaged.
+tart_autologin_kcpassword: ''

--- a/modules/roles_profiles/manifests/profiles/oci_registry.pp
+++ b/modules/roles_profiles/manifests/profiles/oci_registry.pp
@@ -156,11 +156,23 @@ class roles_profiles::profiles::oci_registry {
   $nginx_bin    = '/opt/homebrew/bin/nginx'
 
   if $push_auth {
+    # `brew install` writes into the prefix, so ${user} must own it. Ownership
+    # can drift (seen on m4-194: /opt/homebrew/bin became non-admin-writable and
+    # `brew install nginx` failed). Restore it before installing; the `unless`
+    # keeps this a no-op once the prefix is correctly owned.
+    exec { 'ensure_homebrew_admin_owned':
+      command => "/usr/sbin/chown -R ${user} /opt/homebrew",
+      unless  => "/bin/bash -c '/usr/bin/test $(/usr/bin/stat -f %Su /opt/homebrew/bin) = ${user}'",
+      path    => ['/usr/sbin', '/usr/bin', '/bin'],
+      timeout => 600,
+    }
+
     exec { 'install_nginx':
       command => "/usr/bin/su - ${user} -c '/opt/homebrew/bin/brew install nginx || true'",
       unless  => "/bin/test -x ${nginx_bin}",
       path    => ['/opt/homebrew/bin', '/usr/bin', '/bin'],
       timeout => 600,
+      require => Exec['ensure_homebrew_admin_owned'],
     }
 
     file { $htpasswd:

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -49,10 +49,16 @@ class roles_profiles::profiles::tart {
   # was missing while sibling hosts happened to have it). Managing it here makes
   # reboot-resilience guaranteed instead of dependent on original provisioning.
   #
-  # tart.autologin_kcpassword = base64 of the admin user's /etc/kcpassword.
+  # tart_autologin_kcpassword = base64 of the admin user's /etc/kcpassword.
   # Populate it in vault/hiera; left empty it is a no-op (autologin unmanaged,
   # falls back to whatever the host was provisioned with).
-  $autologin_kcpassword = lookup('tart.autologin_kcpassword', String, 'first', '')
+  #
+  # NB: TOP-LEVEL key, deliberately NOT nested under the `tart` hash. Secrets
+  # live in vault.yaml (highest-priority hiera layer) and lookups here use
+  # 'first' (no deep merge); a partial `tart: {autologin_kcpassword: ...}` in
+  # vault.yaml would shadow the whole role-data `tart` hash (hiding version /
+  # registry_host / oci_image / etc.). A distinct top-level key avoids that.
+  $autologin_kcpassword = lookup('tart_autologin_kcpassword', String, 'first', '')
   if $autologin_kcpassword != '' {
     class { 'macos_utils::autologin_user':
       user       => $user,


### PR DESCRIPTION
Two small hardening fixes surfaced while deploying oci_registry push-auth to macmini-m4-194.

## 1. tart autologin secret → top-level vault key
`profiles::tart` looked up `tart.autologin_kcpassword` (nested in the `tart` hash). Same hiera-shadowing footgun just fixed for oci_registry in #1289: secrets live in `vault.yaml` (highest-priority layer) and lookups use `first` (no deep merge), so a partial `tart: { autologin_kcpassword: ... }` in a host's `vault.yaml` would **shadow the entire role-data `tart` hash** (`version`, `registry_host`, `oci_image`, …) and break the tart role. Moved to a **top-level** key `tart_autologin_kcpassword`. It isn't populated anywhere yet, so this is pre-emptive before the autologin rollout — **no behaviour change**.

## 2. oci_registry: ensure Homebrew prefix ownership before `brew install`
On m4-194, `/opt/homebrew/bin` had drifted to non-admin-writable, so `install_nginx`'s `brew install nginx` failed; `|| true` swallowed it and the apply died later at the nginx verify. Added a guarded `chown -R ${user} /opt/homebrew` (no-op once correctly owned) so a fresh host provisions cleanly.

## Validation
`puppet parser validate` OK; all pre-commit hooks (incl. puppet-lint) Passed. The ownership-check `unless` is wrapped in `bash -c` since puppet's `exec` doesn't use a shell for command substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)