### PR TITLE
profiles::tart: host-mediated worker-vault injection into VMs at launch

### DIFF
--- a/data/roles/tart_worker.yaml
+++ b/data/roles/tart_worker.yaml
@@ -32,6 +32,14 @@ tart:
   user: 'admin'
   manage_image: false
   launchd_type: 'daemon'
+  # Host-mediated worker-vault injection (see profiles::tart). Keep FALSE until
+  # the credential-free tester image (which reads the injected vault at first
+  # boot) is built + promoted — with today's baked image the injected dir is
+  # simply ignored, so flipping this early is harmless but pointless. When true,
+  # the host fetches vault-<vault_role> from the broker (mTLS via its SCEP cert)
+  # and shares it into each VM via `tart run --dir`.
+  inject_vault: false
+  vault_role: 'gecko_t_osx_1500_m_vms'
 
 # Puppet-managed autologin for the VM host (see profiles::tart): base64 of the
 # admin user's /etc/kcpassword, enabling an admin GUI session on reboot (required

--- a/modules/roles_profiles/manifests/profiles/tart.pp
+++ b/modules/roles_profiles/manifests/profiles/tart.pp
@@ -40,6 +40,20 @@ class roles_profiles::profiles::tart {
   $manage_image   = lookup('tart.manage_image',   Boolean, 'first', true)
   $launchd_type   = lookup('tart.launchd_type',   Enum['agent', 'daemon'], 'first', 'agent')
 
+  # Host-mediated worker-vault injection (tart.inject_vault, default false).
+  # When true, the tartworker daemon runs tart-run-vm.sh, which fetches the
+  # worker vault from the relops-bootstrap broker over mTLS using the host's
+  # SCEP-issued System-keychain cert (role = tart.vault_role) and shares it into
+  # the guest via `tart run --dir`; the guest's first-boot puppet run turns it
+  # into the generic-worker config. Leave false until the credential-free image
+  # (which reads the injected vault at boot) is deployed — with a baked image the
+  # injected dir is simply ignored. Only meaningful when launchd_type == daemon.
+  $inject_vault   = lookup('tart.inject_vault',   Boolean, 'first', false)
+  $vault_role     = lookup('tart.vault_role',     String,  'first', '')
+  $broker_host    = lookup('tart.broker_host',    String,  'first', 'forge.relops.mozilla.com')
+  $scep_issuer_cn = lookup('tart.scep_issuer_cn', String,  'first', 'Mozilla RelOps Bootstrap CA Intermediate CA')
+  $vault_dir_base = "/Users/${user}/.tart-vault"
+
   # Autologin the VM-host user. Apple's Virtualization Framework needs an active
   # GUI (Aqua) session for `tart run` to start a VM, and on a headless host that
   # session only exists via autologin at boot. Without a puppet-managed
@@ -147,6 +161,31 @@ class roles_profiles::profiles::tart {
     $dir_require = []
   }
 
+  # The daemon runs this wrapper instead of `tart run` directly, so it can inject
+  # the worker vault into each VM at launch (see tart.inject_vault above). One
+  # shared script; the plist passes the VM name. Only the daemon path uses it.
+  if $launchd_type == 'daemon' {
+    file { '/usr/local/bin/tart-run-vm.sh':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'wheel',
+      mode    => '0755',
+      content => epp('roles_profiles/tart/tart-run-vm.sh.epp', {
+        user           => $user,
+        bin_path       => $bin_path,
+        inject_vault   => $inject_vault,
+        vault_role     => $vault_role,
+        broker_host    => $broker_host,
+        scep_issuer_cn => $scep_issuer_cn,
+        vault_dir_base => $vault_dir_base,
+      }),
+      require => Exec['install_tart'],
+    }
+    $wrapper_require = [File['/usr/local/bin/tart-run-vm.sh']]
+  } else {
+    $wrapper_require = []
+  }
+
   Integer[1, $worker_count].each |$i| {
     $vm_name = "${vm_name_prefix}-${i}"
 
@@ -175,13 +214,12 @@ class roles_profiles::profiles::tart {
         content => epp('roles_profiles/tart/com.mozilla.tartworker.daemon.plist.epp', {
           worker_id => $i,
           vm_name   => $vm_name,
-          bin_path  => $bin_path,
           user      => $user,
         }),
         owner   => 'root',
         group   => 'wheel',
         mode    => '0644',
-        require => $image_require + $dir_require + [Exec["evict_agent_tartworker_${i}"], File[$agent_plist]],
+        require => $image_require + $dir_require + $wrapper_require + [Exec["evict_agent_tartworker_${i}"], File[$agent_plist]],
         notify  => Exec["load_tartworker_${i}"],
       }
 

--- a/modules/roles_profiles/templates/tart/com.mozilla.tartworker.daemon.plist.epp
+++ b/modules/roles_profiles/templates/tart/com.mozilla.tartworker.daemon.plist.epp
@@ -1,6 +1,5 @@
 <%- | Integer $worker_id,
       String  $vm_name,
-      String  $bin_path,
       String  $user,
 | -%>
 <?xml version="1.0" encoding="UTF-8"?>
@@ -11,11 +10,12 @@
     <string>com.mozilla.tartworker-<%= $worker_id %></string>
     <key>UserName</key>
     <string><%= $user %></string>
+    <!-- Runs the tart-run-vm.sh wrapper (fetches + injects the worker vault when
+         enabled, then execs `tart run`) rather than tart directly. -->
     <key>ProgramArguments</key>
     <array>
-        <string><%= $bin_path %></string>
-        <string>run</string>
-        <string>--no-graphics</string>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/tart-run-vm.sh</string>
         <string><%= $vm_name %></string>
     </array>
     <key>EnvironmentVariables</key>

--- a/modules/roles_profiles/templates/tart/tart-run-vm.sh.epp
+++ b/modules/roles_profiles/templates/tart/tart-run-vm.sh.epp
@@ -1,0 +1,74 @@
+<%- | String $user,
+      String $bin_path,
+      Boolean $inject_vault,
+      String $vault_role,
+      String $broker_host,
+      String $scep_issuer_cn,
+      String $vault_dir_base,
+| -%>
+#!/bin/bash
+# Managed by Puppet (roles_profiles::profiles::tart). Do not edit.
+#
+# Wrapper the tartworker LaunchDaemon runs INSTEAD of `tart run` directly.
+# When vault injection is enabled it fetches the worker vault on the HOST (the
+# VM is not MDM-enrolled and has no broker identity; the host holds the SCEP
+# cert), writes it to a per-VM directory, and shares that dir into the guest via
+# `tart run --dir`. The guest's first-boot puppet run reads it and turns it into
+# the generic-worker config (worker.access_token etc). Runs as the daemon user
+# (admin) — the SCEP profile's AllowAllAppsAccess lets SecureTransport sign with
+# the System-keychain key without root.
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+VM="$1"
+BIN="<%= $bin_path %>"
+<% if $inject_vault { -%>
+
+BROKER="<%= $broker_host %>"
+ROLE="<%= $vault_role %>"
+ISSUER_CN="<%= $scep_issuer_cn %>"
+VDIR="<%= $vault_dir_base %>/${VM}"
+
+/bin/mkdir -p "$VDIR"
+/bin/chmod 700 "$VDIR"
+
+log() { echo "$(/bin/date -u +%FT%TZ) tart-run-vm[$VM] $*"; }
+
+# Find the SCEP identity by ISSUER CN. `find-identity` WITHOUT -v on purpose:
+# -v filters by local chain validity, which fails for MDM-pushed CAs (the LB
+# validates the chain, not us). Subject CN varies by ComputerName, so match the
+# stable issuer instead.
+IDENTITY_CN=""
+while IFS= read -r line; do
+  if [[ $line =~ \)\ ([0-9A-Fa-f]+)\ \"([^\"]+)\" ]]; then
+    cn="${BASH_REMATCH[2]}"
+    if /usr/bin/security find-certificate -c "$cn" -p /Library/Keychains/System.keychain 2>/dev/null \
+        | /usr/bin/openssl x509 -noout -issuer 2>/dev/null | /usr/bin/grep -q "$ISSUER_CN"; then
+      IDENTITY_CN="$cn"
+      break
+    fi
+  fi
+done < <(/usr/bin/security find-identity /Library/Keychains/System.keychain 2>/dev/null)
+
+if [ -n "$IDENTITY_CN" ]; then
+  TMP="$VDIR/.vault.yaml.tmp"
+  code=$(CURL_SSL_BACKEND=securetransport /usr/bin/curl -sS --max-time 30 \
+      --cert "$IDENTITY_CN" -w '%{http_code}' -o "$TMP" \
+      "https://${BROKER}/secret/${ROLE}") || true
+  if [ "$code" = "200" ] && [ -s "$TMP" ]; then
+    /bin/chmod 600 "$TMP"
+    /bin/mv "$TMP" "$VDIR/vault.yaml"
+    log "fetched vault for role ${ROLE} ($(/usr/bin/wc -c <"$VDIR/vault.yaml" | /usr/bin/tr -d ' ') bytes)"
+  else
+    log "WARN broker fetch HTTP ${code:-000} for ${ROLE}; leaving prior vault (if any) in place"
+    /bin/rm -f "$TMP"
+  fi
+else
+  log "WARN no SCEP identity (issuer '${ISSUER_CN}') in System keychain; starting VM without a fresh vault"
+fi
+
+exec "$BIN" run --no-graphics --dir="vault:${VDIR}:ro" "$VM"
+<% } else { -%>
+
+exec "$BIN" run --no-graphics "$VM"
+<% } -%>


### PR DESCRIPTION
The tester VMs aren't MDM-enrolled, so they can't authenticate to the vault broker themselves. The **MDM-enrolled host** holds a SCEP cert — so the tartworker daemon now runs a wrapper (`tart-run-vm.sh`) that, when `tart.inject_vault` is true, **fetches the worker vault over mTLS** (SecureTransport + the System-keychain SCEP cert, role = `tart.vault_role`) and **shares it into the guest via `tart run --dir`**. The guest's first-boot puppet run turns it into the generic-worker config (`worker.access_token` etc).

This lets tester images ship **credential-free** — removing the baked TC creds that made the build runner a supply-chain risk (Bug 2049579).

**Proven end-to-end on m4-84**: SCEP cert → `forge.relops.mozilla.com/secret/gecko_t_osx_1500_m_vms` → HTTP 200, returning the exact uploaded vault, running as the **admin** daemon user (the SCEP profile's `AllowAllAppsAccess` lets SecureTransport sign without root).

Notes:
- **Default OFF** (`tart.inject_vault: false`). With today's baked image the injected dir is simply ignored, so this is inert until the credential-free image lands — safe to merge now.
- Uses `security find-identity` **without `-v`**, matching by **issuer CN** (`-v` filters MDM-pushed CAs; subject CN varies by ComputerName).
- Only the `daemon` launchd path uses the wrapper; the daemon plist now runs `tart-run-vm.sh <vm>` instead of `tart run` directly.
- Fetch happens on each VM (re)start (KeepAlive), so the vault refreshes every start.

Validation: `puppet parser`/`epp validate` OK; rendered wrapper `shellcheck` clean (both inject on/off); all pre-commit hooks (incl. puppet-lint) Passed.

**Pairs with** the macos-vms credential-free image change (first-boot reads `/Volumes/My Shared Files/vault/vault.yaml` → `/var/root/vault.yaml` → run-puppet) — that's the next PR; flip `inject_vault: true` once it's promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)