### PR TITLE
reprovision_runner: run hangar-tart-health-agent, and fix the pip guard

### DIFF
--- a/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_reprovision_runner.yaml
@@ -33,5 +33,38 @@ reprovision_runner:
   hangar_api_url: https://hangar-runner.relops.mozilla.com/api
   # step_ca_url uses the module default.
 
+  # ---- tart VM slot health sweep (hangar-tart-health-agent) ----
+  # Pushes per-slot health for gecko-t-osx-1500-m-vms to Hangar's /api/tart-health,
+  # which the Tart VMs page renders. Runs here because Cloud Run cannot reach MDC1 and
+  # this host already holds the mTLS cert and the admin SSH identity.
+  #
+  # Proven from this host 2026-07-30: {"accepted":26,"runner":"cert:macmini-m4-81"}.
+  #
+  # Interval must stay UNDER Hangar's 30 minute staleness window, or every row ages to
+  # `unknown` between sweeps. 600s leaves plenty of margin for a slow sweep.
+  tart_health_enabled: true
+  tart_health_interval: 600
+  # Guest probes (disk headroom, clock skew, worker identity) need an `expect` password
+  # login into each VM and are much slower. They are also the checks that actually catch
+  # a crash-looping guest inside a healthy host — the July 2026 failure mode — so this
+  # should become true once the guest probe path has been exercised in production.
+  tart_health_guests: false
+  # The tart hosts to sweep. Keep in step with the tart_worker role's fleet; a host
+  # missing here is simply never checked.
+  tart_health_hosts:
+    - macmini-m4-185.test.releng.mdc1.mozilla.com
+    - macmini-m4-186.test.releng.mdc1.mozilla.com
+    - macmini-m4-187.test.releng.mdc1.mozilla.com
+    - macmini-m4-188.test.releng.mdc1.mozilla.com
+    - macmini-m4-189.test.releng.mdc1.mozilla.com
+    - macmini-m4-190.test.releng.mdc1.mozilla.com
+    - macmini-m4-191.test.releng.mdc1.mozilla.com
+    - macmini-m4-192.test.releng.mdc1.mozilla.com
+    - macmini-m4-235.test.releng.mdc1.mozilla.com
+    - macmini-m4-236.test.releng.mdc1.mozilla.com
+    - macmini-m4-237.test.releng.mdc1.mozilla.com
+    - macmini-m4-238.test.releng.mdc1.mozilla.com
+    - macmini-m4-239.test.releng.mdc1.mozilla.com
+
 # step-ca root CA fingerprint — pins trust during `step ca bootstrap` (non-secret).
 reprovision_runner::step_renew::ca_fingerprint: f2d8032e35566ecb41b3f1dd5ec7b550fb73f6c8fa855870ca3f35638d777cf6

--- a/modules/reprovision_runner/manifests/init.pp
+++ b/modules/reprovision_runner/manifests/init.pp
@@ -53,6 +53,19 @@
 #   REPROVISION_* creds the `reprovision` CLI needs, keyed by env var name, e.g.
 #   { 'REPROVISION_TC_CLIENT_ID' => Sensitive('...'), ... }. Sourced from vault
 #   by the profile and written to a 0600 env file the daemon sources.
+# @param tart_health_enabled
+#   Run hangar-tart-health-agent, which sweeps the tart VM hosts and pushes per-slot
+#   health to Hangar. Requires tart_health_hosts.
+# @param tart_health_hosts
+#   Tart hosts to sweep, one FQDN per entry. Puppet writes the agent's hosts file, so a
+#   host missing here is never checked.
+# @param tart_health_interval
+#   Seconds between sweeps. Must stay under Hangar's 30 minute staleness window or every
+#   row ages to `unknown` between sweeps.
+# @param tart_health_guests
+#   Also probe inside each VM (disk headroom, clock skew, worker identity). Needs an
+#   `expect` password login per VM and is much slower, hence opt-in — but these are the
+#   checks that catch a crash-looping guest under a healthy host.
 class reprovision_runner (
   Boolean                          $enabled        = false,
   String[1]                        $hangar_api_url = 'https://hangar.relops.mozilla.com/api',
@@ -69,6 +82,10 @@ class reprovision_runner (
   Optional[String[1]]              $step_ca_ip     = undef,
   String[1]                        $step_version   = '0.28.2',
   Hash[Pattern[/^REPROVISION_[A-Z0-9_]+$/], Sensitive[String]] $secrets = {},
+  Boolean                          $tart_health_enabled  = false,
+  Array[Stdlib::Fqdn]              $tart_health_hosts    = [],
+  Integer[60]                      $tart_health_interval = 600,
+  Boolean                          $tart_health_guests   = false,
 ) {
   if $enabled {
     $short_python  = split(String($python_version), '[.]')[0, 2].join('.')
@@ -93,6 +110,18 @@ class reprovision_runner (
     $screen_wrapper      = '/usr/local/bin/hangar-screen-agent.sh'
     $screen_plist_label  = 'com.mozilla.hangar-screen-agent'
     $screen_plist_path   = "/Library/LaunchDaemons/${screen_plist_label}.plist"
+
+    # Companion: hangar-tart-health-agent (per-slot health of the tart VM hosts, pushed
+    # to Hangar's /api/tart-health). Third daemon on the same venv/env file/cert.
+    $tart_bin            = "${venv_dir}/bin/hangar-tart-health-agent"
+    $tart_wrapper        = '/usr/local/bin/hangar-tart-health-agent.sh'
+    $tart_plist_label    = 'com.mozilla.hangar-tart-health-agent'
+    $tart_plist_path     = "/Library/LaunchDaemons/${tart_plist_label}.plist"
+    $tart_hosts_file     = "${conf_dir}/tart-hosts.txt"
+
+    # Every console script pyproject declares. The pip install is guarded on ALL of
+    # them (see below), not just the newest one.
+    $console_bins        = [$runner_bin, $screen_bin, $tart_bin]
 
     # ---- python 3.11 (framework build, same source as scriptworker_prereqs) ----
     class { 'packages::python3':
@@ -140,17 +169,24 @@ class reprovision_runner (
     # PIP_CONFIG_FILE=/dev/null ignores the fleet-wide /Library/Application Support/pip/pip.conf
     # (no-index + internal mirror), which only carries the CI worker's deps — the orchestrator's
     # deps (httpx, typer, taskcluster, …) live on public PyPI, which MDC1 can reach.
-    # creates-guarded (not refreshonly): installs whenever the console script is
+    # Guarded (not refreshonly): installs whenever ANY expected console script is
     # absent, so a partial/failed prior run self-heals on the next apply. The
     # editable install source-links the repo, so vcsrepo's `latest` pulls pick up
     # code changes without a reinstall — only a missing bin needs this to re-run.
+    #
+    # The guard tests EVERY script in $console_bins, because a `creates` on one bin
+    # silently skips the install for all the others. That is not hypothetical: the
+    # guard was `creates => $screen_bin`, and since hangar-screen-agent had existed
+    # since July, adding hangar-tart-health-agent to pyproject never materialized it on
+    # any host with an existing venv — vcsrepo pulled, this exec was notified, and the
+    # guard short-circuited it. An editable install picks up *code* changes without
+    # reinstalling, but a new [project.scripts] entry only appears on reinstall.
+    $bins_present = $console_bins.map |$b| { "-x '${b}'" }.join(' -a ')
     exec { 'reprovision_runner_pip_install':
       command     => "${venv_dir}/bin/pip install --upgrade pip && ${venv_dir}/bin/pip install -e ${orch_dir}",
       path        => ['/usr/bin', '/bin'],
       environment => ['PIP_CONFIG_FILE=/dev/null'],
-      # Guard on the *screen-agent* bin (the newest console script) so an existing venv
-      # re-installs to pick up asyncvnc + hangar-screen-agent, not just reprovision-runner.
-      creates     => $screen_bin,
+      unless      => "/bin/test ${bins_present}",
       timeout     => 900,
       require     => [Exec['reprovision_runner_venv'], Vcsrepo[$repo_dir]],
       notify      => [Exec['reprovision_runner_reload'], Exec['reprovision_runner_screen_reload']],
@@ -316,6 +352,83 @@ class reprovision_runner (
       path        => ['/bin', '/usr/bin'],
       refreshonly => true,
       require     => File[$screen_plist_path],
+    }
+
+    # ---- companion: hangar-tart-health-agent (per-slot tart VM health) ----
+    # Third daemon on the same venv, env file and mTLS cert. Unlike the other two it
+    # takes arguments, so the shared wrapper template renders an argv.
+    #
+    # Opt-in per host: only the runner host should sweep the tart fleet, and a daemon
+    # with no hosts would push an empty payload that ages every row to `unknown`.
+    if $tart_health_enabled {
+      if empty($tart_health_hosts) {
+        fail('reprovision_runner: tart_health_enabled requires a non-empty tart_health_hosts')
+      }
+
+      # Guest probes need an `expect` password login per VM and are much slower than the
+      # host-level sweep, so they are opt-in separately.
+      if $tart_health_guests {
+        $guest_args = []
+      } else {
+        $guest_args = ['--no-guests']
+      }
+      $tart_args = [
+        '--hosts-file', $tart_hosts_file,
+        '--loop',
+        '--interval', String($tart_health_interval),
+      ] + $guest_args
+
+      # Puppet owns the host list: hand-maintaining it means the daemon silently keeps
+      # sweeping a stale fleet as hosts are added or converted. The agent ignores blank
+      # lines and # comments.
+      $tart_hosts_lines = ['# Managed by Puppet (reprovision_runner). Do not edit.'] + $tart_health_hosts
+      $tart_hosts_content = join($tart_hosts_lines, "\n")
+
+      file { $tart_hosts_file:
+        ensure  => file,
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0600',
+        content => "${tart_hosts_content}\n",
+        require => File[$conf_dir],
+        notify  => Exec['reprovision_runner_tart_reload'],
+      }
+
+      file { $tart_wrapper:
+        ensure  => file,
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0755',
+        content => epp("${module_name}/reprovision-runner.sh.epp", {
+          env_file   => $env_file,
+          runner_bin => $tart_bin,
+          args       => $tart_args,
+        }),
+        require => Exec['reprovision_runner_pip_install'],
+        notify  => Exec['reprovision_runner_tart_reload'],
+      }
+
+      file { $tart_plist_path:
+        ensure  => file,
+        owner   => 'root',
+        group   => 'wheel',
+        mode    => '0644',
+        content => epp("${module_name}/com.mozilla.reprovision-runner.plist.epp", {
+          label    => $tart_plist_label,
+          wrapper  => $tart_wrapper,
+          log_dir  => $log_dir,
+          log_name => 'tart-health-agent',
+        }),
+        require => [File[$tart_wrapper], File[$env_file], File[$tart_hosts_file]],
+        notify  => Exec['reprovision_runner_tart_reload'],
+      }
+
+      exec { 'reprovision_runner_tart_reload':
+        command     => "/bin/bash -c 'launchctl bootout system ${tart_plist_path} 2>/dev/null || true; launchctl bootstrap system ${tart_plist_path}'",
+        path        => ['/bin', '/usr/bin'],
+        refreshonly => true,
+        require     => File[$tart_plist_path],
+      }
     }
   }
 }

--- a/modules/reprovision_runner/templates/reprovision-runner.sh.epp
+++ b/modules/reprovision_runner/templates/reprovision-runner.sh.epp
@@ -1,13 +1,22 @@
 <%- | String $env_file,
       String $runner_bin,
+      Array[String] $args = [],
 | -%>
 #!/bin/bash
 # Managed by Puppet (reprovision_runner). Do not edit.
 # Source the root-only env file (HANGAR_API_URL, RUNNER_*, REPROVISION_* creds)
 # then exec the runner. The env file is the only place secrets live at rest.
+#
+# Sourcing is not optional for hangar-tart-health-agent: without
+# REPROVISION_SSH_ADMIN_KEY in the environment its secret resolution falls through to
+# an op:// ref, and the 1Password CLI is not installed on the runner host.
 set -euo pipefail
 set -a
 # shellcheck disable=SC1090
 source '<%= $env_file %>'
 set +a
+<% if empty($args) { -%>
 exec '<%= $runner_bin %>'
+<% } else { -%>
+exec '<%= $runner_bin %>' <%= $args.map |$a| { "'${a}'" }.join(' ') %>
+<% } -%>

--- a/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
+++ b/modules/roles_profiles/manifests/profiles/reprovision_runner.pp
@@ -40,17 +40,23 @@ class roles_profiles::profiles::reprovision_runner {
     }
 
     class { 'reprovision_runner':
-      enabled        => true,
-      cert_mode      => $cert_mode,
-      hangar_api_url => pick_default($rr['hangar_api_url'], 'https://hangar.relops.mozilla.com/api'),
-      runner_id      => pick_default($rr['runner_id'], $facts['networking']['hostname']),
-      repo_url       => pick_default($rr['repo_url'], 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
-      repo_revision  => pick_default($rr['repo_revision'], 'main'),
-      step_ca_url    => pick_default($rr['step_ca_url'], 'https://step-ca.relops.mozilla'),
-      step_ca_ip     => pick_default($rr['step_ca_ip'], undef),
-      client_cert    => $client_cert,
-      client_key     => $client_key,
-      secrets        => $secrets,
+      enabled              => true,
+      cert_mode            => $cert_mode,
+      hangar_api_url       => pick_default($rr['hangar_api_url'], 'https://hangar.relops.mozilla.com/api'),
+      runner_id            => pick_default($rr['runner_id'], $facts['networking']['hostname']),
+      repo_url             => pick_default($rr['repo_url'], 'https://github.com/mozilla-platform-ops/relops-bootstrap.git'),
+      repo_revision        => pick_default($rr['repo_revision'], 'main'),
+      step_ca_url          => pick_default($rr['step_ca_url'], 'https://step-ca.relops.mozilla'),
+      step_ca_ip           => pick_default($rr['step_ca_ip'], undef),
+      client_cert          => $client_cert,
+      client_key           => $client_key,
+      secrets              => $secrets,
+      # Tart VM slot health sweep (hangar-tart-health-agent). Non-secret config, so it
+      # lives in role data rather than vault.
+      tart_health_enabled  => pick_default($rr['tart_health_enabled'], false),
+      tart_health_hosts    => pick_default($rr['tart_health_hosts'], []),
+      tart_health_interval => pick_default($rr['tart_health_interval'], 600),
+      tart_health_guests   => pick_default($rr['tart_health_guests'], false),
     }
   }
 }


### PR DESCRIPTION
Makes the tart VM slot health sweep run unattended. Two changes: a third daemon on the runner host, and the module bug that would have stopped it deploying.

Companion to mozilla-platform-ops/hangar#87 / #88 and relops-bootstrap #55–#58.

## Fix: `Exec[reprovision_runner_pip_install]` never re-ran

It was guarded `creates => $screen_bin`. `hangar-screen-agent` has existed since July, so when `hangar-tart-health-agent` was added to the orchestrator's `[project.scripts]`, **the console script never materialized on any host with an existing venv** — vcsrepo pulled, the exec was notified, and the guard short-circuited it.

Observed on `macmini-m4-81`:

```
Notice: Vcsrepo[/opt/reprovision-runner/repo]/ensure: ensure changed 'present' to 'latest'
Notice: Exec[reprovision_runner_pip_install]: Triggered 'refresh' from 1 event
Notice: Puppet apply succeeded!

$ ls -l .venv/bin/ | grep -E "hangar|reprovision"
hangar-screen-agent      Jul  9 22:47      # <- all unchanged
reprovision              Jul  9 22:47
reprovision-runner       Jul  9 22:47
                                           # <- hangar-tart-health-agent absent
```

It only appeared after running the identical pip command by hand. The guard's comment justified itself by noting an editable install picks up code changes without reinstalling — true for module code, **false for a new console script**, which only appears on reinstall.

The guard now tests every script in `$console_bins`, so adding a fourth needs one list entry and nothing else.

## New: `hangar-tart-health-agent`

Sweeps the tart VM hosts and pushes per-slot health to Hangar's `/api/tart-health`, which the Tart VMs page renders. It runs here because Cloud Run can't reach MDC1 and this host already holds both the mTLS client cert and the admin SSH identity — same venv, same env file, same plist template as the screen agent, i.e. the second-daemon pattern this module already established.

Details worth review:

- **Sourcing the env file is load-bearing for this daemon.** Without `REPROVISION_SSH_ADMIN_KEY` in the environment, the agent's secret resolution falls through to an `op://` ref and the 1Password CLI isn't installed on the runner. The shared wrapper already sources it; it now also renders an **argv**, since unlike the other two this daemon takes arguments.
- **Puppet owns the hosts file.** Hand-maintaining it means the daemon silently keeps sweeping a stale fleet as hosts are added or converted.
- **Fails compilation if enabled with no hosts.** A daemon sweeping nothing would push an empty payload and age every row in Hangar to `unknown` — worse than not running, because it looks like it's working.
- **`tart_health_interval` must stay under Hangar's 30-minute staleness window** (600s default). That's stated in the param doc and the role data.
- **`tart_health_guests: false` for now.** Guest probes need an `expect` password login per VM and are much slower — but they're also the checks that catch a crash-looping guest inside a healthy host, the July 2026 failure mode. Should flip once that path is exercised in production.

## Heads-up when applying

The shared wrapper template's content changes, so `reprovision-runner.sh` and `hangar-screen-agent.sh` get rewritten and **both existing daemons reload once**. Apply when no reprovision job is in flight.

## Verification

- `pre-commit run` clean on all four files (puppet-lint, puppet-validate, epp-validate, yaml)
- Wrapper renders correctly **both** with args and without — the argless output is unchanged apart from the added comment
- Hosts-file content verified by rendering the `join` rather than trusting the interpolation

The agent itself is already proven from this host — `{"accepted":26,"runner":"cert:macmini-m4-81"}` on 2026-07-30, mTLS-authenticated, 26 slots into prod Hangar — but under a **manual** invocation. This PR is what puts it under launchd, so the daemon path is the part still unproven; I'll confirm it on m4-81 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)