### PR TITLE
tart-update-vms: run tart as the VM owner, and verify the recreate happened

### DIFF
--- a/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
+++ b/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
@@ -56,6 +56,26 @@ log() { echo "$(date -u +%FT%TZ) $*"; }
 
 uid_of() { /usr/bin/id -u "${USER_NAME}"; }
 
+# Run tart AS THE VM-OWNING USER. This is not optional and not cosmetic.
+#
+# tart resolves VMs from $HOME/.tart. This script must run as root (the daemon
+# path does `launchctl bootout system/...`, which root alone can do), and root's
+# $HOME is /var/root -- an entirely separate, empty tart namespace. Invoking tart
+# directly here therefore operates on the wrong VMs.
+#
+# Observed on macmini-m4-188 (2026-07-27) before this fix: `tart stop`/`delete`
+# hit root's empty namespace and failed silently behind `2>/dev/null || true`,
+# `tart clone` then SUCCEEDED into /var/root/.tart (two phantom VMs + a 25 GB
+# cache), `start_unit` restarted the launchd job -- which runs as ${USER_NAME}
+# and picked up the untouched original VM -- and the script logged
+# "rolling update complete". Nothing had been updated.
+#
+# Same convention as profiles::tart, which invokes tart-pull-image.sh and
+# `tart list` via `su - ${user} -c`.
+tart_user() {
+  su - "${USER_NAME}" -c "$(printf '%q ' "${BIN}" "$@")"
+}
+
 # --- launchd helpers: daemon (system) vs agent (per-user gui) --------------
 # NOTE: two separate `local` statements, not `local i="$1" label="...${i}"`.
 # `local` expands all its arguments before assigning any of them, so on the
@@ -231,10 +251,15 @@ drain_slot() {  # $1 = vm name
 
 # --- pull the new image once ----------------------------------------------
 log "pulling ${REGISTRY}/${IMAGE}"
-"${BIN}" pull ${INSECURE} "${REGISTRY}/${IMAGE}"
+if ! tart_user pull ${INSECURE} "${REGISTRY}/${IMAGE}"; then
+  log "FATAL: pull of ${REGISTRY}/${IMAGE} failed — refusing to delete any VM"
+  log "       without a usable image to clone from"
+  exit 1
+fi
 
 # --- roll each slot, one at a time ----------------------------------------
 SKIPPED=()
+FAILED=()
 for i in $(seq 1 "${WORKER_COUNT}"); do
   VM="${PREFIX}-${i}"
   log "== slot ${i} (${VM}) =="
@@ -243,24 +268,74 @@ for i in $(seq 1 "${WORKER_COUNT}"); do
     SKIPPED+=("${i}")
     continue
   fi
+
+  # Record the identity we expect to change, so "updated" can be VERIFIED rather
+  # than assumed. Without this the loop reported success merely for reaching its
+  # end, which is exactly how the run-as-root bug went unnoticed.
+  mac_before="$(worker_id_for_vm "${VM}" || true)"
+
   log "  stopping worker unit ${i}"
   stop_unit "${i}"
   sleep 5
-  "${BIN}" stop "${VM}" 2>/dev/null || true
-  "${BIN}" delete "${VM}" 2>/dev/null || true
+  # No 2>/dev/null here: swallowing these is what hid the run-as-root bug for the
+  # entire life of this script. A stop/delete failure is worth seeing in the log.
+  tart_user stop "${VM}" || log "  (stop returned non-zero; VM may already be stopped)"
+  if ! tart_user delete "${VM}"; then
+    log "  slot ${i} FAILED: could not delete ${VM}; leaving it alone rather than"
+    log "  cloning over a VM that still exists"
+    FAILED+=("${i}")
+    start_unit "${i}"
+    continue
+  fi
+
   log "  cloning fresh ${VM} from ${IMAGE}"
-  "${BIN}" clone "${REGISTRY}/${IMAGE}" "${VM}"
-  "${BIN}" set "${VM}" --random-mac --random-serial
+  if ! tart_user clone "${REGISTRY}/${IMAGE}" "${VM}"; then
+    log "  slot ${i} FAILED: clone of ${IMAGE} failed — slot is now EMPTY and its"
+    log "  worker is DOWN. Manual recovery needed: clone ${IMAGE} to ${VM}."
+    FAILED+=("${i}")
+    continue
+  fi
+  if ! tart_user set "${VM}" --random-mac --random-serial; then
+    log "  slot ${i} FAILED: could not randomise MAC/serial; the clone would keep"
+    log "  the image's baked identity and collide with other slots"
+    FAILED+=("${i}")
+    continue
+  fi
+
+  # Post-condition: the workerId is derived from the MAC, so a successful
+  # recreate MUST change it. If it did not, the recreate silently operated
+  # somewhere else and the slot is still on the old image.
+  mac_after="$(worker_id_for_vm "${VM}" || true)"
+  if [ -z "${mac_after}" ]; then
+    log "  slot ${i} FAILED: no workerId readable after recreate (missing config.json?)"
+    FAILED+=("${i}")
+    continue
+  fi
+  if [ -n "${mac_before}" ] && [ "${mac_before}" = "${mac_after}" ]; then
+    log "  slot ${i} FAILED: workerId unchanged (${mac_after}) after clone+set."
+    log "  The recreate did not take effect on ${TART_VMS}/${VM} — check that tart"
+    log "  is running as ${USER_NAME} and not root."
+    FAILED+=("${i}")
+    continue
+  fi
+
   log "  starting worker unit ${i}"
   start_unit "${i}"
-  log "  slot ${i} updated"
+  log "  slot ${i} updated (${mac_before:-unknown} -> ${mac_after})"
 done
 
-# Exit non-zero on a partial roll so the caller (the on-network reprovision
-# runner / Hangar trigger) does not record a skipped slot as a success. Silent
-# truncation reads as "everything is on the new image" when it is not.
-if [ "${#SKIPPED[@]}" -gt 0 ]; then
-  log "rolling update INCOMPLETE: ${#SKIPPED[@]}/${WORKER_COUNT} slot(s) skipped (${SKIPPED[*]}) — still on the old image"
+# Exit non-zero on anything less than a full roll so the caller (the on-network
+# reprovision runner / Hangar trigger) cannot record a partial roll as a success.
+# Silent truncation reads as "everything is on the new image" when it is not.
+#
+# SKIPPED = intentionally left alone (could not prove the worker idle) and still
+#           serving on the old image.
+# FAILED  = the recreate was attempted and did not complete. A slot in here may
+#           be DOWN and needs looking at.
+if [ "${#FAILED[@]}" -gt 0 ] || [ "${#SKIPPED[@]}" -gt 0 ]; then
+  log "rolling update INCOMPLETE (${WORKER_COUNT} slot(s) total):"
+  [ "${#SKIPPED[@]}" -gt 0 ] && log "  skipped, still on old image: ${SKIPPED[*]}"
+  [ "${#FAILED[@]}" -gt 0 ] && log "  FAILED mid-recreate, may be DOWN: ${FAILED[*]}"
   exit 1
 fi
 


### PR DESCRIPTION
Follow-up to #1294, found by running it for real on **macmini-m4-188**. It reported `rolling update complete (2 slot(s))` having updated **nothing**.

## Root cause

`tart` resolves VMs from `$HOME/.tart`. This script must run as root — the daemon path does `launchctl bootout system/…` — and root's `$HOME` is `/var/root`, a separate, empty tart namespace. So every `tart` call operated on the wrong VMs:

1. `tart stop` / `tart delete` hit root's empty namespace and failed **silently**, behind `2>/dev/null || true`
2. `tart clone` then **succeeded** into `/var/root/.tart`, creating two phantom VMs and a 25 GB cache
3. `start_unit` restarted the launchd job, which runs as `UserName=admin` and therefore picked up the original, untouched VM
4. the loop reached its end and declared success

Evidence from the run:

```
/var/root/.tart/vms/    sequoia-tester-1, sequoia-tester-2   created Jul 27 11:42   <- script's work
/var/root/.tart/cache   25G                                                          <- the pull
/Users/admin/.tart/vms/ sequoia-tester-1, sequoia-tester-2   created May 14          <- real workers, untouched
```

MACs were unchanged (`mac-b1a5a3`, `mac-ff3bfb`) despite `tart set --random-mac`. **Production VMs were never touched — by luck, not by design.** Had root's namespace happened to contain same-named VMs, this would have deleted them.

## Fixes

**1. `tart_user()` runs every tart call as the VM owner** via `su - ${USER_NAME} -c`, matching the convention `profiles::tart` already uses for `tart-pull-image.sh` and `tart list` (`tart.pp:150,157`). Args pass through `printf %q` so quoting holds. Verified as root on m4-188:

```
ROOT-DIRECT (buggy path) — VM count: 0
VIA tart_user (fixed path) — VM count: 2   (sequoia-tester-1, sequoia-tester-2)
```

**2. Stop hiding stop/delete failures.** That `2>/dev/null || true` is the whole reason this went unnoticed. A failed `delete` now aborts the slot rather than cloning over a VM that still exists, and a **failed pull aborts the entire run** rather than deleting VMs with no image to clone from.

**3. Verify the post-condition.** The workerId derives from the MAC, so a genuine recreate *must* change it. If it doesn't, the recreate operated elsewhere and the slot is still on the old image. Previously `updated` meant only "we reached the end of the loop" — this is the assertion that would have caught the bug on the first run, and catches any future variant of it.

Also splits reporting into **SKIPPED** (deliberately left serving on the old image) vs **FAILED** (recreate attempted and incomplete — slot may be DOWN), since those need different operator responses. Both still exit non-zero.

## What #1294 got right

The drain logic from that PR worked correctly in this run and is unchanged here:

```
draining sequoia-tester-1 (worker mac-b1a5a3); need 2 consecutive idle checks
mac-b1a5a3 idle (confirmed 2x)        <- 31s, the 2x30s debounce
mac-ff3bfb idle (confirmed 2x)        <- absent-from-queue branch, exercised for real
```

The `local` label fix from #1294 also worked — the daemons did bounce (new pids).

## Testing

Both rendered variants (`daemon`, `agent`) pass `bash -n` and shellcheck; empty `FAILED`/`SKIPPED` arrays are safe under `set -u` on bash 3.2; `tart_user` verified against the live host as shown above.

**Not yet done: a full end-to-end roll with this fix in place.** That needs a drained host and a 22 GB pull (the previous one went into root's cache and has been cleaned up). m4-188 is already drained and on master, so it's the natural place to retry.