### PR TITLE
roles: bump macOS staging taskcluster_version toward 103.0.1

### DIFF
--- a/data/roles/gecko_t_osx_1400_r8_staging.yaml
+++ b/data/roles/gecko_t_osx_1400_r8_staging.yaml
@@ -11,7 +11,7 @@ worker_metadata:
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
 # Pinned to the current effective version -- this is a no-op control move.
-taskcluster_version: '100.5.0'
+taskcluster_version: '103.0.1'
 
 worker:
   taskcluster_version: 60.3.4

--- a/data/roles/gecko_t_osx_1500_m4_staging.yaml
+++ b/data/roles/gecko_t_osx_1500_m4_staging.yaml
@@ -11,7 +11,7 @@ worker_metadata:
 # Role-owned Taskcluster worker version (read by profiles::worker; takes
 # precedence over the legacy vault-sourced worker.taskcluster_version below).
 # Pinned to the current effective version -- this is a no-op control move.
-taskcluster_version: '100.5.0'
+taskcluster_version: '103.0.1'
 
 worker:
   taskcluster_version: 95.0.3


### PR DESCRIPTION
Automated monthly Taskcluster worker-version bump for the **macOS staging** pools.

Latest stable taskcluster: **103.0.1**

Proposed staging bumps (capped per each pool's macOS/Go-toolchain ceiling):
- `gecko_t_osx_1400_r8_staging`: 100.5.0 → **103.0.1**
- `gecko_t_osx_1500_m4_staging`: 100.5.0 → **103.0.1**

### Validate before merging
Push one try run per staging pool (these pools aren't in normal try routing). Each is a
minimal smoke that just exercises the worker binary (claim -> run -> upload); use the
suite that actually generates on each platform post-migration:
```
# 1500 / m4
./mach try fuzzy --all-tasks --worker-override t-osx-1500-m4=releng-hardware/gecko-t-osx-1500-m4-staging -q "'test-macosx1500-aarch64/opt 'xpcshell !vms"

# 1400 / Sonoma  (macosx1470-64 only generates cppunittest/gtest now; mochitests moved to m4)
./mach try fuzzy --all-tasks --worker-override t-osx-1400-r8=releng-hardware/gecko-t-osx-1400-r8-staging -q "'test-macosx1470-64/opt 'cppunittest"

# 1015 / Catalina
./mach try fuzzy --all-tasks --worker-override t-osx-1015-r8=releng-hardware/gecko-t-osx-1015-r8-staging -q "'test-macosx1015-64-qr/opt 'xpcshell"
```
(Or comment `/try-mac 1500` | `/try-mac 1400` | `/try-mac 1015` on this PR to deploy the
branch to that staging pool automatically.) Staging hosts pick up the new binary on their
next reboot (cached). After staging is green, bump the **prod** roles in a separate PR.

_Opened by `.github/workflows/taskcluster-binary-bump.yml`. Do not auto-merge._