### PR TITLE
tart-update-vms: pass --insecure to clone, not just pull

### DIFF
--- a/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
+++ b/modules/roles_profiles/templates/tart/tart-update-vms.sh.epp
@@ -289,7 +289,18 @@ for i in $(seq 1 "${WORKER_COUNT}"); do
   fi
 
   log "  cloning fresh ${VM} from ${IMAGE}"
-  if ! tart_user clone "${REGISTRY}/${IMAGE}" "${VM}"; then
+  # ${INSECURE} is required here, not just on the pull above. `tart clone` from an
+  # OCI reference will re-fetch the manifest from the registry whenever the image
+  # is not in the local cache, and without --insecure it tries HTTPS against a
+  # registry that serves plain HTTP, failing with "An SSL error has occurred".
+  #
+  # It is easy to miss because the FIRST slot usually clones straight from the
+  # cache the pull just populated, and only a later slot re-fetches: tart prunes
+  # that cache automatically under disk pressure (`--prune-limit`, default 100 GB).
+  # Exactly that happened on macmini-m4-188 (2026-07-28) -- slot 1 cloned from
+  # cache and succeeded, the cache was pruned, slot 2 re-fetched over HTTPS and
+  # died, leaving its worker DOWN. A single-slot test cannot catch this.
+  if ! tart_user clone ${INSECURE} "${REGISTRY}/${IMAGE}" "${VM}"; then
     log "  slot ${i} FAILED: clone of ${IMAGE} failed — slot is now EMPTY and its"
     log "  worker is DOWN. Manual recovery needed: clone ${IMAGE} to ${VM}."
     FAILED+=("${i}")


### PR DESCRIPTION
Found by running the #1300 version for real on **macmini-m4-188**. Slot 1 rolled correctly; slot 2's clone died with

```
Error: An SSL error has occurred and a secure connection to the server cannot be made.
```

leaving that slot **empty and its worker DOWN**.

## Cause

`tart clone` from an OCI reference re-fetches the manifest from the registry whenever the image isn't in the local cache, and it takes **its own** `--insecure` flag:

```
USAGE: tart clone <source-name> <new-name> [--insecure] [--concurrency <n>] [--prune-limit <n>]
  --insecure    connect to the OCI registry via insecure HTTP protocol
```

The script passed the flag to `pull` but not to `clone`, so the re-fetch tried HTTPS against a registry serving plain HTTP on `:5000`.

## Why the first slot hides it

Slot 1 normally clones straight out of the cache the up-front `pull` just populated, so it never contacts the registry. tart then **prunes that cache automatically under disk pressure** (`--prune-limit`, default 100 GB), so a later slot re-fetches — and fails.

On m4-188 the sequence was:

1. pull populated the cache; free space ~38 GiB
2. slot 1 cloned from cache → succeeded (`mac-b1a5a3` → `mac-2c8b88`, verified by the #1300 post-condition)
3. cache pruned (admin cache went to 0B)
4. slot 2 re-fetched → `pulling manifest...` → HTTPS → SSL error → slot empty, worker down

**A single-slot test cannot catch this** — the same blind spot that hid the launchd label bug in #1294, which also only surfaced on a real run.

## Verification

- With `insecure_flag` set, the rendered script runs `tart clone --insecure <ref> <vm>`
- With it empty, no stray argument is passed (unquoted expansion drops it), so non-registry hosts are unaffected — checked explicitly, args come out as `[clone] [reg/img] [vm]`
- Both rendered variants (`daemon`, `agent`) pass `bash -n` and shellcheck

Recovery on m4-188 was `tart clone --insecure` by hand as the `admin` user; it succeeded and repopulated the cache, confirming the missing flag was the only cause. Both slots are healthy again (`mac-2c8b88`, `mac-5f9a03`).

## What #1300 got right, on this run

Worth recording, since this failure is the first real exercise of that error handling:

```
slot 2 FAILED: clone ... failed — slot is now EMPTY and its worker is DOWN.
  Manual recovery needed: clone <image> to sequoia-tester-2.
rolling update INCOMPLETE (2 slot(s) total):
  FAILED mid-recreate, may be DOWN: 2
```

Pre-#1300 this run would have reported `rolling update complete`. The `tart_user` fix also held: the VM was recreated in `/Users/admin/.tart` with a changed MAC, and `/var/root/.tart` never appeared.

## Remaining known gap

With the cache pruned between slots, each slot after the first re-downloads the full image (~22 GB here). That's correct but wasteful on the MDC1 link. Not addressed in this PR — the fix makes it *work*; making it *efficient* would mean either raising `--prune-limit`, or ensuring enough free space that automatic pruning doesn't trigger. Worth a follow-up if multi-slot rolls become routine.