### PR TITLE
oci_registry: fix ensure_homebrew_admin_owned test path (/usr/bin/test -> /bin/test)

### DIFF
--- a/modules/roles_profiles/manifests/profiles/oci_registry.pp
+++ b/modules/roles_profiles/manifests/profiles/oci_registry.pp
@@ -162,7 +162,7 @@ class roles_profiles::profiles::oci_registry {
     # keeps this a no-op once the prefix is correctly owned.
     exec { 'ensure_homebrew_admin_owned':
       command => "/usr/sbin/chown -R ${user} /opt/homebrew",
-      unless  => "/bin/bash -c '/usr/bin/test $(/usr/bin/stat -f %Su /opt/homebrew/bin) = ${user}'",
+      unless  => "/bin/bash -c '/bin/test $(/usr/bin/stat -f %Su /opt/homebrew/bin) = ${user}'",
       path    => ['/usr/sbin', '/usr/bin', '/bin'],
       timeout => 600,
     }


### PR DESCRIPTION
## Problem

On m4-194, `puppet apply` fails every run with:

```
Error: /Stage[main]/Roles_profiles::Profiles::Oci_registry/Exec[ensure_homebrew_admin_owned]: Could not evaluate: /bin/bash: /usr/bin/test: No such file or directory
```

which then skips `install_nginx`, the nginx LaunchDaemon, and `verify_push_auth`. The guard's `unless` used `/usr/bin/test`, but on macOS `test` is at **`/bin/test`** (there's no `/usr/bin/test`).

## Fix

`/usr/bin/test` → `/bin/test` in the `ensure_homebrew_admin_owned` `unless`. Regression from #1290. (`/usr/bin/stat` is correct and unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)