### PR TITLE
Experiment: make numberOfTasksToRun configurable; test >1 on m4 staging

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -23,6 +23,12 @@ worker:
   access_token: "%{lookup('vault_secrets::generic_worker.data.taskcluster_access_token')}"
   generic_worker_engine: multiuser-static
   idle_timeout_secs: 21600 # 6 hours
+  # EXPERIMENT (RELOPS capacity): tasks run per boot before the worker exits and
+  # the host reboots + re-runs puppet + re-downloads binaries. Default is 1 (one
+  # reboot per task). Raising it on staging only, to measure whether reclaiming
+  # the ~7min/task boot overhead increases effective throughput without hurting
+  # test integrity. Roll back by removing this key (reverts to default 1).
+  number_of_tasks_to_run: 5
 
 packages_classes:
   - git

--- a/modules/roles_profiles/manifests/profiles/worker.pp
+++ b/modules/roles_profiles/manifests/profiles/worker.pp
@@ -25,17 +25,18 @@ class roles_profiles::profiles::worker {
       }
 
       class { 'worker_runner':
-        taskcluster_version   => $taskcluster_version,
-        provider_type         => lookup('worker.provider_type'),
-        root_url              => 'https://firefox-ci-tc.services.mozilla.com',
-        client_id             => lookup('worker.client_id'),
-        access_token          => lookup('worker.access_token'),
-        worker_pool_id        => lookup('worker.worker_pool_id'),
-        worker_group          => lookup('worker.worker_group'),
-        worker_id             => lookup('worker.worker_id'),
-        generic_worker_engine => $generic_worker_engine,
-        idle_timeout_secs     => lookup('worker.idle_timeout_secs'),
-        task_user_password    => $task_user_password,
+        taskcluster_version    => $taskcluster_version,
+        provider_type          => lookup('worker.provider_type'),
+        root_url               => 'https://firefox-ci-tc.services.mozilla.com',
+        client_id              => lookup('worker.client_id'),
+        access_token           => lookup('worker.access_token'),
+        worker_pool_id         => lookup('worker.worker_pool_id'),
+        worker_group           => lookup('worker.worker_group'),
+        worker_id              => lookup('worker.worker_id'),
+        generic_worker_engine  => $generic_worker_engine,
+        idle_timeout_secs      => lookup('worker.idle_timeout_secs'),
+        number_of_tasks_to_run => lookup('worker.number_of_tasks_to_run', Integer[1], 'first', 1),
+        task_user_password     => $task_user_password,
       }
       # TODO: don't assume these are need with all workers. break out into another profile?
       include mercurial::system_hgrc

--- a/modules/worker_runner/manifests/init.pp
+++ b/modules/worker_runner/manifests/init.pp
@@ -23,6 +23,7 @@ class worker_runner (
     Optional[Hash] $provider_metadata                                      = undef,
     Optional[Hash] $worker_location                                        = undef,
     Optional[Integer] $idle_timeout_secs                                   = undef,
+    Integer[1] $number_of_tasks_to_run                                     = 1,
     # TODO: implement more worker config parameters
     # WorkerConfig parameters
     # Optional[String] $availabilityZone                 = undef,

--- a/modules/worker_runner/templates/worker_runner_config.yaml.erb
+++ b/modules/worker_runner/templates/worker_runner_config.yaml.erb
@@ -21,7 +21,7 @@ workerConfig:
   ed25519SigningKeyLocation: "<%= @ed25519_signing_key %>"
   idleTimeoutSecs: <%= @idle_timeout_secs %>
   livelogExecutable: "/usr/local/bin/livelog"
-  numberOfTasksToRun: 1
+  numberOfTasksToRun: <%= @number_of_tasks_to_run %>
   publicIP: "<%= @facts['networking']['ip'] %>"
   requiredDiskSpaceMegabytes: 20480
   sentryProject: "generic-worker"


### PR DESCRIPTION
## Hypothesis
The `gecko-t-osx-1500-m4` workers run `numberOfTasksToRun: 1`, so a worker exits and the host **reboots + re-runs puppet + re-downloads Taskcluster binaries between every task** (this is deliberate per the template comment). Live profiling put that at **~7 min of dead time per task**. Trace-driven analysis of the July 14 peak day (authoritative Taskcluster `scheduled→started` data, 10k tasks on this pool) suggests this overhead costs a large fraction of effective throughput — enough that reclaiming it at the current fleet size is comparable to adding ~50 machines.

This PR sets up a **staging-only experiment** to test and measure that, before we assume the per-task reboot is load-bearing or draw conclusions for the capacity/purchasing discussion.

## Change
- `worker_runner`: `numberOfTasksToRun` was hardcoded to `1` in the worker-runner config template. Promote it to a class parameter `number_of_tasks_to_run` (type `Integer[1]`, **default `1`**).
- `profiles::worker`: pass it through via `lookup('worker.number_of_tasks_to_run', Integer[1], 'first', 1)`.
- `data/roles/gecko_t_osx_1500_m4_staging.yaml`: set `worker.number_of_tasks_to_run: 5`.

**Production is unchanged** — the default is `1` and no prod role sets the key. Only `releng-hardware/gecko-t-osx-1500-m4-staging` gets the new value.

## What to measure on staging
1. **Throughput** — tasks/worker/hour vs. the `1` baseline (expected to rise).
2. **Machine-queue wait** — `scheduled→started` on the staging pool.
3. **Test integrity (the key risk)** — intermittent/failure-rate delta. The per-task reboot provides clean state; running multiple tasks per boot could surface state leakage. This is the make-or-break signal.
4. **Disk/cache growth** across tasks (`cleanUpTaskDirs: true` cleans per-task, but watch cache/downloads).
5. **Per-boot setup dependencies** — confirm nothing that only runs at boot (screenshot helper, TCC perms, safari semaphores, puppet-managed state) is required *between* tasks.

## Rollback
Remove the `number_of_tasks_to_run` key from the staging hiera (reverts to default `1`). No code revert needed.

## Notes
- Value `5` is a starting point; we can sweep (2/3/5/10) via the hiera key alone.
- Not for prod until staging shows throughput gain **without** an integrity regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)