### PR TITLE
gecko_t_osx_1500_m_vms: drop safaridriver profile (headless-build hostile)

### DIFF
--- a/modules/roles_profiles/manifests/roles/gecko_t_osx_1500_m_vms.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_t_osx_1500_m_vms.pp
@@ -18,7 +18,12 @@ class roles_profiles::roles::gecko_t_osx_1500_m_vms {
   include roles_profiles::profiles::pipconf
   include roles_profiles::profiles::power_management
   include roles_profiles::profiles::relops_users
-  include roles_profiles::profiles::safaridriver
+  # Disabled on the VM image role: safaridriver's "Allow Remote Automation"
+  # enable execs drive osascript in cltbld's GUI session, which a headless VM
+  # image build doesn't have — they hang on the Accessibility/auth prompts and
+  # fail phase-2 puppet non-deterministically. These VMs don't run Safari/perf
+  # tasks, so we skip the profile entirely.
+  # include roles_profiles::profiles::safaridriver
   include roles_profiles::profiles::sudo
   include roles_profiles::profiles::talos
   include roles_profiles::profiles::timezone


### PR DESCRIPTION
## Problem

On the macOS VM **image build** (`gecko_t_osx_1500_m_vms`, built headless via Packer/tart), phase-2 puppet fails non-deterministically on the safaridriver "Allow Remote Automation" enable execs (stable + Safari TP). They bootstrap a `gui/<cltbld_uid>` LaunchAgent that drives osascript to flip Safari's "Allow Remote Automation," then wait ≤120s for a semaphore. That needs cltbld in an **unlocked GUI session** with **Accessibility/auth grants** — which a headless image build doesn't have, so the execs hang on the Accessibility (and a password) prompt, the semaphore never flips, and `run-puppet.sh` retry-loops forever. It's flaky: some builds win the race, most don't.

## Fix

Comment `include roles_profiles::profiles::safaridriver` out of the VM image role. These VMs don't run Safari or perf (`browsertime-benchmark-safari-tp-*`) tasks, so nothing needs it. Makes the VM image build deterministically hands-off.

## Scope

- Only `gecko_t_osx_1500_m_vms`. **Bare-metal roles are untouched.**
- Trivially reversible (uncomment the include).

🤖 Generated with [Claude Code](https://claude.com/claude-code)